### PR TITLE
Continuous okapi registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ env:
     - DOCKER_IMAGE_NAME=thefrontside/mod-kb-ebsco
     - KUBE_DEPLOYMENT_NAME=folio-mod-kb-ebsco
     - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-kb-ebsco
+    - OKAPI_EXTERNAL_ADDRESS=http://104.196.172.62:80
+    - FOLIO_MODULE_NAME=mod-kb-ebsco
+    - FOLIO_TENANT_ID=fs
 
 install:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ env:
   global:
     - GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
     - PROJECT_ID=okapi-173322
-    - CLUSTER_NAME=okapi-mod-resource--management-pipeline
-    - CLOUDSDK_COMPUTE_ZONE=us-central1-a
+    - CLUSTER_NAME=okapi-demo
+    - CLOUDSDK_COMPUTE_ZONE=us-east1-b
     - DOCKER_IMAGE_NAME=thefrontside/mod-kb-ebsco
-    - KUBE_DEPLOYMENT_NAME=folio-mod-resource-management
-    - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-resource-management
+    - KUBE_DEPLOYMENT_NAME=folio-mod-kb-ebsco
+    - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-kb-ebsco
 
 install:
   - bundle install

--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -1,0 +1,17 @@
+{
+  "id": "mod-kb-ebsco-0.1.0",
+  "name": "kb-ebsco",
+  "provides": [
+    {
+      "id": "kb-ebsco",
+      "version": "0.1.0",
+      "handlers" : [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/"
+        }
+      ]
+    }
+  ],
+  "permissionSets" : []
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 bash_escape() ( printf '\\033[%dm' $1; );
 RESET=$(bash_escape 0); BLUE=$(bash_escape 34);

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,3 +36,83 @@ put_info "Pulling new image into container '${KUBE_DEPLOYMENT_CONTAINER_NAME}' o
 kubectl config view;
 kubectl config current-context;
 kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=${DOCKER_IMAGE_NAME}:${TRAVIS_COMMIT};
+
+# variables needed for Okapi registration
+service_id="${FOLIO_MODULE_NAME}-${TRAVIS_COMMIT}"
+service_url="http://${KUBE_DEPLOYMENT_NAME}:8081"
+okapi_modules_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/proxy/modules"
+okapi_discovery_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/discovery/modules"
+okapi_tenants_modules_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/proxy/tenants/${FOLIO_TENANT_ID}/modules"
+
+# deselect module from the tenant
+get_selected_modules() {
+  curl -s -X GET $okapi_tenants_modules_endpoint | \
+  jq -c "map(select(.id | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
+}
+delete_selected_modules() {
+  while read object; do
+    id=$(echo $object | jq -r '.id')
+    put_info "Deselecting module ${id} from tenant ${FOLIO_TENANT_ID}";
+    curl -s -X DELETE "${okapi_tenants_modules_endpoint}/${id}";
+  done;
+}
+get_selected_modules | delete_selected_modules;
+
+# delete existing discovery records for module
+get_discovered_modules() {
+  curl -s -X GET $okapi_discovery_endpoint | \
+  jq -c "map(select(.srvcId | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
+}
+delete_discovered_modules() {
+  while read object; do
+    srvcId=$(echo $object | jq -r '.srvcId');
+    instId=$(echo $object | jq -r '.instId');
+    put_info "Deleting existing discovery record with Service ID: ${srvcId} and Instance ID: ${instId}";
+    curl -s -X DELETE "${okapi_discovery_endpoint}/${srvcId}/${instId}";
+  done;
+}
+get_discovered_modules | delete_discovered_modules;
+
+# delete existing module registrations
+get_registered_modules() {
+  curl -s -X GET $okapi_modules_endpoint | \
+  jq -c "map(select(.id | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
+}
+delete_registered_modules() {
+  while read object; do
+    id=$(echo $object | jq -r '.id')
+    put_info "Deleting existing module registration with Service ID: ${id}";
+    curl -s -X DELETE "${okapi_modules_endpoint}/${id}";
+  done;
+}
+get_registered_modules | delete_registered_modules;
+
+# register module
+put_info "Registering module to Okapi with Service ID: ${service_id}";
+cat ModuleDescriptor.json | jq ".id = \"${service_id}\"" | curl -s -X POST -d @- $okapi_modules_endpoint;
+
+# create discovery record
+discovery_payload() {
+  cat <<EOF
+{
+  "srvcId": "${service_id}",
+  "instId": "${service_id}",
+  "url": "${service_url}"
+}
+EOF
+}
+
+put_info "Creating discovery record for module with Service ID: ${service_id} and Instance ID: ${service_id}";
+echo "$(discovery_payload)" | curl -s -X POST -d @- $okapi_discovery_endpoint;
+
+# select for tenant
+module_tenant_payload() {
+  cat <<EOF
+{
+  "id": "${service_id}"
+}
+EOF
+}
+
+put_info "Link ${service_id} to tenant ${FOLIO_TENANT_ID}";
+echo "$(module_tenant_payload)" | curl -s -X POST -d @- $okapi_tenants_modules_endpoint;


### PR DESCRIPTION
This PR contains two chunks of work:

1. _Point the CI/CD config towards `okapi-demo` cluster
This simply adjusts the configuration to point at the `okapi-demo` k8s cluster instead of the cluster we used to test this work in the early stages.

2. Automatically register module to Okapi during deployment
This alters the `deploy.sh` script to include a workflow for re-registering the module to Okapi upon successful merge to master.  The workflow uses `curl` to
a) de-select any existing version of the module from the tenant 
b) delete existing discovery records for the module 
c) delete existing registrations for the module
d) register the new version of the module
e) discover the new version of the module
f) link the new version of the module to the tenant