### PR TITLE
Connect to RM API sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 log
 tmp
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - OKAPI_EXTERNAL_ADDRESS=http://104.196.172.62:80
     - FOLIO_MODULE_NAME=mod-kb-ebsco
     - FOLIO_TENANT_ID=fs
+    - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://sandbox.ebsco.io
 
 install:
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,15 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 gem 'rails', '~> 5.1.2'
 gem 'sqlite3'
 gem 'puma', '~> 3.7'
-
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
+  gem 'pry-remote'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,12 @@ GEM
     arel (8.0.0)
     builder (3.2.3)
     byebug (9.0.6)
+    coderay (1.1.1)
     concurrent-ruby (1.0.5)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.6.1)
     ffi (1.9.18)
     globalid (0.4.0)
@@ -64,8 +69,16 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     puma (3.9.1)
     rack (2.0.3)
+    rack-cors (1.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -96,6 +109,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     ruby_dep (1.5.0)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -122,8 +136,11 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  dotenv-rails
   listen (>= 3.0.5, < 3.2)
+  pry-remote
   puma (~> 3.7)
+  rack-cors
   rails (~> 5.1.2)
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -134,4 +151,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -8,7 +8,7 @@
       "handlers" : [
         {
           "methods": [ "GET" ],
-          "pathPattern": "/"
+          "pathPattern": "/eholdings/"
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ This software is distributed under the terms of the Apache License, Version 2.0.
 
 Module to broker communication with the EBSCO knowledge base.
 
+## Setup
+
+Environment variables needed:
+- `EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL`
+- `EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID`
+- `EBSCO_RESOURCE_MANAGEMENT_API_KEY`
+
+Place in `.env` or CI project settings.
+
 ## Additional information
 
 Other [modules](http://dev.folio.org/source-code/#server-side).

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,22 @@
+require 'net/http'
+
+class ApiController < ApplicationController
+  def index
+    # Form the URL
+    urlstr = "#{ENV['EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL']}/rm/rmaccounts/#{ENV['EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID']}#{request.fullpath}"
+    uri = URI(urlstr)
+
+    # Create the HTTP object
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    # Create the request
+    external_request = Net::HTTP::Get.new(uri.request_uri)
+    external_request["Accept"] = 'application/json'
+    external_request["X-Api-Key"] = ENV['EBSCO_RESOURCE_MANAGEMENT_API_KEY']
+
+    # Send the request
+    response = http.request(external_request)
+    render :json => response.body
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,9 +9,16 @@ require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
 
-module FolioModResourceManagement
+module ModKbEbsco
   class Application < Rails::Application
     config.load_defaults 5.1
     config.api_only = true
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins 'folio.frontside.io'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
 Rails.application.routes.draw do
+  match '*path' => 'api#index', via: [:get, :post, :put, :patch, :delete]
 end


### PR DESCRIPTION
Connects to RM API sandbox with credentials provided to Frontside.

Requires env variables to be set:
- `EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL`
- `EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID`
- `EBSCO_RESOURCE_MANAGEMENT_API_KEY`