### PR TITLE
Routing Tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - rake test
 
 before_deploy:
-  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash > /dev/null; fi
   - source /home/travis/google-cloud-sdk/path.bash.inc
   - gcloud --quiet version
   - gcloud --quiet components update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ ADD Gemfile.lock /mod-kb-ebsco/Gemfile.lock
 RUN bundle install
 ADD . /mod-kb-ebsco
 
-EXPOSE 3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+EXPOSE 8081
+CMD ["rails", "server", "-b", "0.0.0.0", "-p", "8081"]

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'dotenv-rails', groups: [:development, :test]
 gem 'rails', '~> 5.1.2'
 gem 'sqlite3'
 gem 'puma', '~> 3.7'
-gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   gem 'pry-remote'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
       slop (~> 3.0)
     puma (3.9.1)
     rack (2.0.3)
-    rack-cors (1.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -140,7 +139,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-remote
   puma (~> 3.7)
-  rack-cors
   rails (~> 5.1.2)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -8,7 +8,7 @@
       "handlers" : [
         {
           "methods": [ "GET" ],
-          "pathPattern": "/eholdings/"
+          "pathPattern": "/eholdings/*"
         }
       ]
     }

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,6 +4,7 @@ class ApiController < ApplicationController
   def index
     # Form the URL
     urlstr = "#{ENV['EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL']}/rm/rmaccounts/#{ENV['EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID']}#{request.fullpath}"
+    urlstr.slice! '/eholdings'
     uri = URI(urlstr)
 
     # Create the HTTP object

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,18 +13,5 @@ module ModKbEbsco
   class Application < Rails::Application
     config.load_defaults 5.1
     config.api_only = true
-
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins 'folio.frontside.io'
-        resource '*', :headers => :any, :methods => [:get, :post, :options]
-      end
-
-      # Hack hack hack
-      allow do
-        origins '104.6.33.13'
-        resource '*', :headers => :any, :methods => [:get, :post, :options]
-      end
-    end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,7 +7,7 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 8081 }
 
 # Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV") { "development" }


### PR DESCRIPTION
Since Okapi is routing the requests to mod-kb-ebsco, addressing CORS in the Rack middleware doesn't actually make sense.  As such, we've yanked it.

The module descriptor was adjusted to accept all paths under the `/eholdings/` namespace.

The API Controller code was tweaked to slice the leading `/eholdings` from the path before passing through to RM-API.

The server was set to listen on port 8081, which matches what we specified in the deployment manifest.