### PR TITLE
Allow all HTTP verbs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - DOCKER_IMAGE_NAME=thefrontside/mod-kb-ebsco
     - KUBE_DEPLOYMENT_NAME=folio-mod-kb-ebsco
     - KUBE_DEPLOYMENT_CONTAINER_NAME=folio-mod-kb-ebsco
-    - OKAPI_EXTERNAL_ADDRESS=http://104.196.172.62:80
+    - OKAPI_EXTERNAL_ADDRESS=https://okapi.frontside.io
     - FOLIO_MODULE_NAME=mod-kb-ebsco
     - FOLIO_TENANT_ID=fs
     - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://sandbox.ebsco.io

--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -7,7 +7,7 @@
       "version": "0.1.0",
       "handlers" : [
         {
-          "methods": [ "GET" ],
+          "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
           "pathPattern": "/eholdings/*"
         }
       ]


### PR DESCRIPTION
Our module descriptor has only allowed GET requests to our endpoint thusfar.  Now that we're starting to edit pages we need to allow other HTTP verbs.  The .travis.yaml also needed a minor update to account for the new ingress and load balancer.