### PR TITLE
Pass through HTTP response status code from RM API

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -18,6 +18,6 @@ class ApiController < ApplicationController
 
     # Send the request
     response = http.request(external_request)
-    render :json => response.body
+    render :json => response.body, :status => response.code
   end
 end


### PR DESCRIPTION
`ui-eholdings` was expecting HTTP status codes on errors, but we were previously always returning a 200.