### PR TITLE
Verify peer certificate when deploying module to okapi cluster

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -44,23 +44,27 @@ okapi_modules_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/proxy/modules"
 okapi_discovery_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/discovery/modules"
 okapi_tenants_modules_endpoint="${OKAPI_EXTERNAL_ADDRESS}/_/proxy/tenants/${FOLIO_TENANT_ID}/modules"
 
+put_info "Preparing certificate for okapi.frontside.io"
+echo $OKAPI_CERT | base64 --decode > ${HOME}/okapi_cert.pem;
+okapi_cert="${HOME}/okapi_cert.pem";
+
 # deselect module from the tenant
 get_selected_modules() {
-  curl -s -X GET $okapi_tenants_modules_endpoint | \
+  curl -s --cacert $okapi_cert -X GET $okapi_tenants_modules_endpoint | \
   jq -c "map(select(.id | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
 }
 delete_selected_modules() {
   while read object; do
     id=$(echo $object | jq -r '.id')
     put_info "Deselecting module ${id} from tenant ${FOLIO_TENANT_ID}";
-    curl -s -X DELETE "${okapi_tenants_modules_endpoint}/${id}";
+    curl -s --cacert $okapi_cert -X DELETE "${okapi_tenants_modules_endpoint}/${id}";
   done;
 }
 get_selected_modules | delete_selected_modules;
 
 # delete existing discovery records for module
 get_discovered_modules() {
-  curl -s -X GET $okapi_discovery_endpoint | \
+  curl -s --cacert $okapi_cert -X GET $okapi_discovery_endpoint | \
   jq -c "map(select(.srvcId | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
 }
 delete_discovered_modules() {
@@ -68,28 +72,28 @@ delete_discovered_modules() {
     srvcId=$(echo $object | jq -r '.srvcId');
     instId=$(echo $object | jq -r '.instId');
     put_info "Deleting existing discovery record with Service ID: ${srvcId} and Instance ID: ${instId}";
-    curl -s -X DELETE "${okapi_discovery_endpoint}/${srvcId}/${instId}";
+    curl -s --cacert $okapi_cert -X DELETE "${okapi_discovery_endpoint}/${srvcId}/${instId}";
   done;
 }
 get_discovered_modules | delete_discovered_modules;
 
 # delete existing module registrations
 get_registered_modules() {
-  curl -s -X GET $okapi_modules_endpoint | \
+  curl -s --cacert $okapi_cert -X GET $okapi_modules_endpoint | \
   jq -c "map(select(.id | test(\"${FOLIO_MODULE_NAME}-.*\")==true)) | .[]";
 }
 delete_registered_modules() {
   while read object; do
     id=$(echo $object | jq -r '.id')
     put_info "Deleting existing module registration with Service ID: ${id}";
-    curl -s -X DELETE "${okapi_modules_endpoint}/${id}";
+    curl -s --cacert $okapi_cert -X DELETE "${okapi_modules_endpoint}/${id}";
   done;
 }
 get_registered_modules | delete_registered_modules;
 
 # register module
 put_info "Registering module to Okapi with Service ID: ${service_id}";
-cat ModuleDescriptor.json | jq ".id = \"${service_id}\"" | curl -s -X POST -d @- $okapi_modules_endpoint;
+cat ModuleDescriptor.json | jq ".id = \"${service_id}\"" | curl -s --cacert $okapi_cert -X POST -d @- $okapi_modules_endpoint;
 
 # create discovery record
 discovery_payload() {
@@ -103,7 +107,7 @@ EOF
 }
 
 put_info "Creating discovery record for module with Service ID: ${service_id} and Instance ID: ${service_id}";
-echo "$(discovery_payload)" | curl -s -X POST -d @- $okapi_discovery_endpoint;
+echo "$(discovery_payload)" | curl -s --cacert $okapi_cert -X POST -d @- $okapi_discovery_endpoint;
 
 # select for tenant
 module_tenant_payload() {
@@ -115,4 +119,4 @@ EOF
 }
 
 put_info "Link ${service_id} to tenant ${FOLIO_TENANT_ID}";
-echo "$(module_tenant_payload)" | curl -s -X POST -d @- $okapi_tenants_modules_endpoint;
+echo "$(module_tenant_payload)" | curl -s --cacert $okapi_cert -X POST -d @- $okapi_tenants_modules_endpoint;


### PR DESCRIPTION
Deployments have been broken for this repository since we configured SSL on okapi.frontside.io.  To fix deployments we now keep the intermediate chain certificate in Travis CI as a base64 encoded environment variable.  During deployment we use this string to construct a .pem file that curl can use to verify the peer certificate.

~~DNM: I set the travis config to deploy all branches to make sure this works, if it does i'll set it back to master only and remove this warning.~~