### PR TITLE
Declare implementation of eholdings

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -3,7 +3,7 @@
   "name": "kb-ebsco",
   "provides": [
     {
-      "id": "kb-ebsco",
+      "id": "eholdings",
       "version": "0.1.0",
       "handlers" : [
         {


### PR DESCRIPTION
The e-holdings application could potentially use multiple backends it implement the management of digital resources. As such, it needs to look up which service to use by interface name.

This makes the `mod-kb-ebsco module` provide the `eholdings` interface so that it can be looked up and linked to the eholding UI app at runtime.