### PR TITLE
Implement JSON API endpoint for vendors

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -15,6 +15,10 @@
           "pathPattern": "/eholdings/status"
         },
         {
+          "methods": [ "GET" ],
+          "pathPattern": "/eholdings/rmapi/vendors*"
+        },
+        {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
           "pathPattern": "/eholdings/holdings*"
         },

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -1,0 +1,85 @@
+class VendorsController < ApplicationController
+  def index
+    uri = URI(rmapi_path)
+
+    # Transform query params to what the EBSCO RM-API expects
+    uri.query = URI.encode_www_form(
+      search: params[:q],
+      orderby: params[:orderby] || params[:q] ? 'relevance' : 'vendorname',
+      count: params[:count] || 25,
+      offset: params[:offset] || 1
+    )
+
+    # Make the RM-API request and parse the response body
+    response = get_resource(uri)
+    data = Map JSON.parse(response.body)
+
+    # Return the list of vendors
+    if response.message === 'OK'
+      vendors = data.vendors.map do |vendor|
+        Vendor.new(vendor)
+      end
+
+      render jsonapi: vendors,
+             meta: { totalResults: data.totalResults },
+             status: :ok
+    else
+      render_rmapi_errors(data, response.code)
+    end
+  end
+
+  def show
+    uri = URI(
+      "#{rmapi_path}/%{vendor_id}" % {
+        vendor_id: params[:id]
+      }
+    )
+
+    # Make the RM-API request and parse the response body
+    response = get_resource(uri)
+    data = Map JSON.parse(response.body)
+
+    # Return the requested vendor
+    if response.message === 'OK'
+      vendor = Vendor.new(data)
+      render jsonapi: vendor, status: :ok
+    else
+      render_rmapi_errors(data, response.code)
+    end
+  end
+
+  def get_resource(uri)
+    # Create the HTTP object
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    # Create and send the request
+    http.get(
+      uri.request_uri,
+      {
+        "X-Api-Key" => configuration.api_key,
+        "Content-Type" => 'application/json',
+        "Accept" => 'application/json'
+      }
+    )
+  end
+
+  def render_rmapi_errors(data, code)
+    # Map RMAPI errors to JSON-API error objects
+    jsonapi_errors = data.Errors.map { |err| { title: err.Message } }
+    render jsonapi_errors: jsonapi_errors, status: code
+  end
+
+  def rmapi_path
+    "%{base}/rm/rmaccounts/%{customer_id}/vendors" % {
+      base: rmapi_base_url,
+      customer_id: configuration.customer_id
+    }
+  end
+
+  def configuration
+    @config ||= ::Configuration.new(okapi, rmapi_base_url).tap do |config|
+      config.load!
+    end
+  end
+end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -1,0 +1,21 @@
+class Vendor
+  def initialize(attrs)
+    @attrs = attrs
+  end
+
+  def id
+    @attrs['vendorId']
+  end
+
+  def name
+    @attrs['vendorName']
+  end
+
+  def packages_total
+    @attrs['packagesTotal']
+  end
+
+  def packages_selected
+    @attrs['packagesSelected']
+  end
+end

--- a/app/serializable/serializable_vendor.rb
+++ b/app/serializable/serializable_vendor.rb
@@ -1,0 +1,5 @@
+class SerializableVendor < SerializableResource
+  type 'vendors'
+
+  attributes :name, :packages_total, :packages_selected
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   scope '/eholdings' do
+    scope '/jsonapi' do
+      resources :vendors, only: [:index, :show]
+    end
+
     resource :configuration, only: [:show, :update]
     resource :status, only: [:show]
     match '/*path' => 'proxy#index', via: [:get, :post, :put, :patch, :delete]

--- a/spec/fixtures/vcr_cassettes/get-vendors-not-found.yml
+++ b/spec/fixtures/vcr_cassettes/get-vendors-not-found.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 31 Oct 2017 19:59:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.244.4:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.244.179:8081/configurations/entries..
+        : 200 51085us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 748543/configurations
+      X-Okapi-Url:
+      - http://10.31.250.155:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a8d8ba0e-3a9f-4abd-a85d-fe2caba12b9d",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-10-23T18:52:45.612+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-10-23T18:52:45.612+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:34 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '125'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 31 Oct 2017 19:59:34 GMT
+      X-Amzn-Requestid:
+      - 040e3ea8-be76-11e7-ad22-176ceefefd91
+      X-Amzn-Remapped-Content-Length:
+      - '125'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 31 Oct 2017 19:59:34 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 da94bfa4529bf05a5b62b3f058727c6c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CcDn1yFc4zxOVbvNSGb3Rk0Za4yQ9m7PGgc3TOmonIHM3HoUGKstEA==
+    body:
+      encoding: UTF-8
+      string: '{"Errors":[{"Code":1001,"Message":"The customer TEST_CUSTOMER_ID does
+        not have a vendor with id=1 in their holdings.","SubCode":0}]}'
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-vendors-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-vendors-success.yml
@@ -1,0 +1,172 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 31 Oct 2017 19:59:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.244.4:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.244.179:8081/configurations/entries..
+        : 200 44922us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 754366/configurations
+      X-Okapi-Url:
+      - http://10.31.250.155:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a8d8ba0e-3a9f-4abd-a85d-fe2caba12b9d",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-10-23T18:52:45.612+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-10-23T18:52:45.612+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:33 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '116'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 31 Oct 2017 19:59:33 GMT
+      X-Amzn-Requestid:
+      - 03a25cce-be76-11e7-82c0-8b9490068ed3
+      X-Amzn-Remapped-Content-Length:
+      - '116'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 31 Oct 2017 19:59:32 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f49012242a4f84f01f6dfcdeba18b241.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zeXgIX76F5-HG8mkV3pkfF8E2vMxupOni-B0nvlZdu4RRYZgOD5uKA==
+    body:
+      encoding: UTF-8
+      string: '{"vendorId":19,"vendorName":"EBSCO","vendorToken":null,"isCustomer":false,"packagesTotal":602,"packagesSelected":48}'
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-vendors.yml
+++ b/spec/fixtures/vcr_cassettes/search-vendors.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 31 Oct 2017 19:59:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.244.4:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.244.179:8081/configurations/entries..
+        : 200 49981us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 235081/configurations
+      X-Okapi-Url:
+      - http://10.31.250.155:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a8d8ba0e-3a9f-4abd-a85d-fe2caba12b9d",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-10-23T18:52:45.612+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-10-23T18:52:45.612+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:32 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=ebsco
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '281'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 31 Oct 2017 19:59:32 GMT
+      X-Amzn-Requestid:
+      - 0331c095-be76-11e7-bfb0-5724b93240e9
+      X-Amzn-Remapped-Content-Length:
+      - '281'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 31 Oct 2017 19:59:32 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 fef40efe4cedffcb21c89f4d6ab3a6a6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XvtsehJJOl57l7hPrwzc-qLtqLdYxAdk9tSpvYd9IGLlpr63wfd_vg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":2,"vendors":[{"vendorId":19,"vendorName":"EBSCO","vendorToken":null,"isCustomer":false,"packagesTotal":602,"packagesSelected":48},{"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","vendorToken":null,"isCustomer":false,"packagesTotal":23,"packagesSelected":8}]}'
+    http_version: 
+  recorded_at: Tue, 31 Oct 2017 19:59:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/vendors_spec.rb
+++ b/spec/requests/vendors_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe "Vendors", type: :request do
+  let(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN') }
+
+  let(:headers) do
+    {
+      'X-Okapi-Url': 'https://okapi-sandbox.frontside.io',
+      'X-Okapi-Tenant': 'fs',
+      'X-Okapi-Token': okapi_token
+    }
+  end
+
+  describe "searching for vendors" do
+    before do
+      VCR.use_cassette("search-vendors") do
+        get '/eholdings/jsonapi/vendors/?q=ebsco', headers: headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "gets a list of resources" do
+      expect(response).to have_http_status(200)
+      expect(json.data.length).to equal(2)
+      expect(json.meta.totalResults).to equal(2)
+    end
+  end
+
+  describe "getting a specific vendor" do
+    before do
+      VCR.use_cassette("get-vendors-success") do
+        get '/eholdings/jsonapi/vendors/19', headers: headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "gets the resource" do
+      expect(response).to have_http_status(200)
+      expect(json.data.type).to eq('vendors')
+      expect(json.data.id).to eq('19')
+      expect(json.data.attributes).to include('name', 'packagesTotal', 'packagesSelected')
+    end
+  end
+
+  describe "getting a non-existing vendor" do
+    before do
+      VCR.use_cassette("get-vendors-not-found") do
+        get '/eholdings/jsonapi/vendors/1', headers: headers
+      end
+    end
+
+    it "returns a not found error" do
+      expect(response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Implements a `/eholdings/jsonapi/vendors` endpoint for consuming vendor resources as JSON API documents.

## Approach
- Uses `jsonapi:serializable` to serialize a vendor resource as JSON API
- When searching for vendors, the `search` parameter is now `q`
- When searching for vendors, `totalResults` is now available in the response meta
- Transforms important vendor attributes to be JSON API compliant

  **before:**
  ```
  {
    vendorId: 19,
    vendorName: "Ebsco",
    packagesTotal: 602,
    packagesSelected: 48,
    vendorToken: null,
    isCustomer: false
  }
  ```
  **after:**
  ```
  {
    data: {
      id: "19",
      type: "vendors",
      attributes: {
        name: "Ebsco",
        packagesTotal: 602,
        packagesSelected: 48
      }
    }
  }
  ```
- Any errors returned from the RM API are simply transformed

  **before:**
  ```
  {
    Errors: [
      {
        Code: 1001,
        Message: "RM API error message"
        SubCode: 0
      }
    ]
  }
  ```
  **after:**
  ```
  {
    errors: [
      {
        title: "RM API error message"
      }
    ]
  }
  ```