### PR TITLE
Use camelCase keys for JSON API resources

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -22,9 +22,8 @@ class ConfigurationsController < ApplicationController
              status: :unprocessable_entity
     end
 
-    config.customer_id = data_attributes['customer-id']
-    config.api_key = data_attributes['api-key']
-
+    config.customer_id = data_attributes['customerId']
+    config.api_key = data_attributes['apiKey']
 
     if config.save
       render jsonapi: config,

--- a/app/serializable/serializable_resource.rb
+++ b/app/serializable/serializable_resource.rb
@@ -1,5 +1,5 @@
 class SerializableResource < JSONAPI::Serializable::Resource
   extend JSONAPI::Serializable::Resource::KeyFormat
 
-  key_format -> (key) { key.to_s.dasherize }
+  key_format -> (key) { key.to_s.camelize :lower }
 end

--- a/spec/requests/configurations_spec.rb
+++ b/spec/requests/configurations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Configurations", type: :request do
   let(:api_key) { ENV.fetch('TEST_API_KEY') }
   let(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN') }
   let(:resource) do
-    ['/eholdings/configuration', params: {data:{ type: "configurations", id: 'default', attributes: {"customer-id": customer_id, "api-key": api_key} }}.to_json, headers: {'Content-Type': 'application/vnd.api+json','X-Okapi-Url': 'https://okapi-sandbox.frontside.io', 'X-Okapi-Tenant': 'fs', 'X-Okapi-Token': okapi_token}]
+    ['/eholdings/configuration', params: {data:{ type: "configurations", id: 'default', attributes: {"customerId": customer_id, "apiKey": api_key} }}.to_json, headers: {'Content-Type': 'application/vnd.api+json','X-Okapi-Url': 'https://okapi-sandbox.frontside.io', 'X-Okapi-Tenant': 'fs', 'X-Okapi-Token': okapi_token}]
   end
 
   describe "setting the configuration when it has never been set before" do
@@ -34,8 +34,8 @@ RSpec.describe "Configurations", type: :request do
       end
 
       it 'contains valid attributes' do
-        expect(json.data.attributes['customer-id']).to eql(customer_id)
-        expect(json.data.attributes['api-key']).to eql(api_key)
+        expect(json.data.attributes.customerId).to eql(customer_id)
+        expect(json.data.attributes.apiKey).to eql(api_key)
       end
     end
   end

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Status", type: :request do
     end
 
     it "gets configuration validity" do
-      expect(status["is-configuration-valid"]).to be(true)
+      expect(status.isConfigurationValid).to be(true)
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
## Purpose
CamelCases keys so that our consuming application does not have to have any special handling of said keys

## Approach
- Uses `camelize` instead of `dasherize`
- Updates tests to use new camelized keys
- Configuration update now requires `customerId` and `apiKey` be camelCased