### PR TITLE
Add health endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::Base
+  def index
+    render :json => '', :status => :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
     resource :status, only: [:show]
     match '/*path' => 'proxy#index', via: [:get, :post, :put, :patch, :delete]
   end
+
+  match '/admin/health' => 'health#index', via: [:get]
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Health", type: :request do
+  describe "GET /health" do
+    before do
+      get '/admin/health'
+    end
+
+    it "returns a 200 status code" do
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
A health endpoint is useful when in a clustered/containerized environment and we need to check when the `mod-kb-ebsco` module is available and ready to go.

## Approach
Simply adds an `/admin/health` endpoint that always responds with a 200 status code and an empty body. The reason for `/admin` is simply that all other `mod-*` modules currently in the Folio ecosystem implement various `/admin` endpoints inherited from `raml-module-builder`. So `/admin/health` is used for consistency between modules.