### PR TITLE
Use 'jsonapi' namespace in ModuleDescriptor.json

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -16,7 +16,7 @@
         },
         {
           "methods": [ "GET" ],
-          "pathPattern": "/eholdings/rmapi/vendors*"
+          "pathPattern": "/eholdings/jsonapi/vendors*"
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],


### PR DESCRIPTION
Jeffrey noticed that our new JSON-API vendor endpoint was not working in production after it was successfully deployed.  Turns out this was a simple discrepancy between rails routes and the module descriptor: `routes.rb` scopes our JSON-API endpoints to `/eholdings/jsonapi` but the module descriptor was configured for `/eholdings/rmapi`.  Consequently, attempting to hit our new endpoint actually fell back to the proxy controller which produced the error.

I figured `/eholdings/jsonapi` was the better naming convention, so all I've done is update the module descriptor to reflect that.