### PR TITLE
Add `/jsonapi/titles*` to Module Descriptor

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -19,6 +19,10 @@
           "pathPattern": "/eholdings/jsonapi/vendors*"
         },
         {
+          "methods": [ "GET" ],
+          "pathPattern": "/eholdings/jsonapi/titles*"
+        },
+        {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
           "pathPattern": "/eholdings/holdings*"
         },


### PR DESCRIPTION
We forgot to add this in the JSONAPI titles PR, but we'll need this in order to use the endpoint in production.