### PR TITLE
Move JSON rescue block to the bottom of the configuration update method

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -4,17 +4,7 @@ class ConfigurationsController < ApplicationController
   end
 
   def update
-    begin
-      data_attributes = JSON.parse(request.body.read)['data']['attributes'] || {}
-    rescue
-      error = {
-        title: 'Invalid JSON',
-        detail: 'The provided JSON payload could not be parsed'
-      }
-
-      render jsonapi_errors: [error],
-             status: :unprocessable_entity
-    end
+    data_attributes = JSON.parse(request.body.read)['data']['attributes'] || {}
 
     config.customer_id = data_attributes['customerId']
     config.api_key = data_attributes['apiKey']
@@ -26,5 +16,16 @@ class ConfigurationsController < ApplicationController
       render jsonapi_errors: config.errors,
              status: :unprocessable_entity
     end
+
+  # NoMethodError is raised when [] is invoked on 'data' or
+  # `data_attributes` and they are `nil`
+  rescue JSON::ParserError, NoMethodError
+    error = {
+      title: 'Invalid JSON',
+      detail: 'The provided JSON payload could not be parsed'
+    }
+
+    render jsonapi_errors: [error],
+           status: :unprocessable_entity
   end
 end

--- a/spec/fixtures/vcr_cassettes/put-configuration-bad.yml
+++ b/spec/fixtures/vcr_cassettes/put-configuration-bad.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 07 Nov 2017 20:32:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.245.25:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.240.95:8081/configurations/entries..
+        : 200 48837us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 444726/configurations
+      X-Okapi-Url:
+      - http://10.31.240.183:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "38b02715-f095-4afc-b07f-c299827e9b98",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 20:32:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/configurations_spec.rb
+++ b/spec/requests/configurations_spec.rb
@@ -5,8 +5,31 @@ RSpec.describe "Configurations", type: :request do
   let(:customer_id) { ENV.fetch('TEST_CUSTOMER_ID') }
   let(:api_key) { ENV.fetch('TEST_API_KEY') }
   let(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN') }
+
+  let(:headers) {
+    {
+      'Content-Type': 'application/vnd.api+json',
+      'X-Okapi-Url': 'https://okapi-sandbox.frontside.io',
+      'X-Okapi-Tenant': 'fs',
+      'X-Okapi-Token': okapi_token
+    }
+  }
+
   let(:resource) do
-    ['/eholdings/configuration', params: {data:{ type: "configurations", id: 'default', attributes: {"customerId": customer_id, "apiKey": api_key} }}.to_json, headers: {'Content-Type': 'application/vnd.api+json','X-Okapi-Url': 'https://okapi-sandbox.frontside.io', 'X-Okapi-Tenant': 'fs', 'X-Okapi-Token': okapi_token}]
+    [
+      '/eholdings/configuration',
+      params: {
+        data: {
+          type: "configurations",
+          id: 'default',
+          attributes: {
+            customerId: customer_id,
+            apiKey: api_key
+          }
+        }
+      }.to_json,
+      headers: headers
+    ]
   end
 
   describe "setting the configuration when it has never been set before" do
@@ -37,6 +60,25 @@ RSpec.describe "Configurations", type: :request do
         expect(json.data.attributes.customerId).to eql(customer_id)
         expect(json.data.attributes.apiKey).to eql(api_key)
       end
+    end
+  end
+
+  describe "setting the configuration with invalid JSON" do
+    before do
+      VCR.use_cassette("put-configuration-bad") do
+        put(
+          '/eholdings/configuration',
+          params: {
+            customerId: customer_id,
+            apiKey: api_key
+          }.to_json,
+          headers: headers
+        )
+      end
+    end
+
+    it "returns an unprocessable entity code" do
+      expect(response).to have_http_status(422)
     end
   end
 


### PR DESCRIPTION
## Purpose
I noticed that after the `rescue` block in the configuration controller the method continues execution, causing a double render.

## Approach
- Move the rescue block to the bottom of the method and specifically catch `JSON:ParserError`
- Also rescue `NoMethodError` in the event that the JSON payload does not contain the proper keys
- Add test to make sure we get the proper response code