### PR TITLE
Implement packages JSON API endpoint

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -20,6 +20,10 @@
         },
         {
           "methods": [ "GET" ],
+          "pathPattern": "/eholdings/jsonapi/packages*"
+        },
+        {
+          "methods": [ "GET" ],
           "pathPattern": "/eholdings/jsonapi/titles*"
         },
         {

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -1,0 +1,75 @@
+class PackagesController < ApplicationController
+  def index
+    # Transform query params to what the EBSCO RM-API expects
+    query = URI.encode_www_form(
+      search: params[:q],
+      orderby: params[:orderby] || params[:q] ? 'relevance' : 'packagename',
+      count: params[:count] || 25,
+      offset: params[:offset] || 1
+    )
+
+    # Make the request for packages from the RM API
+    response = rmapi.request(:get, "packages?%{query}" % { query: query })
+
+    if response.ok?
+      render jsonapi: response.data.packagesList.map { |package| Package.new(data: package) },
+             meta: { totalResults: response.data.totalResults }
+    else
+      render jsonapi_errors: response.errors,
+             status: response.code
+    end
+  end
+
+  def show
+    # The package id is a composite of the vendor id since package
+    # resources are nested within vendors
+    vendor_id, package_id = params[:id].split('-')
+    included_resources = params[:include] ? params[:include].split(',') : []
+    pending_requests = {}
+
+    package_path = "vendors/%{vendor_id}/packages/%{package_id}" % {
+      vendor_id: vendor_id || 0,
+      package_id: package_id || 0
+    }
+    pending_requests[:package] = [:get, package_path]
+
+    if included_resources.include?('customerResources')
+      package_titles_path = "#{package_path}/titles?%{query}" % {
+        # Required RM API params
+        query: URI.encode_www_form(
+          search: '',
+          searchfield: 'titlename',
+          orderby: 'titlename',
+          count: 25,
+          offset: 1
+        )
+      }
+      pending_requests[:titles] = [:get,  package_titles_path]
+    end
+
+    # This is a 'compound' request, consisting of multiple calls
+    # to the RMAPI. `request_multi` will process each request
+    # in the pending_requests object and return the responses
+    # in a similar data structure
+    responses = rmapi.request_multi(pending_requests)
+
+    if responses.ok?
+      titles = responses.titles.data.titles rescue []
+      render jsonapi: Package.new(data: responses.package.data, titles: titles),
+             include: params[:include]
+    else
+      render jsonapi_errors: responses.errors,
+             status: responses.code
+    end
+  end
+
+  private
+
+  def rmapi
+    RmApiService.new(
+      base_url: rmapi_base_url,
+      customer_id: config.customer_id,
+      api_key: config.api_key
+    )
+  end
+end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -1,0 +1,75 @@
+class Package
+  def initialize(data:, titles: [])
+    @attrs = data
+    @titles = titles
+  end
+
+  def id
+    "#{vendor_id}-#{package_id}"
+  end
+
+  def package_id
+    @attrs['packageId']
+  end
+
+  def vendor_id
+    @attrs['vendorId']
+  end
+
+  def name
+    @attrs['packageName']
+  end
+
+  def title_count
+    @attrs['titleCount']
+  end
+
+  def selected_count
+    @attrs['selectedCount']
+  end
+
+  def custom_coverage
+    @attrs['customCoverage']
+  end
+
+  def visibility_data
+    visibility = @attrs['visibilityData']
+
+    if visibility['isHidden']
+      { isHidden: true, reason: 'All titles in this package are hidden' }
+    else
+      visibility
+    end
+  end
+
+  def is_selected
+    @attrs['isSelected']
+  end
+
+  def vendor_name
+    @attrs['vendorName']
+  end
+
+  def customer_resources
+    @titles.map do |title|
+      CustomerResource.new(title.customerResourcesList[0])
+    end
+  end
+
+  def content_type
+    content_types = {
+      all: 'All',
+      aggregatedfulltext: 'Aggregated Full Text',
+      abstractandindex: 'Abstract and Index',
+      ebook: 'E-Book',
+      ejournal: 'E-Journal',
+      print: 'Print',
+      unknown: 'Unknown',
+      onlinereference: 'Online Reference'
+    };
+
+    content_type_key = @attrs['contentType'].downcase.to_sym
+
+    content_types[content_type_key] || @attrs['contentType']
+  end
+end

--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -1,0 +1,16 @@
+class SerializablePackage < SerializableResource
+  type 'packages'
+
+  attributes :name, 
+             :vendor_id, 
+             :package_id, 
+             :content_type,
+             :title_count,
+             :selected_count,
+             :custom_coverage,
+             :visibility_data,
+             :is_selected,
+             :vendor_name
+  
+  has_many :customer_resources
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   scope '/eholdings' do
     scope '/jsonapi' do
       resources :vendors, only: [:index, :show]
+      resources :packages, only: [:index, :show]
       resources :titles, only: [:index, :show]
     end
 

--- a/spec/fixtures/vcr_cassettes/get-packages-customer-resources.yml
+++ b/spec/fixtures/vcr_cassettes/get-packages-customer-resources.yml
@@ -1,0 +1,323 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 07 Nov 2017 22:36:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.245.25:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.240.95:8081/configurations/entries..
+        : 200 49241us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 140391/configurations
+      X-Okapi-Url:
+      - http://10.31.240.183:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "38b02715-f095-4afc-b07f-c299827e9b98",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 22:36:37 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - sandbox.ebsco.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '376'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 07 Nov 2017 22:36:37 GMT
+      X-Amzn-Requestid:
+      - 1de2218a-c40c-11e7-ad5e-3d15b8a4a13c
+      X-Amzn-Remapped-Content-Length:
+      - '376'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 07 Nov 2017 22:36:37 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d97deeb2385556a78005515cfaba11f9.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sO0vwR6ixjb0R8I5Ux68peSkv1Nqc6DbAjtOzrNUqegKP9HOSI0ZiA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":163,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":163,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}}'
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 22:36:37 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581/titles?count=25&offset=1&orderby=titlename&search=&searchfield=titlename
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - sandbox.ebsco.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '34288'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 07 Nov 2017 22:36:39 GMT
+      X-Amzn-Requestid:
+      - 1dfdc049-c40c-11e7-a222-bb1b9136262e
+      X-Amzn-Remapped-Content-Length:
+      - '34288'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 07 Nov 2017 22:36:39 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 42ea0e2305991c9712b9c0ba4ef99d94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _4X7N5NIXcPI0WRqfOoHk0dfTh9XGN_39tsvkBzf0jPwvdua-wuuHQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":163,"titles":[{"titleId":581242,"titleName":"Acta Scientiarum
+        Polonorum. Biotechnologia","publisherName":"Wroclaw University of Environmental
+        & Life Sciences","identifiersList":[{"id":"1644-065X","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2083-8654","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"97C7","source":"MFS","subtype":0,"type":8},{"id":"581242","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":581242,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829613,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2008-12-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=97C7&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":432623,"titleName":"Advances
+        in Bioinformatics","publisherName":"Hindawi Publishing Corporation","identifiersList":[{"id":"1687-8027","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1687-8035","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"I16878027","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"015297000","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"718333","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"8NBX","source":"MFS","subtype":0,"type":8},{"id":"432623","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":432623,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829611,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2008-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=8NBX&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":164826,"titleName":"Annals
+        of Applied Biology","publisherName":"Wiley","identifiersList":[{"id":"0003-4746","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1744-7348","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"058475575","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"058475663","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"058477019","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"112477","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"GX5","source":"MFS","subtype":0,"type":8},{"id":"164826","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":164826,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829668,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2004-06-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=GX5&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":182203,"titleName":"American
+        Journal of Biochemistry and Biotechnology","publisherName":"Science Publications","identifiersList":[{"id":"1553-3468","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1558-6332","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"56831021","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"043248640","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"713424","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1DTT","source":"MFS","subtype":0,"type":8},{"id":"182203","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":182203,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829578,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2006-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=1DTT&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":519050,"titleName":"Allelopathy
+        Journal","publisherName":"International Allelopathy Foundation","identifiersList":[{"id":"0971-4693","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"033549264","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"728624","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"8OP3","source":"MFS","subtype":0,"type":8},{"id":"519050","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Agriculture
+        & Farming"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":519050,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829621,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2009-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=8OP3&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":894010,"titleName":"Anadolu
+        University Journal of Science and Technology - C. Life Sciences and Biotechnology","publisherName":"Anadolu
+        University","identifiersList":[{"id":"2146-0264","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2146-0213","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"BEX4","source":"MFS","subtype":0,"type":8},{"id":"894010","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":894010,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829646,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=BEX4&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":6231,"titleName":"Applied
+        biochemistry and biotechnology","publisherName":"Humana Press Incorporated","identifiersList":[{"id":"0273-2289","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1559-0291","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"07033031","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"068045483","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"068045552","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"068046168","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"122616006","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"108584","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"S0N","source":"MFS","subtype":0,"type":8},{"id":"6231","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":6231,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829685,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2011-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=S0N&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":6291,"titleName":"Applied
+        Microbiology and Biotechnology","publisherName":"Springer Verlag","identifiersList":[{"id":"0175-7598","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1432-0614","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"10397249","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"068324672","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"068324789","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"100457","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"NNA","source":"MFS","subtype":0,"type":8},{"id":"6291","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Microbiology"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":6291,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829677,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=NNA&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":7574,"titleName":"Artificial
+        Cells, Blood Substitutes, and Immobilization Biotechnology","publisherName":"Taylor
+        & Francis","identifiersList":[{"id":"1073-1199","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1532-4184","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"29333477","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"083264598","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"083267146","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"083267680","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"107820","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"PQG","source":"MFS","subtype":0,"type":8},{"id":"7574","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":7574,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829683,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2003-02-01","endCoverage":"2012-12-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=PQG&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":84132,"titleName":"Asia
+        Pacific Biotech News","publisherName":"World Scientific","identifiersList":[{"id":"0219-0303","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1793-6721","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"085668366","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"714646","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"P5F","source":"MFS","subtype":0,"type":8},{"id":"84132","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":84132,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829662,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2003-03-17","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=P5F&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":99148,"titleName":"Archaea","publisherName":"Hindawi
+        Publishing Corporation","identifiersList":[{"id":"1472-3646","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1472-3654","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"49631505","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"070356746","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"107936","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"53M7","source":"MFS","subtype":0,"type":8},{"id":"99148","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Microbiology"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":99148,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829597,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=53M7&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":146131,"titleName":"Applied
+        Bioinformatics","publisherName":"Springer","identifiersList":[{"id":"1175-5636","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"068056522","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"111174","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"2SGT","source":"MFS","subtype":0,"type":8},{"id":"146131","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":146131,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829606,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2006-06-01","endCoverage":"2006-12-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=2SGT&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":591460,"titleName":"Artificial
+        Cells, Blood Substitutes, & Immobilization Biotechnology","publisherName":"Informa
+        Healthcare","identifiersList":[{"id":"1073-1199","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"KU5","source":"MFS","subtype":0,"type":8},{"id":"591460","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":591460,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829676,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2001-01-01","endCoverage":"2002-09-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=KU5&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":1438311,"titleName":"Artificial
+        Cells, Nanomedicine and Biotechnology (formerly known as Artificial Cells,
+        Blood Substitutes, and Biotechnology)","publisherName":"Taylor & Francis","identifiersList":[{"id":"2169-1401","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2169-141X","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"083267700","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"725749","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"FU72","source":"MFS","subtype":0,"type":8},{"id":"1438311","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":1438311,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":9364402,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2013-02-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"months","embargoValue":18},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=FU72&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":10437,"titleName":"Biogeochemistry","publisherName":"Springer
+        Science+Business Media B.V.","identifiersList":[{"id":"0168-2563","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1573-515X","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"11749004","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"121945034","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"121945232","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"100244","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"KP2","source":"MFS","subtype":0,"type":8},{"id":"10437","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Ecology"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":10437,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829667,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=KP2&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":10455,"titleName":"Bioinformatics","publisherName":"Oxford
+        University Press","identifiersList":[{"id":"1367-4803","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1460-2059","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"38899833","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"122150006","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101512","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"N56","source":"MFS","subtype":0,"type":8},{"id":"10455","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":10455,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829671,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"1998-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":"years","embargoValue":1},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=N56&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":124436,"titleName":"Australasian
+        Biotechnology","publisherName":"AusBiotech","identifiersList":[{"id":"1036-7128","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"24626190","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"095371692","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"719207","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"5E3T","source":"MFS","subtype":0,"type":8},{"id":"124436","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":124436,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829604,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2008-09-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=5E3T&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":191832,"titleName":"BioInformation","publisherName":"Biomedical
+        Informatics Publishing Group","identifiersList":[{"id":"0973-8894","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"0973-2063","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"122151194","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"113834","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"38LX","source":"MFS","subtype":0,"type":8},{"id":"191832","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":191832,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829565,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2007-02-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=38LX&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":197816,"titleName":"Biointerphases
+        (Springer)","publisherName":"Springer Berlin Heidelberg","identifiersList":[{"id":"1934-8630","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1559-4106","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"122153798","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"723644","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"2F7L","source":"MFS","subtype":0,"type":8},{"id":"197816","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":197816,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829582,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2006-12-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=2F7L&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":212718,"titleName":"Asian
+        Biotechnology and Development Review","publisherName":"Research & Information
+        System for Developing Countries","identifiersList":[{"id":"0972-7566","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"53869306","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"DBKX","source":"MFS","subtype":0,"type":8},{"id":"212718","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Technology
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":212718,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":5104205,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2012-06-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=DBKX&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":275404,"titleName":"Biomedical
+        Business & Technology","publisherName":"AHC Media LLC","identifiersList":[{"id":"1930-2614","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"1049-4316","source":"ResourceIdentifier","subtype":7,"type":0},{"id":"123074270","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"2SCM","source":"MFS","subtype":0,"type":8},{"id":"275404","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Medical
+        Sciences"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":275404,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829579,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2007-02-01","endCoverage":"2011-12-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=2SCM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":419865,"titleName":"Bioinformatics
+        and Biology Insights","publisherName":"Libertas Academica Ltd.","identifiersList":[{"id":"1177-9322","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"B076","source":"MFS","subtype":0,"type":8},{"id":"419865","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":419865,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829632,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2009-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=B076&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":591455,"titleName":"Avicenna
+        Journal of Medical Biotechnology","publisherName":"Avicenna Research Institute","identifiersList":[{"id":"2008-2835","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2008-4625","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"ATX9","source":"MFS","subtype":0,"type":8},{"id":"591455","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":591455,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829610,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2009-04-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=ATX9&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":773536,"titleName":"Biomedical
+        Engineering and Computational Biology","publisherName":"Libertas Academica
+        Ltd.","identifiersList":[{"id":"1179-5972","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"BNLW","source":"MFS","subtype":0,"type":8},{"id":"773536","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":773536,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829647,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=BNLW&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":1750220,"titleName":"BioMed
+        Research International","publisherName":"Hindawi Publishing Corporation","identifiersList":[{"id":"2314-6133","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2314-6141","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"123058850","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"725758","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"FT2T","source":"MFS","subtype":0,"type":8},{"id":"1750220","source":"AtoZ","subtype":0,"type":9}],"subjectsList":null,"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":1750220,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":6016301,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2013-01-01","endCoverage":""}],"customCoverageList":[{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=FT2T&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}]}'
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 22:36:39 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-packages-not-found.yml
+++ b/spec/fixtures/vcr_cassettes/get-packages-not-found.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 07 Nov 2017 18:56:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.245.25:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.240.95:8081/configurations/entries..
+        : 200 51101us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 789068/configurations
+      X-Okapi-Url:
+      - http://10.31.240.183:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "38b02715-f095-4afc-b07f-c299827e9b98",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:10 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/1/packages/0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - sandbox.ebsco.io
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '67'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 07 Nov 2017 18:56:10 GMT
+      X-Amzn-Requestid:
+      - 51c9948f-c3ed-11e7-a68f-f1115bbce30a
+      X-Amzn-Remapped-Content-Length:
+      - '67'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 07 Nov 2017 18:56:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 1a6fd7bc1e35705af1474194163aa15f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-p3hO8x2njU4WT6zJFpyhOjoAaKUTiITeQkl1cLdwHPVPI66jbTIkg=="
+    body:
+      encoding: UTF-8
+      string: '{"Errors":[{"Code":1001,"Message":"Vendor not found","SubCode":0}]}'
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-packages-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-packages-success.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 07 Nov 2017 18:56:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.245.25:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.240.95:8081/configurations/entries..
+        : 200 47024us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 364926/configurations
+      X-Okapi-Url:
+      - http://10.31.240.183:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "38b02715-f095-4afc-b07f-c299827e9b98",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:08 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - sandbox.ebsco.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '376'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 07 Nov 2017 18:56:09 GMT
+      X-Amzn-Requestid:
+      - 51471e36-c3ed-11e7-a636-b53058981eae
+      X-Amzn-Remapped-Content-Length:
+      - '376'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 07 Nov 2017 18:56:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 11246b86a4ea89501512bda5b8fea01b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DiiG9v4X8x_uImSHs4kRCu7SR0sunpxV1lX0PpGkzh5KGVJ3mD62EQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":163,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":163,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}}'
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi-sandbox.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 07 Nov 2017 18:56:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.31.245.25:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.31.240.95:8081/configurations/entries..
+        : 200 49236us'
+      Host:
+      - okapi-sandbox.frontside.io
+      X-Real-Ip:
+      - 10.28.1.1
+      X-Forwarded-For:
+      - 10.28.1.1
+      X-Forwarded-Host:
+      - okapi-sandbox.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 979846/configurations
+      X-Okapi-Url:
+      - http://10.31.240.183:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "38b02715-f095-4afc-b07f-c299827e9b98",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:07 GMT
+- request:
+    method: get
+    uri: https://sandbox.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?count=25&offset=1&orderby=relevance&search=ebsco
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - sandbox.ebsco.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '8868'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 07 Nov 2017 18:56:07 GMT
+      X-Amzn-Requestid:
+      - 500108d7-c3ed-11e7-a60d-71180c4e41a0
+      X-Amzn-Remapped-Content-Length:
+      - '8868'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 07 Nov 2017 18:56:07 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2d2e1e199c18b4b9392796150bff22d6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - t60QwVVFMQ3hetY5gDCW4kfQGvjpZ3gpZmDQVyYWkkXdPbUOv35Nzg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":101,"packagesList":[{"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":163,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":163,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2014-01-01","endCoverage":"2015-12-31"}},{"packageId":3964,"packageName":"EBSCO
+        Business Basics","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":527,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6856,"packageName":"EBSCO
+        Chemical Engineering Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":162,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6027,"packageName":"EBSCO
+        Citations","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":4841,"packageName":"EBSCO
+        Discovery Service","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":5207,"packageName":"EBSCO
+        eBooks","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":968452,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":968452,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6582,"packageName":"EBSCO
+        Engineering Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1131,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6857,"packageName":"EBSCO
+        Environmental Engineering Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":431,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6859,"packageName":"EBSCO
+        Geotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":110,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":3950,"packageName":"EBSCO
+        MegaFILE","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":20190,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6860,"packageName":"EBSCO
+        Nanotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":116,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1726,"packageName":"EBSCO
+        Open Access Arts Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":400,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1703,"packageName":"EBSCO
+        Open Access Biology Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":1242,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1656,"packageName":"EBSCO
+        Open Access Business and Economics Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":896,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":896,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1657,"packageName":"EBSCO
+        Open Access Computer Science Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":491,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":491,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":3732,"packageName":"EBSCO
+        Open Access Education Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":669,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1707,"packageName":"EBSCO
+        Open Access Environmental Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":537,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":537,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1816,"packageName":"EBSCO
+        Open Access French Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":117,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1813,"packageName":"EBSCO
+        Open Access German Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":57,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1728,"packageName":"EBSCO
+        Open Access History Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":536,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1812,"packageName":"EBSCO
+        Open Access Journals","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":11752,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1680,"packageName":"EBSCO
+        Open Access Language and Literature Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":850,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1697,"packageName":"EBSCO
+        Open Access Law Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":781,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":781,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1727,"packageName":"EBSCO
+        Open Access Mathematics and Statistics","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":450,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":450,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1530,"packageName":"EBSCO
+        Open Access Medical and Health Collection","isCustom":false,"vendorId":273,"vendorName":"EBSCO
+        Open Access Lists","titleCount":3141,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 18:56:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe "Packages", type: :request do
+  let(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN') }
+
+  let(:headers) do
+    {
+      'X-Okapi-Url': 'https://okapi-sandbox.frontside.io',
+      'X-Okapi-Tenant': 'fs',
+      'X-Okapi-Token': okapi_token
+    }
+  end
+
+  describe "searching for packages" do
+    before do
+      VCR.use_cassette("search-packages") do
+        get '/eholdings/jsonapi/packages/?q=ebsco', headers: headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "gets a list of resources" do
+      expect(response).to have_http_status(200)
+      expect(json.data.length).to equal(25)
+      expect(json.meta.totalResults).to equal(101)
+    end
+  end
+
+  describe "getting a specific package" do
+    before do
+      VCR.use_cassette("get-packages-success") do
+        get '/eholdings/jsonapi/packages/19-6581', headers: headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "gets the resource" do
+      expect(response).to have_http_status(200)
+      expect(json.data.type).to eq('packages')
+      expect(json.data.id).to eq('19-6581')
+      expect(json.data.attributes).to include(
+        'name',
+        'contentType',
+        'titleCount',
+        'selectedCount',
+        'customCoverage',
+        'visibilityData',
+        'isSelected',
+        'vendorName'
+      )
+      expect(json.data.attributes.vendorId).to eq(19)
+      expect(json.data.attributes.packageId).to eq(6581)
+    end
+
+    it "returns a human readable content type" do
+      expect(json.data.attributes.contentType).to eq('Aggregated Full Text')
+    end
+
+    it "returns a valid visibility reason" do
+      expect(json.data.attributes.visibilityData.reason).to eq('All titles in this package are hidden')
+    end
+  end
+
+  describe "getting a package with customer resources" do
+    before do
+      VCR.use_cassette("get-packages-customer-resources") do
+        get '/eholdings/jsonapi/packages/19-6581?include=customerResources', headers: headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "includes a list of customer resources" do
+      expect(json.data.relationships.customerResources.data.length).to eq(25)
+      expect(json.included.length).to eq(25)
+    end
+
+    it "returns the correct included type" do
+      expect(json.included.first.type).to eq('customerResources')
+    end
+  end
+
+  describe "getting a non-existing package" do
+    before do
+      VCR.use_cassette("get-packages-not-found") do
+        get '/eholdings/jsonapi/packages/1', headers: headers
+      end
+    end
+
+    it "returns a not found error" do
+      expect(response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Implements a JSON API endpoint for packages and also allows you to include customer resources via `?include=customerResources`.

## Approach
- Adds a new `request_multi` method to the RM API Service which can make multiple requests and returns the responses with combined `ok?` and `errors` methods.

  ```ruby
  # requests are made in the order defined until one fails
  responses = rmapi.request_multi(
    package: [:get, '/vendors/19/packages/6581'],
    titles: [:get, '/vendors/19/packages/6581/titles?count=25']
  )

  responses.ok? 
  # => true if all responses are OK

  responses.errors
  # => errors from the last failed request

  responses.code
  # => the last response's code

  responses.package
  # => package request response

  responses.titles
  # => titles request response
  ```

- Formats package responses as JSON API

- Formats a package's `visibilityData` as always displaying "All titles in this package are hidden" rather than the RM API message

- Formats a package's `contentType` attribute

- Adds the ability to include customer resources when requesting a package (this creates another request to RM API for the related package titles)