### PR TITLE
Add default value for ENV.fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - OKAPI_EXTERNAL_ADDRESS=https://okapi.frontside.io
     - FOLIO_MODULE_NAME=mod-kb-ebsco
     - FOLIO_TENANT_ID=fs
-    - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://sandbox.ebsco.io
+    - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://api.ebsco.io
     - MODULE_VERSION=0.1.1
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - OKAPI_EXTERNAL_ADDRESS=https://okapi.frontside.io
     - FOLIO_MODULE_NAME=mod-kb-ebsco
     - FOLIO_TENANT_ID=fs
-    - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://api.ebsco.io
+    - EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL=https://sandbox.ebsco.io
     - MODULE_VERSION=0.1.1
 
 install:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::API
   end
 
   def rmapi_base_url
-    ENV.fetch('EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL')
+    ENV.fetch('EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL', 'https://sandbox.ebsco.io')
   end
 
   def okapi_url


### PR DESCRIPTION
## Purpose
By default if no base URL is passed we want to communicate with the RMAPI sandbox. This will allow us to have control over setting which RMAPI backend `mod-kb-ebsco` is communicating with.  So if we have `mod-kb-ebsco` running in our production cluster we can point that instance of `mod-kb-ebsco` in that cluster to point at the production version of RMAPI. The opposite will be true for the sandbox environment `mod-kb-ebsco` will point at the RMAPI-sandbox.

## Approach
Add
```
ENV.fetch('EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL', 'https://sandbox.ebsco.io')
```
 