### PR TITLE
Make sure contributors and subjects are always arrays

### DIFF
--- a/app/serializable/serializable_customer_resource.rb
+++ b/app/serializable/serializable_customer_resource.rb
@@ -15,7 +15,7 @@ class SerializableCustomerResource < SerializableResource
 
 
   attribute :contributors do
-    @object.contributorsList
+    @object.contributorsList || []
   end
   attribute :identifiers do
     types = {
@@ -76,7 +76,7 @@ class SerializableCustomerResource < SerializableResource
     publication_types[type_key] || @object.pubType
   end
   attribute :subjects do
-    @object.subjectsList
+    @object.subjectsList || []
   end
 
 

--- a/app/serializable/serializable_title.rb
+++ b/app/serializable/serializable_title.rb
@@ -14,11 +14,11 @@ class SerializableTitle < SerializableResource
   end
 
   attribute :contributors do
-    @object.contributorsList
+    @object.contributorsList || []
   end
 
   attribute :subjects do
-    @object.subjectsList
+    @object.subjectsList || []
   end
 
 

--- a/spec/fixtures/vcr_cassettes/get-titles-empty-array-fields.yml
+++ b/spec/fixtures/vcr_cassettes/get-titles-empty-array-fields.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 05 Dec 2017 22:36:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41377us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 056260/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 05 Dec 2017 22:36:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/146131
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '7797'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 05 Dec 2017 22:36:05 GMT
+      X-Amzn-Requestid:
+      - ae0e60d6-da0c-11e7-a7c9-a13293f6020c
+      X-Amzn-Remapped-Content-Length:
+      - '7797'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 05 Dec 2017 22:36:05 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5fc5d2c46569dc26a5e3b49fee3b19a4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gkTtM-CJ2VWLPXg-WAO_vTuwRJ1HtPNcHI1CyRwYq4x6eMZcQUyXwQ==
+    body:
+      encoding: UTF-8
+      string: '{"description":"Features articles that provide the practising bioinformaticist
+        with information relating to global and regional bioinformatics resources,
+        and a future view of this developing field.","edition":null,"isPeerReviewed":true,"contributorsList":[],"titleId":146131,"titleName":"Applied
+        Bioinformatics","publisherName":"Springer","identifiersList":[{"id":"068056522","source":"ResourceIdentifier","subtype":0,"type":11},{"id":"111174","source":"ResourceIdentifier","subtype":0,"type":13},{"id":"1175-5636","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"146131","source":"AtoZ","subtype":0,"type":9},{"id":"2SGT","source":"MFS","subtype":0,"type":17}],"subjectsList":[],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":146131,"packageId":0,"packageName":"Publisher''s
+        Site","isPackageCustom":false,"vendorId":0,"vendorName":"System Account","locationId":972416,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-03-01","endCoverage":"2006-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://link.springer.com/journal/40282","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":240,"packageName":"Journals@Ovid","isPackageCustom":false,"vendorId":16,"vendorName":"Ovid
+        Technologies","locationId":818439,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-03-01","endCoverage":"2006-05-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://ovidsp.ovid.com/ovidweb.cgi?T=JS&NEWS=n&CSC=Y&PAGE=toc&D=ovft&AN=00822942-000000000-00000","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":434,"packageName":"SpringerLINK
+        Journals","isPackageCustom":false,"vendorId":36,"vendorName":"Springer Nature","locationId":7763334,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://link.springer.com/journal/40282","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":508,"packageName":"OCLC
+        Electronic Collections Online","isPackageCustom":false,"vendorId":21,"vendorName":"OCLC","locationId":1259341,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2006-01-01","endCoverage":"2006-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://firstsearch.oclc.org/FSIP?db=ECO&journal=1175-5636&screen=info&done=referer","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":1336,"packageName":"MEDLINE
+        with Full Text (EBSCO)","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1400420,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2006-06-01","endCoverage":"2006-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=mnh&jid=2SGT&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":2088,"packageName":"NSTL
+        Archives","isPackageCustom":false,"vendorId":265,"vendorName":"National Science
+        and Technology Library","locationId":27918078,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2005-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://archive.nstl.gov.cn/Archives/browse.do?action=viewJournal&journalID=2225&flag=byWord","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":2494,"packageName":"Journals@Ovid
+        (Athens Authorization)","isPackageCustom":false,"vendorId":16,"vendorName":"Ovid
+        Technologies","locationId":1720917,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-03-01","endCoverage":"2006-05-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://ovidsp.ovid.com/athens/ovidweb.cgi?T=JS&NEWS=n&CSC=Y&PAGE=toc&D=ovft&AN=00822942-000000000-00000","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":5604,"packageName":"MEDLINE
+        Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":3959072,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2006-06-01","endCoverage":"2006-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=mdc&jid=2SGT&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829606,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"managedCoverageList":[{"beginCoverage":"2006-06-01","endCoverage":"2006-12-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=2SGT&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":146131,"packageId":1987440,"packageName":"Adis
+        International Archive","isPackageCustom":false,"vendorId":36,"vendorName":"Springer
+        Nature","locationId":18792421,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://link.springer.com/journal/40282","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
+    http_version: 
+  recorded_at: Tue, 05 Dec 2017 22:36:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe "Packages", type: :request do
     it "returns the correct included type" do
       expect(json.included.first.type).to eq('customerResources')
     end
+
+    it "returns empty arrays for array attributes" do
+      expect(json.included[8].attributes.contributors).to eq([])
+      expect(json.included[8].attributes.subjects).to eq([])
+    end
   end
 
   describe "getting a package with included vendor" do

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe "Titles", type: :request do
     end
   end
 
+  describe "getting a title with empty array fields" do
+    before do
+      VCR.use_cassette("get-titles-empty-array-fields") do
+        get '/eholdings/jsonapi/titles/146131', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it "returns empty arrays for array attributes" do
+      expect(json.data.attributes.contributors).to eq([])
+      expect(json.data.attributes.subjects).to eq([])
+    end
+  end
+
 
   describe "getting a non-existing title" do
     before do


### PR DESCRIPTION
The EBSCO RM API usually returns an array for `subjectsList` and `contributorsList`, but not always.

In the response from RM API's `/vendors/19/packages/6581/titles?count=25&offset=1&orderby=titlename&search=&searchfield=titlename`, one of customer resources has a `subjectsList` of `null`.

This will ensure `subjects` and `contributors` attributes on titles and customer resources coming back from `mod-kb-ebsco` always return an array (but an empty one if RM API returned `null`).