### PR TITLE
Adjust isHidden deserialization

### DIFF
--- a/app/deserializable/deserializable_customer_resource.rb
+++ b/app/deserializable/deserializable_customer_resource.rb
@@ -1,12 +1,9 @@
 class DeserializableCustomerResource < JSONAPI::Deserializable::Resource
   attributes :isSelected,
-             :customEmbargoPeriod
+             :customEmbargoPeriod,
+             :visibilityData
 
   attribute :customCoverages do |value|
     { customCoverageList: value }
-  end
-
-  attribute :isHidden do |value|
-    { visibilityData: { isHidden: value } }
   end
 end

--- a/app/deserializable/deserializable_package.rb
+++ b/app/deserializable/deserializable_package.rb
@@ -1,8 +1,5 @@
 class DeserializablePackage < JSONAPI::Deserializable::Resource
   attributes :isSelected,
-             :customCoverage
-
-  attribute :isHidden do |value|
-    { visibilityData: { isHidden: value } }
-  end
+             :customCoverage,
+             :visibilityData
 end

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage-verify.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:34 GMT
+      - Thu, 07 Dec 2017 18:25:58 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41631us'
+        : 200 41714us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 699778/configurations
+      - 302313/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:34 GMT
+  recorded_at: Thu, 07 Dec 2017 18:25:58 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '360'
+      - '342'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:34 GMT
+      - Thu, 07 Dec 2017 18:25:58 GMT
       X-Amzn-Requestid:
-      - 3c6ff3d5-d9e4-11e7-b506-312c0a4947a0
+      - 1220b405-db7c-11e7-a2f7-4d3d12a05954
       X-Amzn-Remapped-Content-Length:
-      - '360'
+      - '342'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,19 +157,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:35 GMT
+      - Thu, 07 Dec 2017 18:25:58 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 66ed69e8b47ad05050331602c798132f.cloudfront.net (CloudFront)
+      - 1.1 11dd60d1f68e8258294f92935b53a91f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - boIPenUBSYWQLhBHv30timI88TdYp6ovNzIMhOAFxolu7kvirQDNxw==
+      - Gytk-H5ksUqomodNKAMrp9UDuoqUF5TtF4DGsw-t7UQ9IkKk_g5wPw==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:35 GMT
+  recorded_at: Thu, 07 Dec 2017 18:25:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
@@ -1,0 +1,235 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 18:25:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41849us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 128412/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:25:56 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 18:25:57 GMT
+      X-Amzn-Requestid:
+      - 114b897c-db7c-11e7-9f7b-ad1dcb50df91
+      X-Amzn-Remapped-Content-Length:
+      - '342'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 18:25:57 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 11dd60d1f68e8258294f92935b53a91f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 1cxtN7XhXumwafLcIdgp5KqY7V_ZuUvNPVGqViUbGoHIzcpQfIvjmg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:25:57 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false,"visibilityData":{"isHidden":null},"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 18:25:57 GMT
+      X-Amzn-Requestid:
+      - 11870bea-db7c-11e7-9ea7-0d040f8d1c07
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 18:25:57 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 441811a054e8d055b893175754efd0c3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ZyrCSjWfsxoNmU4gGze7vgwjP-bMEiXpIIByEQjHkIDg1ZHBKhSYLA==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:25:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:47:22 GMT
+      - Thu, 07 Dec 2017 19:08:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 45289us'
+        : 200 43596us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 971548/configurations
+      - 633152/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:47:22 GMT
+  recorded_at: Thu, 07 Dec 2017 19:08:40 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:47:23 GMT
+      - Thu, 07 Dec 2017 19:08:40 GMT
       X-Amzn-Requestid:
-      - 5928b3b5-d9e4-11e7-8568-910c60d9f096
+      - '094cd106-db82-11e7-a29e-552bb90c9464'
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -157,26 +157,26 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:47:22 GMT
+      - Thu, 07 Dec 2017 19:08:40 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0cf1d7257c633ae75623c5e75bf3805e.cloudfront.net (CloudFront)
+      - 1.1 4c2196e36fd33f377384d605b4424e95.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - dcTcG3DMjP1gtSc1np95Iqpk4qCYZ9P33yPw63AV7_x7hTiYKSQejA==
+      - oTR_IlkLBi96WVl2RlzmHpZkRW8cNknLuHcBvsGtZ2Mh32n6d6e97g==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:47:23 GMT
+  recorded_at: Thu, 07 Dec 2017 19:08:40 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverage":{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}}'
+      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:47:23 GMT
+      - Thu, 07 Dec 2017 19:08:41 GMT
       X-Amzn-Requestid:
-      - 595a72f9-d9e4-11e7-8410-470df1158401
+      - '09742f85-db82-11e7-b2ce-2516f118c0a1'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,18 +218,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:47:23 GMT
+      - Thu, 07 Dec 2017 19:08:40 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c54d7f08e2f3dab1918454910cc8aad0.cloudfront.net (CloudFront)
+      - 1.1 455cf6ccbccc261c46d02110de1c0237.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fLhTnbQiqizdKQlAEQGAoWspLRKjDgKdGmwi6yoVYSgJ4WJif7G3TQ==
+      - xEiMlHqFJV2lK_8OLgo9yBA6aPXk9Gm2xUzJoRvVZEw4H57vMMB1-Q==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:47:23 GMT
+  recorded_at: Thu, 07 Dec 2017 19:08:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-verify.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:37 GMT
+      - Thu, 07 Dec 2017 19:08:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41145us'
+        : 200 42188us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 125775/configurations
+      - 223158/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:37 GMT
+  recorded_at: Thu, 07 Dec 2017 19:08:41 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:37 GMT
+      - Thu, 07 Dec 2017 19:08:42 GMT
       X-Amzn-Requestid:
-      - 3e07d111-d9e4-11e7-b6a0-17861fa15474
+      - 0a25cc11-db82-11e7-8d72-af681b48496e
       X-Amzn-Remapped-Content-Length:
       - '376'
       X-Amzn-Remapped-Connection:
@@ -157,19 +157,19 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:37 GMT
+      - Thu, 07 Dec 2017 19:08:42 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 20f1c35f343f4b271ae8dcacfd7ea0e9.cloudfront.net (CloudFront)
+      - 1.1 e1eb7447ab46f530f6009f1d93917c54.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - DrwfHLG0iSTcLhJ9kBZsb_Qkiytp_9o69z8DBfRtB5RSSx8FibQuDg==
+      - CS1BiEkaw8u_69SWQziXGVlF-XQAIT4lTydVtPgU7tPYKmUP9VKAPg==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:37 GMT
+  recorded_at: Thu, 07 Dec 2017 19:08:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden-verify.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:32 GMT
+      - Thu, 07 Dec 2017 18:18:57 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41516us'
+        : 200 42886us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 558203/configurations
+      - 698680/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:32 GMT
+  recorded_at: Thu, 07 Dec 2017 18:18:57 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '343'
+      - '342'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:32 GMT
+      - Thu, 07 Dec 2017 18:18:57 GMT
       X-Amzn-Requestid:
-      - 3b053fe4-d9e4-11e7-8278-1b35aba88451
+      - 1774f2fb-db7b-11e7-9d97-cd0229d058e2
       X-Amzn-Remapped-Content-Length:
-      - '343'
+      - '342'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,18 +157,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:32 GMT
+      - Thu, 07 Dec 2017 18:18:58 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 e30ae5b3d9f6779a9b8bc992faad0b09.cloudfront.net (CloudFront)
+      - 1.1 4c2196e36fd33f377384d605b4424e95.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - q3ux-BQKi7CfnNFvKVwo_BeOmppsQwr9ovjSezowUZ2xwUqxhZCBvQ==
+      - mqAbpz5jiSxPkkj74uKG7avHMEJwkBajsv9bmMKjQVQciV4vXukERg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:32 GMT
+  recorded_at: Thu, 07 Dec 2017 18:18:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:33 GMT
+      - Thu, 07 Dec 2017 18:18:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41486us'
+        : 200 41778us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 489831/configurations
+      - 275160/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:33 GMT
+  recorded_at: Thu, 07 Dec 2017 18:18:55 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '343'
+      - '342'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:33 GMT
+      - Thu, 07 Dec 2017 18:18:56 GMT
       X-Amzn-Requestid:
-      - 3ba43eec-d9e4-11e7-9db7-7d5700008373
+      - 15f382d8-db7b-11e7-bcc7-bbc24c6dc4b5
       X-Amzn-Remapped-Content-Length:
-      - '343'
+      - '342'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,26 +157,26 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:32 GMT
+      - Thu, 07 Dec 2017 18:18:56 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c54d7f08e2f3dab1918454910cc8aad0.cloudfront.net (CloudFront)
+      - 1.1 423912f2b1c5569e2fa5017167c61fa0.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - QdcUnibRpN5cSf5Z7NYL4HQqZIJU2w5xM3ShHQU6oUztBbSel4lyxQ==
+      - pZzTVXjmzoDlyLdsEJ9rwnOwYENf2c-ukog2rov0qvAT0c_D0hfPgA==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:33 GMT
+  recorded_at: Thu, 07 Dec 2017 18:18:56 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"isSelected":false,"visibilityData":{"isHidden":null},"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:33 GMT
+      - Thu, 07 Dec 2017 18:18:56 GMT
       X-Amzn-Requestid:
-      - 3bcbeac0-d9e4-11e7-878c-b3549eca30e1
+      - 16b06a80-db7b-11e7-9b30-29b5b560a758
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,18 +218,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:33 GMT
+      - Thu, 07 Dec 2017 18:18:56 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1b52a5dd431f9e3c81753e61dfdf467a.cloudfront.net (CloudFront)
+      - 1.1 76bce8bb4fbd102fc0b3aa2e41094b79.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - wXfKguCMEXzk2wxvcOVONwhSpFWB0ckT6NOzKdUkAZJkgkWoBr4HFw==
+      - viGlg50r01-toiOnOybEHPIAhQjA3Bt9TFSUMSYHHxCzlpkHaJm3WA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:33 GMT
+  recorded_at: Thu, 07 Dec 2017 18:18:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected-verify.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 18:16:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41411us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 498004/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:16:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 18:16:02 GMT
+      X-Amzn-Requestid:
+      - aee6e59d-db7a-11e7-a221-b705a5d0d53f
+      X-Amzn-Remapped-Content-Length:
+      - '343'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 18:16:02 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6cd88b9fd84ad5daa3b3867fb8c5c91a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DzzuSdf0pNwAeGDeuji7Mvf4g6Qo5zoBWW2GoXkMHrVDBUffHPdMwg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:16:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
@@ -1,0 +1,235 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 18:16:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41218us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 506074/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:16:01 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 18:16:01 GMT
+      X-Amzn-Requestid:
+      - ae1d542b-db7a-11e7-acbd-7f24fd16c9d9
+      X-Amzn-Remapped-Content-Length:
+      - '342'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 18:16:01 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c54d7f08e2f3dab1918454910cc8aad0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _br2OQHvKmyBdhlL3h_mmznuuUEMVcfAH-8DeVESL1WbDrSauTPRNg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:16:01 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"visibilityData":{"isHidden":null},"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 18:16:01 GMT
+      X-Amzn-Requestid:
+      - ae46ad8d-db7a-11e7-a4b3-19516f239b3b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 18:16:01 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1b52a5dd431f9e3c81753e61dfdf467a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - I_cZ27ACtKby94XcpJc5ZyLZTnAGVqXuwyaLzeL25TXk28-wy52J6A==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 18:16:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage-verify.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 22:05:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 40545us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 359605/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:05:01 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '359'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:05:02 GMT
+      X-Amzn-Requestid:
+      - ac383304-db9a-11e7-9a7c-219f375873b1
+      X-Amzn-Remapped-Content-Length:
+      - '359'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:05:02 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2708ce9c9ca82cfc3f3661b87f21b072.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ANUG5XTjwukl9Gcas46IXs2GC_z9K0c-PS_tPqQZbuKU5bcG9_C7ZQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:05:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:35 GMT
+      - Thu, 07 Dec 2017 22:05:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 40943us'
+        : 200 42489us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.1.1
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.36.1.1
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 176364/configurations
+      - 141253/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:35 GMT
+  recorded_at: Thu, 07 Dec 2017 22:05:00 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '360'
+      - '343'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:35 GMT
+      - Thu, 07 Dec 2017 22:05:00 GMT
       X-Amzn-Requestid:
-      - 3d1cae20-d9e4-11e7-a1b6-d5d31779dd39
+      - ab77c8ee-db9a-11e7-b792-f1d79ead6cb0
       X-Amzn-Remapped-Content-Length:
-      - '360'
+      - '343'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,27 +157,26 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:36 GMT
+      - Thu, 07 Dec 2017 22:05:01 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 73fa5a1ee49cf827e596b502b5927eab.cloudfront.net (CloudFront)
+      - 1.1 a05e153e17e2a6485edf7bf733e131a4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - wTyRvLYjiqj0W6b7arPjxL3dOTsENRUwjrS6N-PNCWAjA9KyAC9cZA==
+      - ZHVAoW6nzvYw0ltW0gdi6kUdjAYbFYu5flgIZ_mOKYSOyKdK4kiflw==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:36 GMT
+  recorded_at: Thu, 07 Dec 2017 22:05:00 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -203,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:36 GMT
+      - Thu, 07 Dec 2017 22:05:01 GMT
       X-Amzn-Requestid:
-      - 3d43e5ba-d9e4-11e7-bcae-81888a02fd60
+      - ab97ad0c-db9a-11e7-8136-6945058bee0f
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -219,18 +218,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:36 GMT
+      - Thu, 07 Dec 2017 22:05:01 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 41b2ee7cbe95749816a7586d9ab4629d.cloudfront.net (CloudFront)
+      - 1.1 f32e4aea3683be99c4324204c29f5852.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - S5nIpTTtegqLmqKsg8dpfYbX1kwZkG85jaR1AnyCmjXqcUacH_Gqzw==
+      - 4t5n8AivrnNX5yU6nmgD4p3LVYIEEjk5ksgT-b_A4EaaR4YDi6SDnw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:36 GMT
+  recorded_at: Thu, 07 Dec 2017 22:05:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:47:24 GMT
+      - Thu, 07 Dec 2017 22:08:59 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42310us'
+        : 200 42852us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.2.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.2.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 626736/configurations
+      - 238506/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:47:24 GMT
+  recorded_at: Thu, 07 Dec 2017 22:09:00 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '359'
+      - '343'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:47:24 GMT
+      - Thu, 07 Dec 2017 22:09:00 GMT
       X-Amzn-Requestid:
-      - 5a22f2ca-d9e4-11e7-a481-230fc84cf267
+      - 3a381feb-db9b-11e7-b6ef-0ba1ca58bc3b
       X-Amzn-Remapped-Content-Length:
-      - '359'
+      - '343'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,18 +157,79 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:47:24 GMT
+      - Thu, 07 Dec 2017 22:09:00 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 d8f42fc9558e3e49ebfdf8834baeb756.cloudfront.net (CloudFront)
+      - 1.1 b1b23b42cbc299e715c1f970637c6748.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fH329yZq8SY70nCVIydGohyQqWSaIr3a9RbQx8YyVeKqO34Tj9gbAA==
+      - nKQ85aGuIsWO0JNS6MfUAtd4ABzxAOlfQ3EIcSoyF6FbBKb4hUn4Vg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:47:24 GMT
+  recorded_at: Thu, 07 Dec 2017 22:09:00 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false,"isHidden":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:09:00 GMT
+      X-Amzn-Requestid:
+      - 3a68cd45-db9b-11e7-8ba3-49b38112114d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:09:00 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c4032d302400e72942a63d2c4ac1acc5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - OnkVShSmxYrJT3D74qWp8uM7FX9LfjNoZpfSmDdH4UoWtPwICgK53g==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:09:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-verify.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 22:09:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41897us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 199944/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:09:01 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:09:01 GMT
+      X-Amzn-Requestid:
+      - 3afa5e82-db9b-11e7-890a-cbee259c6661
+      X-Amzn-Remapped-Content-Length:
+      - '342'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:09:01 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b08d3fd1ea7c0f4b62f5adbb976ab099.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kxfLZFUv38LX8NhGRPnY4nx0t6iFtGMY10mDEA_Cq0PaVJ9BJyDfFg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:09:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden-verify.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 22:01:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 42175us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 326001/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:01:27 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '360'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:01:27 GMT
+      X-Amzn-Requestid:
+      - 2c72b234-db9a-11e7-999f-03de2539851d
+      X-Amzn-Remapped-Content-Length:
+      - '360'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:01:27 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d03e57da6d2a774444e63ebbe2e7e9c0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4-wXmO5OQzpjRM3WjB5UXSoIFfWvYl-crNOypYuBiWb8FbYlPvFhPw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:01:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
@@ -1,0 +1,235 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 22:01:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41824us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 797444/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:01:26 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:01:26 GMT
+      X-Amzn-Requestid:
+      - 2bbafa7c-db9a-11e7-867f-65a2f8c25160
+      X-Amzn-Remapped-Content-Length:
+      - '343'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:01:26 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4f672256eaca5524999342dc8678cdd2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Tynuj0Ei70GjaleU_Atg5Wvq_4mFHRA7FmlEaVYzQ4HrhtOMc0xNiw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:01:26 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 22:01:26 GMT
+      X-Amzn-Requestid:
+      - 2bd9f42b-db9a-11e7-878c-c5ed758482c8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 22:01:26 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d03e57da6d2a774444e63ebbe2e7e9c0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DbpGpGtTPKySW3PoDjFnrBf_WvjR_FJrMkrpR4AaLiFej9GnrrrVUw==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 22:01:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected-verify.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected-verify.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 07 Dec 2017 21:59:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
+        : 202'
+      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
+        : 200 41913us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 268519/configurations
+      X-Okapi-Url:
+      - http://10.39.247.213:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:59:47 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 07 Dec 2017 21:59:48 GMT
+      X-Amzn-Requestid:
+      - f1147b7d-db99-11e7-aed5-772d8d11b3fe
+      X-Amzn-Remapped-Content-Length:
+      - '342'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 07 Dec 2017 21:59:48 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0c146399837c7d36c1f0f9d2636f8cf8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - un7hzSiCfERREdJEVtl1ErXNjI1rNRLQtIqFx32p23vaXI4dIqsm0A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Thu, 07 Dec 2017 21:59:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 05 Dec 2017 17:46:29 GMT
+      - Thu, 07 Dec 2017 21:59:46 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 272980us'
+        : 200 42780us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 845827/configurations
+      - 520485/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:29 GMT
+  recorded_at: Thu, 07 Dec 2017 21:59:46 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '342'
+      - '343'
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:30 GMT
+      - Thu, 07 Dec 2017 21:59:46 GMT
       X-Amzn-Requestid:
-      - 39b8e9c2-d9e4-11e7-b931-bf6cc1f1673f
+      - f0674b6d-db99-11e7-92c6-9f3046edcaed
       X-Amzn-Remapped-Content-Length:
-      - '342'
+      - '343'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,26 +157,26 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:30 GMT
+      - Thu, 07 Dec 2017 21:59:47 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 24b0e5a3429d07ef12381da50e07f70f.cloudfront.net (CloudFront)
+      - 1.1 b20a36f6809f60038027cfc2337597fe.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - SGmP89GevhnP6g3CMe048_06aPwMNUyuaJ39i8Ufu-yYG6QUMEi_ZA==
+      - gqlFZXZMYCx4aLtcq5YanfxKKCR1U-hcBcwppd9WkrcUvW5ELM8JzA==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:30 GMT
+  recorded_at: Thu, 07 Dec 2017 21:59:46 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"isSelected":false,"isHidden":false,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 05 Dec 2017 17:46:30 GMT
+      - Thu, 07 Dec 2017 21:59:47 GMT
       X-Amzn-Requestid:
-      - 39efd864-d9e4-11e7-baeb-e19acec07cf0
+      - f08449ba-db99-11e7-b1ec-aff32c19d5ab
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,18 +218,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 05 Dec 2017 17:46:30 GMT
+      - Thu, 07 Dec 2017 21:59:47 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 d2bd759914e30b1d5aee2929535c55f9.cloudfront.net (CloudFront)
+      - 1.1 ee9d39c7785a9185384280d8c69fefec.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - kOpCv1IdIzbMHZj1xTa6JfFJbf7VOhA2IK2a1MjRklq4xpJ8MsNXJw==
+      - ZpX6vwpTSwXC9fss8b7-hmECYF-5tCVOJ3ujnPNbtQIHQjdjTnjCng==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Dec 2017 17:46:30 GMT
+  recorded_at: Thu, 07 Dec 2017 21:59:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/customer_resources_spec.rb
+++ b/spec/requests/customer_resources_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Customer Resources", type: :request do
             "attributes" => {
               "isSelected" => true
             }
-	  }
+    }
         }
       end
 
@@ -228,9 +228,11 @@ RSpec.describe "Customer Resources", type: :request do
           "data" => {
             "type" => 'customerResources',
             "attributes" => {
-              "isHidden" => true
+              "visibilityData" => {
+                "isHidden" => true
+              }
             }
-	  }
+          }
         }
       end
 
@@ -274,7 +276,7 @@ RSpec.describe "Customer Resources", type: :request do
                 }
               ]
             }
-	  }
+    }
         }
       end
 
@@ -322,7 +324,7 @@ RSpec.describe "Customer Resources", type: :request do
                 "embargoValue" => 7
               }
             }
-	  }
+    }
         }
       end
 
@@ -361,7 +363,9 @@ RSpec.describe "Customer Resources", type: :request do
             "type" => 'customerResources',
             "attributes" => {
               "isSelected" => true,
-              "isHidden" => false,
+              "visibilityData" => {
+                "isHidden" => false
+              },
               "customEmbargoPeriod" => {
                 "embargoUnit" => "Months",
                 "embargoValue" => 5


### PR DESCRIPTION
## Background
- RM API gives us a package's `isHidden` attribute inside of a `visibilityData` object.
- To edit, RM API expects `isHidden` to be a top-level key in a PUT, not inside of `visibilityData`.
- The de/serialization taking place in https://github.com/thefrontside/mod-kb-ebsco/pull/30 expected `mod-kb-ebsco` consumers to PUT `isHidden` on the top level of attributes, not within `visibilityData`.

## Approach
This makes `mod-kb-ebsco`'s GETs and PUTs symmetrical, with `isHidden` always inside of `visibilityData`.

We may want to flatten it out at some point, with `isHidden` and `isHiddenReason` as un-nested top-level attributes, but this will work with `ui-eholdings` as currently built.

## Bonus
I documented a few of RM API's quirkier behaviors in the packages spec, but didn't attempt to solve for them better yet. When a package is not selected, its custom coverage and hidden status aren't editable, but RM API still returns a 204. In that scenario, we should probably return a 500 from `mod-kb-ebsco` with a useful error message instead.