### PR TITLE
Upgrade jsonapi-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ gem 'dotenv-rails', groups: [:development, :test]
 
 gem 'rails', '~> 5.1.2'
 gem 'puma', '~> 3.7'
-gem 'jsonapi-rails'
+gem 'jsonapi-rails', :git => "https://github.com/jsonapi-rb/jsonapi-rails.git", :ref => "14a9421"
 gem 'flexirest'
-gem 'okapi', :git => 'git://github.com/thefrontside/okapi.rb/', :branch => "master"
+gem 'okapi', :git => 'https://github.com/thefrontside/okapi.rb/', :branch => "master"
 
 group :development, :test do
   gem 'pry-remote'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,14 @@
 GIT
-  remote: git://github.com/thefrontside/okapi.rb/
+  remote: https://github.com/jsonapi-rb/jsonapi-rails.git
+  revision: 14a9421658495fe916ec1886834b6adfd764b211
+  ref: 14a9421
+  specs:
+    jsonapi-rails (0.3.1)
+      jsonapi-parser (~> 0.1.0)
+      jsonapi-rb (~> 0.5.0)
+
+GIT
+  remote: https://github.com/thefrontside/okapi.rb/
   revision: 04e69b667f443ec859120e14dcf4639bca93bb2c
   branch: master
   specs:
@@ -80,9 +89,6 @@ GEM
       concurrent-ruby (~> 1.0)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
-    jsonapi-rails (0.3.1)
-      jsonapi-parser (~> 0.1.0)
-      jsonapi-rb (~> 0.5.0)
     jsonapi-rb (0.5.0)
       jsonapi-deserializable (~> 0.2.0)
       jsonapi-serializable (~> 0.3.0)
@@ -205,7 +211,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   flexirest
-  jsonapi-rails
+  jsonapi-rails!
   listen (>= 3.0.5, < 3.2)
   map (~> 6.0)
   okapi!


### PR DESCRIPTION
When PUTting a package or customer resource, we've been getting 
`#<NoMethodError: undefined method 'to_unsafe_hash' for nil:NilClass>`
coming from:
`jsonapi-rails (0.3.1) lib/jsonapi/rails/controller.rb:72:in 'block in deserializable_resource'`

That code in `jsonapi-rails` has been refactored since the last release. If this upgrade doesn't fix the error we're running into, it will at least provide a more useful error message.