### PR TITLE
Manually deserialize package and customer resource PUTs

### DIFF
--- a/app/controllers/customer_resources_controller.rb
+++ b/app/controllers/customer_resources_controller.rb
@@ -9,7 +9,6 @@ class CustomerResourcesController < ApplicationController
   end
 
   def update
-    params = DeserializableCustomerResource.new(params).to_h
     @customer_resource.update customer_resource_params
 
     render status: :no_content
@@ -32,7 +31,12 @@ class CustomerResourcesController < ApplicationController
   end
 
   def customer_resource_params
-    params
+    deserialized_params = ActionController::Parameters.new({
+      customer_resource: DeserializableCustomerResource.new(params[:data].to_unsafe_hash).to_h
+    })
+
+    deserialized_params
+      .require(:customer_resource)
       .permit(
         :isSelected,
         visibilityData: [ :isHidden ],

--- a/app/controllers/customer_resources_controller.rb
+++ b/app/controllers/customer_resources_controller.rb
@@ -3,15 +3,13 @@ class CustomerResourcesController < ApplicationController
 
   before_action :set_customer_resource
 
-  deserializable_resource :customer_resource, only: :update,
-                          class: DeserializableCustomerResource
-
   def show
     render jsonapi: @customer_resource,
            include: params[:include]
   end
 
   def update
+    params = DeserializableCustomerResource.new(params).to_h
     @customer_resource.update customer_resource_params
 
     render status: :no_content
@@ -35,7 +33,6 @@ class CustomerResourcesController < ApplicationController
 
   def customer_resource_params
     params
-      .require(:customer_resource)
       .permit(
         :isSelected,
         visibilityData: [ :isHidden ],

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -1,7 +1,4 @@
 class PackagesController < ApplicationController
-  deserializable_resource :package, only: :update,
-                          class: DeserializablePackage
-
   def index
     @packages = packages.all(q: params[:q])
     render jsonapi: @packages.packagesList.to_a,
@@ -15,6 +12,7 @@ class PackagesController < ApplicationController
 
   def update
     @package = packages.find package_id
+    params = DeserializablePackage.new(params).to_h
     @package.update package_params
 
     render status: :no_content
@@ -33,7 +31,6 @@ class PackagesController < ApplicationController
 
   def package_params
     params
-      .require(:package)
       .permit(
         :isSelected,
         visibilityData: [ :isHidden ],

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -12,7 +12,6 @@ class PackagesController < ApplicationController
 
   def update
     @package = packages.find package_id
-    params = DeserializablePackage.new(params).to_h
     @package.update package_params
 
     render status: :no_content
@@ -30,7 +29,12 @@ class PackagesController < ApplicationController
   end
 
   def package_params
-    params
+    deserialized_params = ActionController::Parameters.new({
+      package: DeserializablePackage.new(params[:data].to_unsafe_hash).to_h
+    })
+
+    deserialized_params
+      .require(:package)
       .permit(
         :isSelected,
         visibilityData: [ :isHidden ],

--- a/spec/requests/customer_resources_spec.rb
+++ b/spec/requests/customer_resources_spec.rb
@@ -176,11 +176,16 @@ RSpec.describe "Customer Resources", type: :request do
 
   describe "updating a customer resource" do
     let(:update_headers) do
-      okapi_headers.merge(
-        {
-          'Content-Type': 'application/vnd.api+json'
-        }
-      )
+      okapi_headers
+
+      # Okapi does not appear to pass through the content-type header
+      # These tests should now pass with or without this content-type header value
+      #
+      # okapi_headers.merge(
+      #   {
+      #     'Content-Type': 'application/vnd.api+json'
+      #   }
+      # )
     end
 
     describe "selecting a customer resource" do

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -102,11 +102,16 @@ RSpec.describe "Packages", type: :request do
 
   describe "updating a package" do
     let(:update_headers) do
-      okapi_headers.merge(
-        {
-          'Content-Type': 'application/vnd.api+json'
-        }
-      )
+      okapi_headers
+
+      # Okapi does not appear to pass through the content-type header
+      # These tests should now pass with or without this content-type header value
+      #
+      # okapi_headers.merge(
+      #   {
+      #     'Content-Type': 'application/vnd.api+json'
+      #   }
+      # )
     end
 
     describe "when the package is not already selected" do


### PR DESCRIPTION
## Purpose
PUT requests for packages and customer resources were failing on production, despite the exact same scenario passing with rspec tests.

## Hypothesis
Okapi must not be passing through the `application/vnd.api+json` `content-type` header to `mod-kb-ebsco` (I haven't validated that's the case, just a decent guess). The deserializer relies on the presence of that header to know that it needs to do its thing.

## Workaround
While that should probably be fixed in Okapi (if that's what's happening), we can get around it. We can manually deserialize the package and customer resource PUTs all the time, instead of only when the `application/vnd.api+json` `content-type` header is set. 

I see minimal downside to this approach, since these endpoints aren't expecting to get any requests that aren't JSON API.