### PR TITLE
Return composite package id for customer resource

### DIFF
--- a/app/serializable/serializable_customer_resource.rb
+++ b/app/serializable/serializable_customer_resource.rb
@@ -103,7 +103,7 @@ class SerializableCustomerResource < SerializableResource
     @object.resource.managedEmbargoPeriod
   end
   attribute :packageId do
-    @object.resource.packageId
+    "#{@object.resource.vendorId}-#{@object.resource.packageId}"
   end
   attribute :packageName do
     @object.resource.packageName

--- a/spec/requests/customer_resources_spec.rb
+++ b/spec/requests/customer_resources_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe "Customer Resources", type: :request do
                             )
     end
 
+    it "has a composite pacakge id of '{vendor_id}-{package_id}'" do
+      expect(attributes.packageId).to eq('22-1887786')
+    end
+
     it "has a human readable publication type" do
       expect(attributes.publicationType).to eq('Book')
     end


### PR DESCRIPTION
## Purpose
With `ui-eholdings` hitting the new JSON API endpoints, this package link was broken.
<img width="469" alt="screen shot 2017-12-11 at 8 14 51 am" src="https://user-images.githubusercontent.com/230597/33841151-c1ac4868-de4b-11e7-97eb-45077c24052d.png">

## Approach
Serialize a customer resource's `packageId` to be the composite format that includes vendor ID.
