### PR TITLE
Add ChunkedTransferDecoder middleware, but not as string

### DIFF
--- a/app/middleware/chunked_transfer_decoder.rb
+++ b/app/middleware/chunked_transfer_decoder.rb
@@ -12,7 +12,7 @@
 # If you are using Webrick or Unicorn/Rainbows/Zbatery, pass a `decoded_upstream`
 # option when adding this to the middleware chain like so:
 #
-#     config.middleware.insert_before 'Rack::Runtime', "ChunkedTransferDecoder", decoded_upstream: true
+#     config.middleware.insert_before Rack::Runtime, ChunkedTransferDecoder, decoded_upstream: true
 #
 # See: https://github.com/rails/rails/issues/15079
 #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,5 +45,5 @@ Rails.application.configure do
   end
 
   # Load middleware for dealing with Transfer-Encoding: chunked
-  config.middleware.insert_before 'Rack::Runtime', 'ChunkedTransferDecoder', decoded_upstream: true
+  config.middleware.insert_before Rack::Runtime, ChunkedTransferDecoder, decoded_upstream: true
 end


### PR DESCRIPTION
In Rails 5, the parameters for `config.middleware.insert_before` need to be classes, not strings.