### PR TITLE
Apply ChunkedTransferEncoding Middleware to Rails 'development' environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,4 +30,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Load middleware for dealing with Transfer-Encoding: chunked
+  config.middleware.insert_before Rack::Runtime, ChunkedTransferDecoder, decoded_upstream: true
 end


### PR DESCRIPTION
Jeffrey's original addition of the ChunkedTransferEncoding middleware does
successfully fix our issue with PUT requests to JSONAPI endpoints.  It was not
working before because apparently our Rails app is running in development mode
and the middelware had been configured for the production environment.  We
should configure Rails to run in production mode while on production, but for
now this will allow us to accept requests that respect strong parameters and
play nicely with the deserialization layer.