### PR TITLE
Use latest release of `jsonapi-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'dotenv-rails', groups: [:development, :test]
 
 gem 'rails', '~> 5.1.2'
 gem 'puma', '~> 3.7'
-gem 'jsonapi-rails', :git => "https://github.com/jsonapi-rb/jsonapi-rails.git", :ref => "14a9421"
+gem 'jsonapi-rails'
 gem 'flexirest'
 gem 'okapi', :git => 'https://github.com/thefrontside/okapi.rb/', :branch => "master"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/jsonapi-rb/jsonapi-rails.git
-  revision: 14a9421658495fe916ec1886834b6adfd764b211
-  ref: 14a9421
-  specs:
-    jsonapi-rails (0.3.1)
-      jsonapi-parser (~> 0.1.0)
-      jsonapi-rb (~> 0.5.0)
-
-GIT
   remote: https://github.com/thefrontside/okapi.rb/
   revision: 04e69b667f443ec859120e14dcf4639bca93bb2c
   branch: master
@@ -89,6 +80,9 @@ GEM
       concurrent-ruby (~> 1.0)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
+    jsonapi-rails (0.3.1)
+      jsonapi-parser (~> 0.1.0)
+      jsonapi-rb (~> 0.5.0)
     jsonapi-rb (0.5.0)
       jsonapi-deserializable (~> 0.2.0)
       jsonapi-serializable (~> 0.3.0)
@@ -211,7 +205,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   flexirest
-  jsonapi-rails!
+  jsonapi-rails
   listen (>= 3.0.5, < 3.2)
   map (~> 6.0)
   okapi!


### PR DESCRIPTION
In order to fix what we thought as an error in the `jsonapi-rails` gem we had pointed our Gemfile to a specific commit sha on that repo.  As it turns out the bug was coming from elsewhere, so we are safe to use the latest stable release of the gem instead (0.3.1)

Closes #36 