### PR TITLE
Return failure code when trying to customize a deselected package

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -1,3 +1,4 @@
+
 class PackagesController < ApplicationController
 
   before_action :set_package, only: [:show, :update, :customer_resources]
@@ -15,8 +16,15 @@ class PackagesController < ApplicationController
   end
 
   def update
-    @package.update package_params
-    render jsonapi: @package
+    package_validation = Validation::PackageParameters.new(package_params)
+
+    if package_validation.valid?
+      @package.update package_params
+      render jsonapi: @package
+    else
+      render jsonapi_errors: package_validation.errors,
+             status: :unprocessable_entity
+    end
   end
 
   # Relationships

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -1,0 +1,24 @@
+module Validation
+  class PackageParameters
+    include ActiveModel::Validations
+
+    attr_accessor :isSelected, :isHidden, :beginCoverage, :endCoverage
+
+    # Deselected resources cannot be customized.  Though the UI is smart enough
+    # to keep this from happening, a manual request to the API could lead
+    # to confusing behavior unless we signal a failure code here.
+    # TODO: clearer messaging might be nice here
+    with_options unless: :isSelected do |package|
+      package.validates :isHidden, absence: true, unless: :isSelected
+      package.validates :beginCoverage, absence: true, unless: :isSelected
+      package.validates :endCoverage, absence: true, unless: :isSelected
+    end
+
+    def initialize(params={})
+      @isSelected = params[:isSelected]
+      @isHidden = params.dig(:visibilityData, :isHidden)
+      @beginCoverage = params.dig(:customCoverage, :beginCoverage)
+      @endCoverage = params.dig(:customCoverage, :endCoverage)
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:40:35 GMT
+      - Tue, 19 Dec 2017 21:01:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43641us'
+        : 200 42596us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.1.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.1.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 935380/configurations
+      - 304740/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:40:35 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:55 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:40:35 GMT
+      - Tue, 19 Dec 2017 21:01:55 GMT
       X-Amzn-Requestid:
-      - d9eb7f29-df95-11e7-ba3e-65def3b87172
+      - d824e7bc-e4ff-11e7-b8b3-b75bb8656d45
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -157,142 +157,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:40:35 GMT
+      - Tue, 19 Dec 2017 21:01:54 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0576b942ae9f4fc9c0b62b0736e9bfd6.cloudfront.net (CloudFront)
+      - 1.1 11246b86a4ea89501512bda5b8fea01b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - HGY7RQiNT15iiCbAXQpk5K6FWKNFiB0JaI-ekVfZUx3BccDqToJPrA==
+      - ZazI-649vHxTNDVFWZ2T7Ns1TrOEFURPMAGe2vq9RyG39bRsjXhX5g==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:40:35 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":false,"isHidden":false,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:40:36 GMT
-      X-Amzn-Requestid:
-      - da24b81d-df95-11e7-9bc9-d3fc5c70f222
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:40:35 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 95da1452a75435200220a7075ca3893f.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - 8TRVI62q51TVczORZtxhRkq9fZRSxPIE1QsObQo8S5TN7hk8VijVYw==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:40:36 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '342'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:40:36 GMT
-      X-Amzn-Requestid:
-      - da551685-df95-11e7-98f8-ff0ed34a0217
-      X-Amzn-Remapped-Content-Length:
-      - '342'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:40:35 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 2a47832c458ab2a6b20c8363f5aa35ea.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - Sdrx8ZAL17IJWHYJI9CLjFT_9kAWgwBnwe9dHFjuS2NsBjlssx65Dw==
-    body:
-      encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:40:36 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:39:41 GMT
+      - Tue, 19 Dec 2017 21:01:56 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43173us'
+        : 200 42269us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.1.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.1.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 278396/configurations
+      - 409623/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:39:41 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:56 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
+      - Tue, 19 Dec 2017 21:01:56 GMT
       X-Amzn-Requestid:
-      - b9e4f392-df95-11e7-af92-294ba0e0a236
+      - d8b233ea-e4ff-11e7-b060-b7e9aa17f9dc
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -157,143 +157,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
+      - Tue, 19 Dec 2017 21:01:56 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0576b942ae9f4fc9c0b62b0736e9bfd6.cloudfront.net (CloudFront)
+      - 1.1 81deb3cac40f83b66a4f52f702656987.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - RgcC6d4fJfgrnlKJP5LA-AQ90phGoe9fhSV1MbuiOjJ4tUvD2SdLKQ==
+      - Lj59r-PlBC7GBMA72DjQTMTG26NWNZpkR2S6UI2yXhwJyGxfk-C5yg==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:39:42 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
-      X-Amzn-Requestid:
-      - ba1f164e-df95-11e7-b1f5-151e6367a11c
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 68e4011ca1c00bec92bb202e1ddce131.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - Ymrnu1qDxyVk5iWwt-br5pb-Xh1wlczzid5kV-QPnY4a1sZDXDtRYw==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:39:42 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '376'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
-      X-Amzn-Requestid:
-      - ba6d845b-df95-11e7-a7a8-6bdb4712b53b
-      X-Amzn-Remapped-Content-Length:
-      - '376'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:39:42 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 81871f1c889cc44b6c25e3ef722a3801.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - d362tIQNiIy9Cbed6sYwTsnAsmhUuOYdMRM-MDSg1KyvjwI0L1nJ6Q==
-    body:
-      encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:39:43 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:41:16 GMT
+      - Tue, 19 Dec 2017 21:01:54 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 44846us'
+        : 200 52019us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 266337/configurations
+      - '091698/configurations'
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:16 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:54 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
+      - Tue, 19 Dec 2017 21:01:54 GMT
       X-Amzn-Requestid:
-      - f29dfa1b-df95-11e7-af92-294ba0e0a236
+      - d7b02c66-e4ff-11e7-bb63-a7c5804883c9
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -157,142 +157,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
+      - Tue, 19 Dec 2017 21:01:54 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 88972e3933cc06dd11a6fa704a208631.cloudfront.net (CloudFront)
+      - 1.1 2d2e1e199c18b4b9392796150bff22d6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - u_7bi_STW5DnA6ccNd4_eClHSzkkL-BqXIvZ9r38C5GIaDXKN5KJPg==
+      - llpDACvwNWeTwB5csrnGcGsGFq_zqZeL3i4_v0Ns87g2xTMYs3Ziow==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:17 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":false,"isHidden":true,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
-      X-Amzn-Requestid:
-      - f2c29998-df95-11e7-9423-2d34bfdb92e4
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 6e65abb04cb818a6ec78111935b507f7.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - QnTmOkWjyPMJgPk0rp-lyPY8OK8amGP0inMVDqzpWvR-bpTjGFQW8g==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:17 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '342'
-      Connection:
-      - keep-alive
-      Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
-      X-Amzn-Requestid:
-      - f2ee1681-df95-11e7-bac5-31cdbe7b3c8a
-      X-Amzn-Remapped-Content-Length:
-      - '342'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:17 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 6e65abb04cb818a6ec78111935b507f7.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - rorEQOIQPta3KRyvEOy0jMB36p8h3GFxWFxRh-cRMbkkf_AbAj9A_w==
-    body:
-      encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
-    http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:17 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:41:52 GMT
+      - Tue, 19 Dec 2017 21:01:56 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42554us'
+        : 200 41103us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 369951/configurations
+      - 316575/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:52 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:56 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:41:52 GMT
+      - Tue, 19 Dec 2017 21:01:57 GMT
       X-Amzn-Requestid:
-      - 07ca0d99-df96-11e7-961a-77e6ca1e4bd1
+      - d92ba906-e4ff-11e7-b6a3-f739aefbfbba
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -157,20 +157,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:52 GMT
+      - Tue, 19 Dec 2017 21:01:56 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 3344ddc09ccf1d185bb41add18940cc4.cloudfront.net (CloudFront)
+      - 1.1 31a5ac398732eefcbcca024a00640590.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 61PVlzoc4VrHpzcZqJd4UPoVtG3i-eB-VZfz5QhdCm-_aODuM4PYGg==
+      - 02xb4s3fFedMZNNj2nVqDymMlxyMmTr9HScvwYreiNpRud0XKyaWqg==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:52 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:57 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:41:53 GMT
+      - Tue, 19 Dec 2017 21:01:57 GMT
       X-Amzn-Requestid:
-      - '0801bf4e-df96-11e7-bd8f-27fd49e0c3a8'
+      - d95af663-e4ff-11e7-b8cd-0ff17373b65b
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,20 +218,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:52 GMT
+      - Tue, 19 Dec 2017 21:01:57 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a7b695b8ae560fe9087da065a2b7812.cloudfront.net (CloudFront)
+      - 1.1 0c9b2c7f2bb4de1a6bfc1944dd0b4e44.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - tr7wuG4rKv58LOnY_TqkP_bOotWxwkBxMR9QhYAx04R4rPzZdwjOoQ==
+      - 9S5oxlJTNU7BbMZm9GBgup8cm20NE54oxoALILKhOExcQySlzIjnnA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:53 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:57 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -263,9 +263,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:41:53 GMT
+      - Tue, 19 Dec 2017 21:01:57 GMT
       X-Amzn-Requestid:
-      - '084901c6-df96-11e7-af38-af220cd81bb4'
+      - d994cb18-e4ff-11e7-acb0-09c01abe28c2
       X-Amzn-Remapped-Content-Length:
       - '343'
       X-Amzn-Remapped-Connection:
@@ -281,18 +281,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:41:52 GMT
+      - Tue, 19 Dec 2017 21:01:57 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 30bb04916f91d64c600e15c15000042d.cloudfront.net (CloudFront)
+      - 1.1 06e94244570e30a89339ef5ac0f77650.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KcMsn9gplE2sXk4q3xz7s2H4kFkmMMNrSVtcO-r9eFA8SKcfvB0qmg==
+      - RqphpPl_ZFEOdgAPZAr9H4MrRxRydQI4IM6lr1btzLl3zhwnCxx8dg==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:41:53 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:36:53 GMT
+      - Tue, 19 Dec 2017 21:01:59 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42386us'
+        : 200 48545us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 274166/configurations
+      - 137779/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:36:53 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:59 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '343'
+      - '360'
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:36:53 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Amzn-Requestid:
-      - 55b5ac0f-df95-11e7-8f82-f1e975e71173
+      - daebf66f-e4ff-11e7-8c45-896e41ed6457
       X-Amzn-Remapped-Content-Length:
-      - '343'
+      - '360'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,20 +157,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:36:53 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 68e4011ca1c00bec92bb202e1ddce131.cloudfront.net (CloudFront)
+      - 1.1 48caa39e1bf7b421aefe9f98b0ab696b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - WAwr_m1C5ugouwFT-l2k3k1oKFT18BBGTNeXmTWn2kwc_y0yYYn2sw==
+      - QWIqWXXBKdZn62IlTdEXeLKa55bspBRIwHuyQPMwRPqCk5m2LGI1iA==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:36:54 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:00 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -202,9 +203,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:36:54 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Amzn-Requestid:
-      - 55dce3d4-df95-11e7-8876-2170bf5e15f6
+      - db11f5b4-e4ff-11e7-a04b-513ca863a269
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,20 +219,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:36:53 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 88972e3933cc06dd11a6fa704a208631.cloudfront.net (CloudFront)
+      - 1.1 5166c1d4111b6a4df05e4a75b6118136.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - Rk7E-bXUsk0RX5jk7viNXXxQUshvkqVTNX2g-kOYk31hCXAx9q9PKw==
+      - vAOSw9sTpPwTAKnNuGjpVrcrRDk8uAIk6eeHS3aAjz2ee2IMpWW9IQ==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:36:54 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:00 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -263,9 +264,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:36:54 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Amzn-Requestid:
-      - 56378627-df95-11e7-8568-055d9533afee
+      - db39a1ef-e4ff-11e7-8314-07678a9a7222
       X-Amzn-Remapped-Content-Length:
       - '359'
       X-Amzn-Remapped-Connection:
@@ -281,18 +282,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:36:53 GMT
+      - Tue, 19 Dec 2017 21:02:00 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 6e65abb04cb818a6ec78111935b507f7.cloudfront.net (CloudFront)
+      - 1.1 0ae25fed904e0259c5db061e4b999b59.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - sEjHttgw9Ok3GPNNx0GNR-2EjFuYxx44ugroIBaX8euDUSmS44uO-Q==
+      - 9VU2pwTBjw8qg3mh8IR4cWbw9Rng1-39lk6HEzTNt3PeOgxZKafZgw==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:36:55 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:26:28 GMT
+      - Tue, 19 Dec 2017 21:02:01 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43065us'
+        : 200 47359us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 707925/configurations
+      - 774345/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:26:28 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:01 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '343'
+      - '359'
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:01 GMT
       X-Amzn-Requestid:
-      - e1417769-df93-11e7-bcfa-69de97512a1b
+      - dbdfccef-e4ff-11e7-b97e-5125b0014901
       X-Amzn-Remapped-Content-Length:
-      - '343'
+      - '359'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,26 +157,26 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:01 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 30bb04916f91d64c600e15c15000042d.cloudfront.net (CloudFront)
+      - 1.1 da94bfa4529bf05a5b62b3f058727c6c.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - ricYKMjaT4EbBcAJb-VVr-n4UHrGt39Xdbav_pOk58c968Jo8XV-fA==
+      - "-ES_vCYqhpAaAcGh5gZFZsWw62XkLn9wRBF6sO1HGvU60xOTMPjQcw=="
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:26:29 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:01 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":false,"visibilityData":{"isHidden":true,"reason":""},"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
+      string: '{"isSelected":true,"isHidden":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:02 GMT
       X-Amzn-Requestid:
-      - e17643c5-df93-11e7-90b3-13fd177f9a86
+      - dc12eb24-e4ff-11e7-b463-ad72e51f0585
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,20 +218,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:01 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ca024aca72de992a25bcd7fdcfe84b67.cloudfront.net (CloudFront)
+      - 1.1 29f7f51088f787614ba16c3961f39f43.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - umoFNFp9gnXMkbLqZPq24aJ7eJkiAZ_R3mk02kqc43KbbU6Kd_h4ow==
+      - tN-pUtGFBh6CmJZ9Yb5LEvqUZF_TGbyN6WUXtAE4iUCIyeRRM8Iw3w==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:26:29 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:02 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -259,15 +259,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '342'
+      - '376'
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:02 GMT
       X-Amzn-Requestid:
-      - e1aa24f6-df93-11e7-ba0c-6fb1f435ec05
+      - dc6b1ca0-e4ff-11e7-99c4-d7aec10e88d4
       X-Amzn-Remapped-Content-Length:
-      - '342'
+      - '376'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -281,18 +281,19 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:26:29 GMT
+      - Tue, 19 Dec 2017 21:02:01 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 3344ddc09ccf1d185bb41add18940cc4.cloudfront.net (CloudFront)
+      - 1.1 06df2f0e5cefb5e7b8be41ff25b6fd8a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - zJlWYeDccJ0MzxBaelRH02cKl1wIYaDyqyLvHT2Ox9d0zDJTSK9U-w==
+      - RTc22bFAzLO4VjtZRFpU-WFNLPA4c8sLo5z-5C11ezmmlxzn6vY8sw==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:26:29 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:34:29 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43684us'
+        : 200 41219us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 074556/configurations
+      - 150118/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:34:29 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:58 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       X-Amzn-Requestid:
-      - '00009abc-df95-11e7-9fbe-8fd2718be5c4'
+      - da26d1d1-e4ff-11e7-ab28-43e0f23668ae
       X-Amzn-Remapped-Content-Length:
       - '343'
       X-Amzn-Remapped-Connection:
@@ -157,20 +157,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 88972e3933cc06dd11a6fa704a208631.cloudfront.net (CloudFront)
+      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fInNWQ2mdwlo6xZhN2R3syhjvCdX0tehn13QXNaX0tXhtECcOqsSZw==
+      - CMeXuJR4a4XvEZ4w0V8w-yV3YnRnWZow17sJYdIWysTh7z_FMuytMQ==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:34:30 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:58 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -202,9 +202,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       X-Amzn-Requestid:
-      - 002ba206-df95-11e7-a879-5ff918b2df2c
+      - da3e0412-e4ff-11e7-8f0e-a749bd5455c2
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,20 +218,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b04a4cffa8fb4f524ff7edcab1b5ae31.cloudfront.net (CloudFront)
+      - 1.1 85902ff1f49a5dc3b52b14024a37cf19.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - RUllsSVKDIB1I5hcU_TXZkiJS_EeQ3g3jalw0SAb93xM7sX1evMIhg==
+      - 1AtyDiukUy-s9j5Fy-qWUGVT-5af2oibEd7Xn0vcMSH9oKpBMqeL8g==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:34:30 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:58 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -263,9 +263,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:59 GMT
       X-Amzn-Requestid:
-      - '005597f5-df95-11e7-a04a-69280867ba8d'
+      - da6980d0-e4ff-11e7-a4a2-fd6c0a88b289
       X-Amzn-Remapped-Content-Length:
       - '360'
       X-Amzn-Remapped-Connection:
@@ -281,19 +281,19 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:34:30 GMT
+      - Tue, 19 Dec 2017 21:01:58 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 81871f1c889cc44b6c25e3ef722a3801.cloudfront.net (CloudFront)
+      - 1.1 fef40efe4cedffcb21c89f4d6ab3a6a6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - iE_S5M4z7aiIubXQo03TXUrRQw6vUTWVYZAbEo1OJ6zlK0o1wkVFPg==
+      - Cv478ac9qfvtjz0cp0VFaz_u18RwRftNzrLoZaVkf1SJ3a2r8JLl6Q==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:34:30 GMT
+  recorded_at: Tue, 19 Dec 2017 21:01:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:35:57 GMT
+      - Tue, 19 Dec 2017 21:02:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42921us'
+        : 200 42176us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 782967/configurations
+      - 237898/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:35:57 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:03 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,15 +135,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '342'
+      - '376'
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:35:57 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Amzn-Requestid:
-      - 341b12c4-df95-11e7-84ec-b92bdbf37644
+      - dd733e0a-e4ff-11e7-8c45-896e41ed6457
       X-Amzn-Remapped-Content-Length:
-      - '342'
+      - '376'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -157,20 +157,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:35:57 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f0ef92e52918ab5129ebd66f2f633cbb.cloudfront.net (CloudFront)
+      - 1.1 8cf3b0c0dbbd56e2b65caa29e0eea872.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 785SDCbLEEP2LdNRTKhoBwnFxUlh3A9ygO1Cx5NwnE-h4pxEovqxhg==
+      - 9pxMDkJyPdKXw4YwVHDM5phXOtQfvDxnzlOjqIIFDr-Re3xWpvHFXg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:35:57 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:04 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -202,9 +203,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:35:58 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Amzn-Requestid:
-      - 34801616-df95-11e7-a883-49c5df43f095
+      - dd8d7c8c-e4ff-11e7-ac0a-ff1a2483b28b
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -218,20 +219,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:35:57 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 95da1452a75435200220a7075ca3893f.cloudfront.net (CloudFront)
+      - 1.1 1e0f6d91fb358639e6808cb6d2638da0.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - L3SGNKENpZLL-khwvg-8TEnLId52HUvvxfEMz019OfdKuo9ZuW1p-g==
+      - gJ0ChT6YvSXIa50VzPW_Deb_p3Fvv1Tmi7NBmjpZZmVbUX1v8ZGARw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:35:58 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:04 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -263,9 +264,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:35:58 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Amzn-Requestid:
-      - 34b2976c-df95-11e7-9198-79f3cc6a707b
+      - dda9de07-e4ff-11e7-824a-d9ef95c3ddb3
       X-Amzn-Remapped-Content-Length:
       - '342'
       X-Amzn-Remapped-Connection:
@@ -281,18 +282,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:35:58 GMT
+      - Tue, 19 Dec 2017 21:02:04 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 6eaa7f856e226a0db7cef6201d3b8393.cloudfront.net (CloudFront)
+      - 1.1 06df2f0e5cefb5e7b8be41ff25b6fd8a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - gAg1LYJ0qy5MnfUyxiE8OCFdSi2q0Rdy1v0rKW3-w_deaXZ8S_2NqQ==
+      - hgAr3TNECZ4Bh_UW59Vjag4bWtn37ZUOPF6TBiQY3lmtzCTn_rG8Pw==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:35:58 GMT
+  recorded_at: Tue, 19 Dec 2017 21:02:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1,3 +1,4 @@
+
 require 'rails_helper'
 
 RSpec.describe "Packages", type: :request do
@@ -145,6 +146,102 @@ RSpec.describe "Packages", type: :request do
     end
 
     describe "when the package is not already selected" do
+      describe "hiding a package should fail" do
+        let(:params) do
+          {
+            "data": {
+              "type": "packages",
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": nil,
+                  "endCoverage": nil
+                },
+                "isSelected": false,
+                "visibilityData": {
+                  "isHidden": true,
+                  "reason": ""
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-packages-isnotselected-toggle-ishidden") do
+            put '/eholdings/jsonapi/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with unprocessable entity status" do
+          expect(response).to have_http_status(422)
+        end
+      end
+
+      describe "adding custom coverage should fail" do
+        let(:params) do
+          {
+            "data": {
+              "type": "packages",
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": "2003-01-01",
+                  "endCoverage": "2004-01-01"
+                },
+                "isSelected": false,
+                "visibilityData": {
+                  "isHidden": false,
+                  "reason": ""
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-packages-isnotselected-add-customcoverage") do
+            put '/eholdings/jsonapi/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with unprocessable entity status" do
+          expect(response).to have_http_status(422)
+        end
+      end
+
+      describe "combined update" do
+        let(:params) do
+          {
+            "data": {
+              "type": "packages",
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": "2003-01-01",
+                  "endCoverage": "2004-01-01"
+                },
+                "isSelected": false,
+                "visibilityData": {
+                  "isHidden": true,
+                  "reason": ""
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-packages-isnotselected-combined-update") do
+            put '/eholdings/jsonapi/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with unprocessable entity status" do
+          expect(response).to have_http_status(422)
+        end
+      end
+
       describe "selecting a package" do
         let(:params) do
           {
@@ -181,190 +278,11 @@ RSpec.describe "Packages", type: :request do
         it "is now selected" do
           expect(json.data.attributes.isSelected).to be true
         end
-
-        it "is not hidden" do
-          expect(json.data.attributes.visibilityData.isHidden).to be false
-        end
-      end
-
-      describe "hiding a package should fail" do
-        let(:params) do
-          {
-            "data": {
-              "type": "packages",
-              "attributes": {
-                "customCoverage": {
-                  "beginCoverage": nil,
-                  "endCoverage": nil
-                },
-                "isSelected": false,
-                "visibilityData": {
-                  "isHidden": true,
-                  "reason": ""
-                }
-              }
-            }
-          }
-        end
-
-        before do
-          VCR.use_cassette("put-packages-isnotselected-toggle-ishidden") do
-            put '/eholdings/jsonapi/packages/19-6581',
-                params: params, as: :json, headers: update_headers
-          end
-        end
-
-        it "responds with OK status" do
-          # TODO: should return 4xx or 5xx instead
-          expect(response).to have_http_status(200)
-        end
-
-        let!(:json) { Map JSON.parse response.body }
-
-        it "is not selected" do
-          expect(json.data.attributes.isSelected).to be false
-        end
-
-        it "is still not hidden" do
-          expect(json.data.attributes.visibilityData.isHidden).to be false
-        end
-      end
-
-      describe "adding custom coverage should fail" do
-        let(:params) do
-          {
-            "data": {
-              "type": "packages",
-              "attributes": {
-                "customCoverage": {
-                  "beginCoverage": "2003-01-01",
-                  "endCoverage": "2004-01-01"
-                },
-                "isSelected": false,
-                "visibilityData": {
-                  "isHidden": false,
-                  "reason": ""
-                }
-              }
-            }
-          }
-        end
-
-        before do
-          VCR.use_cassette("put-packages-isnotselected-add-customcoverage") do
-            put '/eholdings/jsonapi/packages/19-6581',
-                params: params, as: :json, headers: update_headers
-          end
-        end
-
-        it "responds with OK status" do
-          # TODO: should return 4xx or 5xx instead
-          expect(response).to have_http_status(200)
-        end
-
-        let!(:json) { Map JSON.parse response.body }
-
-        it "is not selected" do
-          expect(json.data.attributes.isSelected).to be false
-        end
-
-        it "is still without custom coverage" do
-          expect(json.data.attributes.customCoverage.beginCoverage).to be nil
-          expect(json.data.attributes.customCoverage.endCoverage).to be nil
-        end
-      end
-
-      describe "combined update" do
-        let(:params) do
-          {
-            "data": {
-              "type": "packages",
-              "attributes": {
-                "customCoverage": {
-                  "beginCoverage": "2003-01-01",
-                  "endCoverage": "2004-01-01"
-                },
-                "isSelected": true,
-                "visibilityData": {
-                  "isHidden": true,
-                  "reason": ""
-                }
-              }
-            }
-          }
-        end
-
-        before do
-          VCR.use_cassette("put-packages-isnotselected-combined-update") do
-            put '/eholdings/jsonapi/packages/19-6581',
-                params: params, as: :json, headers: update_headers
-          end
-        end
-
-        it "responds with OK status" do
-          expect(response).to have_http_status(200)
-        end
-
-        let!(:json) { Map JSON.parse response.body }
-
-        it "is now selected" do
-          expect(json.data.attributes.isSelected).to be true
-        end
-
-        it "is now hidden" do
-          expect(json.data.attributes.visibilityData.isHidden).to be true
-        end
-
-        it "is populated with custom coverage" do
-          expect(json.data.attributes.customCoverage.beginCoverage).to eq("2003-01-01")
-          expect(json.data.attributes.customCoverage.endCoverage).to eq("2004-01-01")
-        end
       end
     end
 
+
     describe "when the package is already selected" do
-      describe "deselecting a package" do
-        let(:params) do
-          {
-            "data": {
-              "type": "packages",
-              "attributes": {
-                "customCoverage": {
-                  "beginCoverage": nil,
-                  "endCoverage": nil
-                },
-                "isSelected": false,
-                "visibilityData": {
-                  "isHidden": false,
-                  "reason": ""
-                }
-              }
-            }
-          }
-        end
-
-        before do
-          VCR.use_cassette("put-packages-isselected-toggle-isselected") do
-            put '/eholdings/jsonapi/packages/19-6581',
-                params: params, as: :json, headers: update_headers
-          end
-        end
-
-        it "responds with OK status" do
-          expect(response).to have_http_status(200)
-        end
-
-        let!(:json) { Map JSON.parse response.body }
-
-        it "is not selected" do
-          expect(json.data.attributes.isSelected).to be false
-        end
-
-        it "is not hidden" do
-          expect(json.data.attributes.visibilityData.isHidden).to be false
-        end
-      end
-
       describe "hiding a package" do
         let(:params) do
           {
@@ -461,7 +379,7 @@ RSpec.describe "Packages", type: :request do
                   "beginCoverage": "2003-01-01",
                   "endCoverage": "2004-01-01"
                 },
-                "isSelected": false,
+                "isSelected": true,
                 "visibilityData": {
                   "isHidden": true,
                   "reason": ""
@@ -484,17 +402,59 @@ RSpec.describe "Packages", type: :request do
 
         let!(:json) { Map JSON.parse response.body }
 
-        it "is now unselected" do
+        it "is selected" do
+          expect(json.data.attributes.isSelected).to be true
+        end
+
+        it "is not hidden" do
+          expect(json.data.attributes.visibilityData.isHidden).to be true
+        end
+
+        it "is populated with custom coverage" do
+          expect(json.data.attributes.customCoverage.beginCoverage).to eq "2003-01-01"
+          expect(json.data.attributes.customCoverage.endCoverage).to eq "2004-01-01"
+        end
+      end
+
+      describe "deselecting a package" do
+        let(:params) do
+          {
+            "data": {
+              "type": "packages",
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": nil,
+                  "endCoverage": nil
+                },
+                "isSelected": false,
+                "visibilityData": {
+                  "isHidden": false,
+                  "reason": ""
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-packages-isselected-toggle-isselected") do
+            put '/eholdings/jsonapi/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "is not selected" do
           expect(json.data.attributes.isSelected).to be false
         end
 
         it "is not hidden" do
           expect(json.data.attributes.visibilityData.isHidden).to be false
-        end
-
-        it "is not populated with custom coverage" do
-          expect(json.data.attributes.customCoverage.beginCoverage).to be nil
-          expect(json.data.attributes.customCoverage.endCoverage).to be nil
         end
       end
     end


### PR DESCRIPTION
This addresses the `TODO`s in the packages spec.  While our UI will not attempt to customize deselected resources, a manual API request to our service could result in a confusing state: a success code with a response body not matching the desired updates.  This rejects any attempted customization to deselected packages with a 422 (Unprocessable Entity) status code, and a response body with the relevant error(s).