### PR TITLE
Return failure code when customizing a deselected customer resource

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -3,7 +3,8 @@ class PackagesController < ApplicationController
 
   before_action :set_package, only: [:show, :update, :customer_resources]
 
-  deserializable_resource :package, only: :update
+  deserializable_resource :package, only: :update,
+                          class: DeserializablePackage
 
   def index
     @packages = packages.all(q: params[:q], page: params[:page])

--- a/app/controllers/validation/customer_resource_parameters.rb
+++ b/app/controllers/validation/customer_resource_parameters.rb
@@ -1,0 +1,26 @@
+module Validation
+  class CustomerResourceParameters
+    include ActiveModel::Validations
+
+    attr_accessor :isSelected, :isHidden, :customCoverageList, :embargoUnit, :embargoValue
+
+    # Deselected resources cannot be customized.  Though the UI is smart enough
+    # to keep this from happening, a manual request to the API could lead
+    # to confusing behavior unless we signal a failure code here.
+    # TODO: clearer messaging might be nice here
+    with_options unless: :isSelected do |customer_resource|
+      customer_resource.validates :isHidden, absence: true, unless: :isSelected
+      customer_resource.validates :customCoverageList, absence: true, unless: :isSelected
+      customer_resource.validates :embargoUnit, absence: true, unless: :isSelected
+      customer_resource.validates :embargoValue, absence: true, unless: :isSelected
+    end
+
+    def initialize(params={})
+      @isSelected = params[:isSelected]
+      @isHidden = params.dig(:visibilityData, :isHidden)
+      @customCoverageList = params[:customCoverageList]
+      @embargoUnit = params.dig(:customEmbargoPeriod, :embargoUnit)
+      @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
+    end
+  end
+end

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -4,7 +4,7 @@ module Validation
 
     attr_accessor :isSelected, :isHidden, :beginCoverage, :endCoverage
 
-    # Deselected resources cannot be customized.  Though the UI is smart enough
+    # Deselected packages cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
     # to confusing behavior unless we signal a failure code here.
     # TODO: clearer messaging might be nice here

--- a/spec/fixtures/vcr_cassettes/put-customer-resource-ishidden-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resource-ishidden-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:51:44 GMT
+      - Wed, 20 Dec 2017 20:03:47 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43512us'
+        : 200 41757us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 163436/configurations
+      - 169071/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:44 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:47 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:44 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Amzn-Requestid:
-      - 689bdbcf-df97-11e7-9d3e-3957dbf9f8de
+      - e3f5fd3e-e5c0-11e7-8f42-a3e368ef60ef
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -157,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:44 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 3d3d633d266d05d90a4eea7a6a59b514.cloudfront.net (CloudFront)
+      - 1.1 5ae8b0e76af80aa471660f48d35acb41.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - EDqDp7Zat6FctXXtB5llsDb9AuacTLzVd8i6_JhWPLoTqDneIAXc_A==
+      - IqAVkxXXrQe7RgPO9-H7QpGZUiDUmzPo-h5UZDXe6l1L96qIjhDl_A==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -175,7 +175,7 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:44 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -207,9 +207,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:45 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Amzn-Requestid:
-      - 68c5365a-df97-11e7-bf56-eb0765fc151b
+      - e426f873-e5c0-11e7-b47e-19463f23d40e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -223,20 +223,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:44 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ff09df097f823b2834408d17e9779d62.cloudfront.net (CloudFront)
+      - 1.1 5ae8b0e76af80aa471660f48d35acb41.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - Y2BHpQyAI6wipPB-8ElziO4_O80f2kpUubH1LC7rc5c7AoUe4K63PQ==
+      - GBN_5MZEbp6zmQ6XNEn4OyDdQn7vyuZuK8kkG-VLvaSNeopTUv1Wdw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:45 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -268,9 +268,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:45 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Amzn-Requestid:
-      - 6919bf05-df97-11e7-848d-af2f26db0e50
+      - e43ffeb0-e5c0-11e7-9c84-3be4208b146c
       X-Amzn-Remapped-Content-Length:
       - '1596'
       X-Amzn-Remapped-Connection:
@@ -286,15 +286,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:44 GMT
+      - Wed, 20 Dec 2017 20:03:48 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b04a4cffa8fb4f524ff7edcab1b5ae31.cloudfront.net (CloudFront)
+      - 1.1 9443b13f9c1702357fc79e34ddbc761c.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KT1x3GVW0kQbJRkasldeo_90zzKoh8EdtYhZ0PTNAjgYIok1nqh_Rw==
+      - rN4LzrpanwV452btRF9sc9Zh79lQKXkMM8f7gDMsAccGi7IWwZ7RDw==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -305,5 +305,5 @@ http_interactions:
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:45 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resource-isnotselected-customcoverages.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resource-isnotselected-customcoverages.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
+      - Wed, 20 Dec 2017 20:03:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 294140us'
+        : 200 44370us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 252193/configurations
+      - 889707/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,137 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1546'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Amzn-Requestid:
-      - f2178b0e-e5c0-11e7-b39c-050f524bcfe2
-      X-Amzn-Remapped-Content-Length:
-      - '1546'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - f9DkoftWQyiyjohowj7syh-MtfsTWItBqQLJ86ot0VqtqizJKk_usg==
-    body:
-      encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
-        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":7},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2005-01-01"},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
-      X-Amzn-Requestid:
-      - f2642499-e5c0-11e7-a84e-05c5f67ac08b
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - AvHCDdHgwhtOGRR_dtR_SoeseBLS1fpZ_FF5YVGZVgjbpXBu9Zwcmg==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:43 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -269,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:43 GMT
       X-Amzn-Requestid:
-      - f2d6e33d-e5c0-11e7-8410-9f67d5d9460a
+      - e1791639-e5c0-11e7-8583-452a6dba6cbf
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -287,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:43 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a9f4aeaf8e0968a45a9154a0c9198bf.cloudfront.net (CloudFront)
+      - 1.1 6eadd6c6c5a53c34c6fce458c34cd790.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 6Rl1OjQTPaKjcB1j1l9YvkLMbeaICzlOeTAGUd7fqKVs42b5xMIpTw==
+      - MkM_Ai1cbhTy6SBfCkjVigBNYTHAkcRG14evSJYFYJWfuTWJD_ahvg==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -305,5 +175,5 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:43 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resource-isnotselected-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resource-isnotselected-ishidden.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
+      - Wed, 20 Dec 2017 20:03:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 294140us'
+        : 200 42080us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 252193/configurations
+      - 288505/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,137 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1546'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Amzn-Requestid:
-      - f2178b0e-e5c0-11e7-b39c-050f524bcfe2
-      X-Amzn-Remapped-Content-Length:
-      - '1546'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - f9DkoftWQyiyjohowj7syh-MtfsTWItBqQLJ86ot0VqtqizJKk_usg==
-    body:
-      encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
-        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":7},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2005-01-01"},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
-      X-Amzn-Requestid:
-      - f2642499-e5c0-11e7-a84e-05c5f67ac08b
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - AvHCDdHgwhtOGRR_dtR_SoeseBLS1fpZ_FF5YVGZVgjbpXBu9Zwcmg==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:41 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -269,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:42 GMT
       X-Amzn-Requestid:
-      - f2d6e33d-e5c0-11e7-8410-9f67d5d9460a
+      - e0847c7d-e5c0-11e7-8831-61f17c06d0bc
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -287,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:42 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a9f4aeaf8e0968a45a9154a0c9198bf.cloudfront.net (CloudFront)
+      - 1.1 4a495e8480f789db14c4afa001a38181.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 6Rl1OjQTPaKjcB1j1l9YvkLMbeaICzlOeTAGUd7fqKVs42b5xMIpTw==
+      - BbB84hIT3x0iIun6xFD5rfKIT0cMggzsF0C0Y0clLYzocwalicU_gQ==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -305,5 +175,5 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resources-customcoverage-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resources-customcoverage-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:49 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43569us'
+        : 200 41680us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - '089791/configurations'
+      - 152351/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:00 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:50 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:50 GMT
       X-Amzn-Requestid:
-      - 71f1150a-df97-11e7-8468-af43b485d354
+      - e55f50a8-e5c0-11e7-9487-116bf427d6d0
       X-Amzn-Remapped-Content-Length:
       - '1596'
       X-Amzn-Remapped-Connection:
@@ -157,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:50 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 96255a5b0caf50bcafcd101c1ff13691.cloudfront.net (CloudFront)
+      - 1.1 7535f1fa7462c24d8a3add0701350cb5.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 0zMKU5ZpwrwKkfoSLiqi31qSe-ZJge_yP9LK2KHJCgNstgs8mPjyNg==
+      - KWWkqKZ1hHLxs-SUdTxD53k3xyNJTj3_ac63RgL4s6cAs5346lW2ww==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -176,7 +176,7 @@ http_interactions:
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:00 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:50 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -208,9 +208,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:50 GMT
       X-Amzn-Requestid:
-      - 722013a5-df97-11e7-8987-6b4aeda5b42a
+      - e5863a4e-e5c0-11e7-a750-13ec56a46ee5
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -224,20 +224,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:50 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 fc7da6323a08a2c16d48dd4939ce0898.cloudfront.net (CloudFront)
+      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - JP0COM35S4O9Fq1uR_G88OutoS1MMGdrOicsXzv51BHHMNOPBNMYgQ==
+      - 9lMGfg2_OWmSvg1EOEPVZk6VnrUVuwcQhvf5g0oxGjPtJQTtMaQ9Lg==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:00 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:51 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -269,9 +269,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:01 GMT
+      - Wed, 20 Dec 2017 20:03:51 GMT
       X-Amzn-Requestid:
-      - 724faf67-df97-11e7-8b6e-c5a3b228722b
+      - e5dd33ff-e5c0-11e7-9cbd-15c689f36ff0
       X-Amzn-Remapped-Content-Length:
       - '1548'
       X-Amzn-Remapped-Connection:
@@ -287,15 +287,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:00 GMT
+      - Wed, 20 Dec 2017 20:03:50 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0ffb9964022445351e635c66ad0176ff.cloudfront.net (CloudFront)
+      - 1.1 6eadd6c6c5a53c34c6fce458c34cd790.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - BJLDW44T12TX3xiSjdJjmjV9gu_w2kcD7IZ07fvDMfnuZmLAN6Veug==
+      - vFjNxbWMt49bP8_Ltoh4HLbTJN0_OrNrN1ptT8rKB_vYRj72b5r8RQ==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -306,5 +306,5 @@ http_interactions:
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:01 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resources-customembargo-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resources-customembargo-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:52:11 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,13 +38,13 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42383us'
+        : 200 42670us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.1.1
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.36.1.1
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 404846/configurations
+      - 732011/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:54 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:12 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Amzn-Requestid:
-      - 791870d6-df97-11e7-ad07-fd711c41248a
+      - e7b0941b-e5c0-11e7-8720-f756771a4a96
       X-Amzn-Remapped-Content-Length:
       - '1548'
       X-Amzn-Remapped-Connection:
@@ -157,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:12 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 55676da1e5c0a9c4e60a94a95b01dc04.cloudfront.net (CloudFront)
+      - 1.1 106d08be45f5967314966d4d8b406722.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 2OMfDSjT2OcBOSpzSIe0j2-sILvY2F9_mAa57xAt_RlEHPSl50FPEA==
+      - urYinc4rfpNTx9z6DcHmw1BZN5SsAlL11QYdXe3Ju_CV3_FDtuSoow==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -176,7 +176,7 @@ http_interactions:
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:54 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -208,9 +208,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:12 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Amzn-Requestid:
-      - 7954b6c6-df97-11e7-94eb-13758bb610d8
+      - e7c8614c-e5c0-11e7-95c0-db10846f208a
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -224,20 +224,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:12 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 373880a309382d9266a9313233b86d25.cloudfront.net (CloudFront)
+      - 1.1 d69720531b393bbe46e33088d4ad3a49.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - h0n7-FTD6EGEazBJzUt-9Wgp4I9jLfb1R21vAlik47b4-24GIZn5Eg==
+      - MjkADr6t34mB5oO-_Iv8r6cNbQPCVJ8U2YH10tJPJmwQnf1r5M14yA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:13 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:54 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -269,9 +269,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:52:13 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Amzn-Requestid:
-      - 79a45cc6-df97-11e7-863f-33f562100d54
+      - e80ff276-e5c0-11e7-a70c-fb4d7956e7f1
       X-Amzn-Remapped-Content-Length:
       - '1546'
       X-Amzn-Remapped-Connection:
@@ -287,15 +287,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:52:12 GMT
+      - Wed, 20 Dec 2017 20:03:54 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 6be093c16fa776bbd432bbe9bd03f6af.cloudfront.net (CloudFront)
+      - 1.1 00a1d8f37a58e42d70fb6d319f45045f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - sbHKNtY2q7X6uCAaog0HJ_Nsa3zZs4OwDKXYN3u9J4LdqccOzS6KEw==
+      - sm3cFNZJVBnoR4-NuIAxFkWVrl5Ct22lLrCAx1qFab3YgtlBZXeDJQ==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -306,5 +306,5 @@ http_interactions:
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":7},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:52:13 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resources-isnotselected-customembargo.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resources-isnotselected-customembargo.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
+      - Wed, 20 Dec 2017 20:03:44 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 294140us'
+        : 200 44459us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 252193/configurations
+      - 777389/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,137 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1546'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Amzn-Requestid:
-      - f2178b0e-e5c0-11e7-b39c-050f524bcfe2
-      X-Amzn-Remapped-Content-Length:
-      - '1546'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - f9DkoftWQyiyjohowj7syh-MtfsTWItBqQLJ86ot0VqtqizJKk_usg==
-    body:
-      encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
-        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":7},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:11 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2005-01-01"},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5}}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
-      X-Amzn-Requestid:
-      - f2642499-e5c0-11e7-a84e-05c5f67ac08b
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 9438b4fa578cbce283b48cf092373802.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - AvHCDdHgwhtOGRR_dtR_SoeseBLS1fpZ_FF5YVGZVgjbpXBu9Zwcmg==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:44 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -269,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:44 GMT
       X-Amzn-Requestid:
-      - f2d6e33d-e5c0-11e7-8410-9f67d5d9460a
+      - e2150803-e5c0-11e7-b09a-79aba84398d6
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -287,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:04:12 GMT
+      - Wed, 20 Dec 2017 20:03:44 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a9f4aeaf8e0968a45a9154a0c9198bf.cloudfront.net (CloudFront)
+      - 1.1 8fb8ee88d9921a973386204b4edaab26.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 6Rl1OjQTPaKjcB1j1l9YvkLMbeaICzlOeTAGUd7fqKVs42b5xMIpTw==
+      - 21C1b1lF3gY8SIw1y4ME3uiGzg2NvxS7aAREY6h2UijalhFzxBZB2g==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -305,5 +175,5 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:04:12 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:44 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-customer-resources-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-customer-resources-isselected.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:45 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,7 +38,7 @@ http_interactions:
       - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
         : 202'
       - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 43324us'
+        : 200 54056us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 857874/configurations
+      - 380062/configurations
       X-Okapi-Url:
       - http://10.39.247.213:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:24 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:45 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -139,9 +139,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:45 GMT
       X-Amzn-Requestid:
-      - 5c93b8f7-df97-11e7-abd0-659331d3e2dd
+      - e2c6f2aa-e5c0-11e7-bb80-a545266ab433
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -157,15 +157,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a7b695b8ae560fe9087da065a2b7812.cloudfront.net (CloudFront)
+      - 1.1 04548871feef153485c789be4f01c614.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 4qj7jcUJlEnCsUdMh0StXSTuB88liA8F5qS8DAqMRgM4h3_d-uVJfA==
+      - ICqxAvvK_nJf5Awwm8J1Ug2U0qDCJZEhGXqnsiEBMagR76RRxf76Lw==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -175,7 +175,7 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:24 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:45 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -207,9 +207,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:46 GMT
       X-Amzn-Requestid:
-      - 5cbe4ae6-df97-11e7-b107-2518dfb78644
+      - e2e06dde-e5c0-11e7-baa4-5ddb34629668
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Server:
@@ -223,20 +223,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 3d3d633d266d05d90a4eea7a6a59b514.cloudfront.net (CloudFront)
+      - 1.1 4a9f4aeaf8e0968a45a9154a0c9198bf.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - nPpOE53MthojRPsFzp9AeQxOqh357y2rq0K_qA01SB09MlFxqsB0xw==
+      - 4u7lnxLskeXcaZbT3ziRLBBnL7s8VLgblS69MU5sd51ZDa3TEf0aKg==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:25 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:46 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -268,9 +268,9 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 12 Dec 2017 23:51:25 GMT
+      - Wed, 20 Dec 2017 20:03:46 GMT
       X-Amzn-Requestid:
-      - 5d012048-df97-11e7-8953-f10f52eb9eae
+      - e35af59d-e5c0-11e7-9b95-97dd4f452fde
       X-Amzn-Remapped-Content-Length:
       - '1579'
       X-Amzn-Remapped-Connection:
@@ -286,15 +286,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 12 Dec 2017 23:51:24 GMT
+      - Wed, 20 Dec 2017 20:03:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 02192a27c967e955f8c815efa939bfc8.cloudfront.net (CloudFront)
+      - 1.1 6f051d41810c0741cbcf827aa95ece89.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - AktooEdMm798gYo-x9vlTWa3mAX8TvGvXcaiTqqBgHT799_ZF4X0WA==
+      - hUG2HiEX6lPVR21XsmpTKAXuOPbXWqEz5DZIPKde-gSe30RyLbIMLw==
     body:
       encoding: UTF-8
       string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
@@ -304,5 +304,5 @@ http_interactions:
         Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
     http_version: 
-  recorded_at: Tue, 12 Dec 2017 23:51:25 GMT
+  recorded_at: Wed, 20 Dec 2017 20:03:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/customer_resources_spec.rb
+++ b/spec/requests/customer_resources_spec.rb
@@ -187,194 +187,295 @@ RSpec.describe "Customer Resources", type: :request do
       )
     end
 
-    describe "selecting a customer resource" do
-      let(:params) do
-        {
-          "data" => {
-            "type" => 'customerResources',
-            "attributes" => {
-              "isSelected" => true
-            }
-    }
-        }
-      end
-
-      before do
-        VCR.use_cassette("put-customer-resources-isselected-update") do
-          put '/eholdings/customer-resources/22-1887786-1440285',
-              params: params, as: :json, headers: update_headers
-        end
-      end
-
-      it "responds with OK status" do
-        expect(response).to have_http_status(200)
-      end
-
-      let!(:json) { Map JSON.parse response.body }
-
-      it "is no longer selected" do
-        expect(json.data.attributes.isSelected).to be true
-      end
-    end
-
-    describe "hiding a customer resource" do
-      let(:params) do
-        {
-          "data" => {
-            "type" => 'customerResources',
-            "attributes" => {
-              "visibilityData" => {
-                "isHidden" => true
-              }
-            }
-          }
-        }
-      end
-
-      before do
-        VCR.use_cassette("put-customer-resource-ishidden-update") do
-          put '/eholdings/customer-resources/22-1887786-1440285',
-              params: params, as: :json, headers: update_headers
-        end
-      end
-
-      it "responds with OK status" do
-        expect(response).to have_http_status(200)
-      end
-
-      let!(:json) { Map JSON.parse response.body }
-
-      it "is no longer visible" do
-        expect(json.data.attributes.visibilityData.isHidden).to be true
-      end
-    end
-
-    describe "setting custom coverage" do
-      let(:params) do
-        {
-          "data" => {
-            "type" => 'customerResources',
-            "attributes" => {
-              "customCoverages" => [
-                {
-                  "beginCoverage" => "2003-01-01",
-                  "endCoverage" => "2004-01-01"
-                }
-              ]
-            }
-          }
-        }
-      end
-
-      before do
-        VCR.use_cassette("put-customer-resources-customcoverage-update") do
-          put '/eholdings/customer-resources/22-1887786-1440285',
-              params: params, as: :json, headers: update_headers
-        end
-      end
-
-      it "responds with OK status" do
-        expect(response).to have_http_status(200)
-      end
-
-      let!(:json) { Map JSON.parse response.body }
-
-      it "has a custom coverage range" do
-        expect(json.data.attributes.customCoverages.length).to eq(1)
-      end
-      it "custom coverage range has a beginning" do
-        expect(json.data.attributes.customCoverages[0].beginCoverage).to eq("2003-01-01")
-      end
-      it "custom coverage range has an ending" do
-        expect(json.data.attributes.customCoverages[0].endCoverage).to eq("2004-01-01")
-      end
-    end
-
-    describe "setting a custom embargo period" do
-      let(:params) do
-        {
-          "data" => {
-            "type" => 'customerResources',
-            "attributes" => {
-              "customEmbargoPeriod" => {
-                "embargoUnit" => "Days",
-                "embargoValue" => 7
-              }
-            }
-          }
-        }
-      end
-
-      before do
-        VCR.use_cassette("put-customer-resources-customembargo-update") do
-          put '/eholdings/customer-resources/22-1887786-1440285',
-              params: params, as: :json, headers: update_headers
-        end
-      end
-
-      it "responds with OK status" do
-        expect(response).to have_http_status(200)
-      end
-
-      let!(:json) { Map JSON.parse response.body }
-
-      it "has a custom embargo period" do
-        expect(json.data.attributes.customEmbargoPeriod.embargoUnit).to eq("Days")
-        expect(json.data.attributes.customEmbargoPeriod.embargoValue).to eq(7)
-      end
-    end
-
-    describe "combined update" do
-      let(:params) do
-        {
-          "data" => {
-            "type" => 'customerResources',
-            "attributes" => {
-              "isSelected" => true,
-              "visibilityData" => {
-                "isHidden" => false
-              },
-              "customEmbargoPeriod" => {
-                "embargoUnit" => "Months",
-                "embargoValue" => 5
-              },
-              "customCoverages" => [
-                {
-                  "beginCoverage" => "2005-01-01"
+    describe "when the customer resource is not selected" do
+      describe "hiding a customer resource" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => false,
+                "visibilityData" => {
+                  "isHidden" => true
                 },
-                {
-                  "beginCoverage" => "2000-01-01",
-                  "endCoverage" => "2004-02-01"
-                }
-              ]
+                "customEmbargoPeriod" => nil,
+                "customCoverages" => []
+              }
             }
           }
-        }
-      end
+        end
 
-      before do
-        VCR.use_cassette("put-customer-resources-combined-update") do
-          put '/eholdings/customer-resources/22-1887786-1440285',
-              params: params, as: :json, headers: update_headers
+        before do
+          VCR.use_cassette("put-customer-resource-isnotselected-ishidden") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "fails with unprocessable entity status" do
+          expect(response).to have_http_status(422)
         end
       end
 
-      it "responds with OK status" do
-        expect(response).to have_http_status(200)
+      describe "setting custom coverages" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => false,
+                "visibilityData" => nil,
+                "customEmbargoPeriod" => nil,
+                "customCoverages" => [
+                  {
+                    "beginCoverage" => "2001-01-02"
+                  },
+                  {
+                    "beginCoverage" => "2000-01-01",
+                    "endCoverage" => "2000-02-01"
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resource-isnotselected-customcoverages") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "fails with unprocessable entity status" do
+          expect(response).to have_http_status(422)
+        end
       end
 
-      let!(:json) { Map JSON.parse response.body }
+      describe "setting a custom embargo period" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => false,
+                "visibilityData" => nil,
+                "customEmbargoPeriod" => {
+                  "embargoUnit" => "Weeks",
+                  "embargoValue" => 6
+                },
+                "customCoverages" => []
+              }
+            }
+          }
+        end
 
-      it "all fields have been successfully updated" do
-        expect(json.data.attributes.isSelected).to be true
-        expect(json.data.attributes.visibilityData.isHidden).to be false
+        before do
+          VCR.use_cassette("put-customer-resources-isnotselected-customembargo") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
 
-        expect(json.data.attributes.customCoverages.length).to eq(2)
-        expect(json.data.attributes.customCoverages[0].beginCoverage).to eq("2000-01-01")
-        expect(json.data.attributes.customCoverages[0].endCoverage).to eq("2004-02-01")
+        it "fails with unprocessable entity status" do
+          expect(response).to have_http_status(422)
+        end
+      end
 
-        expect(json.data.attributes.customEmbargoPeriod.embargoUnit).to eq("Months")
-        expect(json.data.attributes.customEmbargoPeriod.embargoValue).to eq(5)
+      describe "selecting a customer resource" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => true
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resources-isselected") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "is now selected" do
+          expect(json.data.attributes.isSelected).to be true
+        end
+      end
+    end
+
+    describe "when the customer resource is selected" do
+      describe "hiding a customer resource" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => true,
+                "visibilityData" => {
+                  "isHidden" => true
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resource-ishidden-update") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "is no longer visible" do
+          expect(json.data.attributes.visibilityData.isHidden).to be true
+        end
+      end
+
+      describe "setting custom coverage" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => true,
+                "customCoverages" => [
+                  {
+                    "beginCoverage" => "2003-01-01",
+                    "endCoverage" => "2004-01-01"
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resources-customcoverage-update") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "has a custom coverage range" do
+          expect(json.data.attributes.customCoverages.length).to eq(1)
+        end
+        it "custom coverage range has a beginning" do
+          expect(json.data.attributes.customCoverages[0].beginCoverage).to eq("2003-01-01")
+        end
+        it "custom coverage range has an ending" do
+          expect(json.data.attributes.customCoverages[0].endCoverage).to eq("2004-01-01")
+        end
+      end
+
+      describe "setting a custom embargo period" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => true,
+                "customEmbargoPeriod" => {
+                  "embargoUnit" => "Days",
+                  "embargoValue" => 7
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resources-customembargo-update") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "has a custom embargo period" do
+          expect(json.data.attributes.customEmbargoPeriod.embargoUnit).to eq("Days")
+          expect(json.data.attributes.customEmbargoPeriod.embargoValue).to eq(7)
+        end
+      end
+
+      describe "combined update" do
+        let(:params) do
+          {
+            "data" => {
+              "type" => 'customerResources',
+              "attributes" => {
+                "isSelected" => true,
+                "visibilityData" => {
+                  "isHidden" => false
+                },
+                "customEmbargoPeriod" => {
+                  "embargoUnit" => "Months",
+                  "embargoValue" => 5
+                },
+                "customCoverages" => [
+                  {
+                    "beginCoverage" => "2005-01-01"
+                  },
+                  {
+                    "beginCoverage" => "2000-01-01",
+                    "endCoverage" => "2004-02-01"
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette("put-customer-resources-combined-update") do
+            put '/eholdings/customer-resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it "responds with OK status" do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it "all fields have been successfully updated" do
+          expect(json.data.attributes.isSelected).to be true
+          expect(json.data.attributes.visibilityData.isHidden).to be false
+
+          expect(json.data.attributes.customCoverages.length).to eq(2)
+          expect(json.data.attributes.customCoverages[0].beginCoverage).to eq("2000-01-01")
+          expect(json.data.attributes.customCoverages[0].endCoverage).to eq("2004-02-01")
+
+          expect(json.data.attributes.customEmbargoPeriod.embargoUnit).to eq("Months")
+          expect(json.data.attributes.customEmbargoPeriod.embargoValue).to eq(5)
+        end
       end
     end
   end


### PR DESCRIPTION
Similar to https://github.com/thefrontside/mod-kb-ebsco/pull/45, but for customer resources.  Return a 422 status when user attempts to customize a deselected customer resource.

I also added back the explicit `class` option to the `deserializable_resource` declaration, because without it the deserialization didn't seem to actually trigger.

Note, the validator will accept an empty array as "absent", so `customCoverages` (if passed) can either be `null`, `false` or `[]`.