### PR TITLE
Move access for raw EBSCO RM API endpoints

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -32,19 +32,19 @@
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/eholdings/proxy/holdings*"
+          "pathPattern": "/ebsco-rmapi/holdings*"
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/eholdings/proxy/packages*"
+          "pathPattern": "/ebsco-rmapi/packages*"
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/eholdings/proxy/vendors*"
+          "pathPattern": "/ebsco-rmapi/vendors*"
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/eholdings/proxy/titles*"
+          "pathPattern": "/ebsco-rmapi/titles*"
         }
       ]
     }

--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -34,7 +34,7 @@ class ProxyController < ApplicationController
 
   def rmapi_path
     # What we really care about here is what comes after
-    # the `/eholdings/proxy` namespace.  That's what we proxy to RMAPI
-    request.fullpath.gsub(/\/eholdings\/proxy/, '')
+    # the `/ebsco-rmapi` namespace.  That's what we proxy to RMAPI
+    request.fullpath.gsub(/\/ebsco-rmapi/, '')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,9 @@ Rails.application.routes.draw do
     resource :configuration, only: [:show, :update]
     resource :status, only: [:show]
 
-    match '/proxy/*path' => 'proxy#index', via: [:get, :post, :put, :patch, :delete]
+
   end
 
+  match '/ebsco-rmapi/*path' => 'proxy#index', via: [:get, :post, :put, :patch, :delete]
   match '/admin/health' => 'health#index', via: [:get]
 end

--- a/spec/requests/proxy_spec.rb
+++ b/spec/requests/proxy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Proxy", type: :request do
   describe "getting a vendor" do
     let(:resource) do
       [
-        '/eholdings/proxy/vendors/19',
+        '/ebsco-rmapi/vendors/19',
         headers: okapi_headers
       ]
     end
@@ -23,7 +23,7 @@ RSpec.describe "Proxy", type: :request do
   describe "getting a package" do
     let(:resource) do
       [
-        '/eholdings/proxy/vendors/19/packages/6581',
+        '/ebsco-rmapi/vendors/19/packages/6581',
         headers: okapi_headers
       ]
     end
@@ -42,7 +42,7 @@ RSpec.describe "Proxy", type: :request do
   describe "getting a title" do
     let(:resource) do
       [
-        '/eholdings/proxy/titles/316875',
+        '/ebsco-rmapi/titles/316875',
         headers: okapi_headers
       ]
     end
@@ -61,11 +61,11 @@ RSpec.describe "Proxy", type: :request do
   describe "getting a customer resource" do
     let(:resource) do
       [
-        '/eholdings/proxy/vendors/22/packages/1887786/titles/1440285',
+        '/ebsco-rmapi/vendors/22/packages/1887786/titles/1440285',
         headers: okapi_headers
       ]
     end
-    
+
     before do
       VCR.use_cassette("get-proxy-customer-resource-valid") do
         get(*resource)


### PR DESCRIPTION
`proxy` is a loaded word in the FOLIO ecosystem, and we weren't using it in the same way as Okapi expects.

Now the raw access to the EBSCO RM API endpoints will be under `/ebsco-rmapi` instead of `/eholdings/proxy`.