### PR TITLE
Give configuration id of configuration

### DIFF
--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -10,7 +10,7 @@ class Configuration
   validate :verify_credentials
 
   def id
-    'rmapi'
+    'configuration'
   end
 
   def initialize(okapi, rmapi_base_url)


### PR DESCRIPTION
## Purpose
eHoldings settings is broken.

## Approach
The `configurations` endpoint needs type `configurations` and id `configuration`. It's currently returning type `configuration` and id `rmapi`.
