### PR TITLE
Update interface version to two-part version

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "eholdings",
-      "version": "0.1.1",
+      "version": "0.1",
       "handlers" : [
         {
           "methods": [ "GET", "PUT" ],


### PR DESCRIPTION
If I'm not mistaken,  interface versions are two-part - a major and minor revision.  This PR updates the interface version in the module descriptor from 0.1.1. to 0.1.  