### PR TITLE
Set default environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,27 @@ Module to broker communication with the EBSCO knowledge base.
 
 ## Setup
 
+- Ruby 2.4.2
+- rspec (test runner)
+
 Environment variables needed:
 - `EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL`
 - `EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID`
 - `EBSCO_RESOURCE_MANAGEMENT_API_KEY`
 
 Place in `.env` or CI project settings.
+
+## Running tests
+
+Run existing tests using 
+
+- bundle exec rspec
+
+However, if new recordings for tests need to be made, set the following in .env file at the root of the project:
+
+- TEST_CUSTOMER_ID
+- TEST_API_KEY
+- TEST_OKAPI_TOKEN
 
 ## Additional information
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,10 +14,7 @@ class ApplicationController < ActionController::API
   end
 
   def rmapi_base_url
-    ENV.fetch(
-      'EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL',
-      'https://sandbox.ebsco.io'
-    )
+    Rails.application.config.rmapi_base_url
   end
 
   def okapi_url

--- a/app/models/rm_api_resource.rb
+++ b/app/models/rm_api_resource.rb
@@ -52,10 +52,7 @@ class RmApiResource < Flexirest::Base
   private
 
   def set_base_url(_name, request)
-    rmapi_url = ENV.fetch(
-      'EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL',
-      'https://sandbox.ebsco.io'
-    )
+    rmapi_url = Rails.application.config.rmapi_base_url
     customer_id = request.object.config.customer_id
     self.class.base_url "#{rmapi_url}/rm/rmaccounts/#{customer_id}"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,9 @@ module ModKbEbsco
   class Application < Rails::Application
     config.load_defaults 5.1
     config.api_only = true
+
+    def config.rmapi_base_url
+      ENV.fetch('EBSCO_RMAPI_BASE_URL', 'https://api.ebsco.io')
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,9 @@
 
 # Shared context for values common to all request tests
 RSpec.shared_context 'Request Test Helpers' do
-  let!(:customer_id) { ENV.fetch('TEST_CUSTOMER_ID') }
-  let!(:api_key) { ENV.fetch('TEST_API_KEY') }
-  let!(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN') }
+  let!(:customer_id) { ENV.fetch('TEST_CUSTOMER_ID', 'test-customer-id') }
+  let!(:api_key) { ENV.fetch('TEST_API_KEY', 'test-rm-api-key') }
+  let!(:okapi_token) { ENV.fetch('TEST_OKAPI_TOKEN', 'test-okapi-token') }
   let!(:okapi_url) { ENV.fetch('TEST_OKAPI_URL', 'https://okapi.frontside.io') }
   let!(:okapi_tenant) { ENV.fetch('TEST_OKAPI_TENANT', 'fs') }
 
@@ -42,12 +42,12 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
   config.filter_sensitive_data('TEST_CUSTOMER_ID') do
-    ENV['TEST_CUSTOMER_ID']
+    ENV.fetch('TEST_CUSTOMER_ID', 'test-customer-id')
   end
   config.filter_sensitive_data('TEST_API_KEY') do
-    ENV['TEST_API_KEY']
+    ENV.fetch('TEST_API_KEY', 'test-rm-api-key')
   end
   config.filter_sensitive_data('TEST_OKAPI_TOKEN') do
-    ENV['TEST_OKAPI_TOKEN']
+    ENV.fetch('TEST_OKAPI_TOKEN', 'test-okapi-token')
   end
 end


### PR DESCRIPTION
## Purpose

Developers should be able to clone the repository, and having only a modern ruby interpreter and the `bundler` gem, be able to run the tests. Unfortunately, this is not currently the case.

## Approach
- Set default environment variables so that we do not need to have .env file for the existing recordings to go through. 
- Set RM_API_BASE_URL at an application level scope rather than duplicating in 2 places
- Edit Readme.md to have better instructions for running tests and setting up environment

TODO: 
Redundancy in fetching environment variables, could be moved to global scope within the file and the duplication could be avoided.