### PR TITLE
Generate code coverage reports with SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ log
 tmp
 .env
 telepresence.log
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 
 script:
   - rubocop
-  - rake spec
+  - COVERAGE=true rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-checkstyle_formatter', require: false
+  gem 'simplecov'
   gem 'vcr', '~> 3.0'
   gem 'webmock', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
     diff-lcs (1.3)
+    docile (1.1.5)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -79,6 +80,7 @@ GEM
     highline (1.7.10)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
     jsonapi-rails (0.3.1)
@@ -188,6 +190,11 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -234,6 +241,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-checkstyle_formatter
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Place in `.env` or CI project settings.
 
 ## Running tests
 
-Run existing tests using 
+Run existing tests using
 
 - bundle exec rspec
 
@@ -37,6 +37,10 @@ However, if new recordings for tests need to be made, set the following in .env 
 - TEST_CUSTOMER_ID
 - TEST_API_KEY
 - TEST_OKAPI_TOKEN
+
+To run tests that also generate a code coverage report at `/coverage`
+
+- COVERAGE=true bundle exec rspec
 
 ## Additional information
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,4 +30,9 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Load middleware for dealing with Transfer-Encoding: chunked
+  config.middleware.insert_before Rack::Runtime,
+                                  ChunkedTransferDecoder,
+                                  decoded_upstream: true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# If COVERAGE=true, generate simplecov reports
+require 'simplecov'
+if ENV['COVERAGE']
+  SimpleCov.start 'rails' do
+    minimum_coverage 85
+  end
+end
+
 # Shared context for values common to all request tests
 RSpec.shared_context 'Request Test Helpers' do
   let!(:customer_id) { ENV.fetch('TEST_CUSTOMER_ID', 'test-customer-id') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@
 require 'simplecov'
 if ENV['COVERAGE']
   SimpleCov.start 'rails' do
-    minimum_coverage 85
+    minimum_coverage 90
   end
 end
 


### PR DESCRIPTION
## Purpose
Code coverage reports are a handy to way to identify holes in test coverage.

## Approach
[SimpleCov](https://github.com/colszowka/simplecov) is a Ruby code coverage tool we can use to generate coverage reports for `mod-kb-ebsco`.

To run tests that will also generate a coverage report, `COVERAGE=true bundle exec rspec`.

Travis will run the coverage report in CI builds (but not FOLIO's Jenkins, since that's an opaque box inaccessible by pull requests). In the [spec helper](https://github.com/folio-org/mod-kb-ebsco/compare/jc/code-coverage?expand=1#diff-93830fa29d616f7c87903d08b5b1b29aR5), I defined a threshold for coverage. If that percentage dips below the threshold, the CI build will fail.

## Next Steps
We should upload the generated reports to a free tool like [Coveralls](https://coveralls.io) or [CodeCov](https://codecov.io) for trend tracking, more detailed report UIs, and a shiny badge to put on our GitHub repo.

## Learning
[Running SimpleCov on demand](http://www.rubydoc.info/gems/simplecov/frames#Running_coverage_only_on_demand)

## Screenshots
<img width="567" alt="screen shot 2018-01-16 at 4 58 12 pm" src="https://user-images.githubusercontent.com/230597/35016504-76e2c9d8-fade-11e7-971f-d0431840e1f3.png">