### PR TITLE
Implement Package Level Hiding reason Change

### DIFF
--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -22,11 +22,11 @@ class SerializablePackage < SerializableResource
   attribute :visibilityData do
     visibility = @object.visibilityData
 
-    if visibility['isHidden']
-      { isHidden: true, reason: 'All titles in this package are hidden' }
-    else
-      visibility
+    if visibility[:isHidden]
+      visibility[:reason] =
+        visibility[:reason] == 'Hidden by EP' ? 'Set by System' : ''
     end
+    visibility
   end
 
   attribute :contentType do

--- a/spec/fixtures/vcr_cassettes/get-package-reason-hidden-by-customer.yml
+++ b/spec/fixtures/vcr_cassettes/get-package-reason-hidden-by-customer.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 17 Jan 2018 23:32:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 348687us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 41686us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 498995/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 23:32:06 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/2697502
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Jan 2018 23:32:06 GMT
+      X-Amzn-Requestid:
+      - a15b83bc-fbde-11e7-a477-a5f4ed332fb8
+      X-Amzn-Remapped-Content-Length:
+      - '343'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 17 Jan 2018 23:32:05 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2f5583cd8188200f0382a2333e21239a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0drPiTHIzFff3WzHk3rArA7sPmt6ulcUBgCwr9thFfIPWOAsOb_Y2A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2697502,"packageName":"ABC-CLIO WORLD RELIGIONS","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 23:32:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-package-reason-hidden-by-ep.yml
+++ b/spec/fixtures/vcr_cassettes/get-package-reason-hidden-by-ep.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 17 Jan 2018 23:32:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 353860us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42735us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 290950/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 23:32:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/2516
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '348'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Jan 2018 23:32:05 GMT
+      X-Amzn-Requestid:
+      - a00e6a2d-fbde-11e7-ba40-2fd4e0eb238b
+      X-Amzn-Remapped-Content-Length:
+      - '348'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 17 Jan 2018 23:32:05 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ff57cfb1ab4e48e1d0a484a3a45384f4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - z5wleL9o8ytuJMtguCFywuWDxq0ieG-Og_sGHIq6XiaddAjYTCtCjg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2516,"packageName":"Abstracts in Social Gerontology","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"2018-01-04","endCoverage":""}}'
+    http_version: 
+  recorded_at: Wed, 17 Jan 2018 23:32:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Packages', type: :request do
 
     it 'returns a valid visibility reason' do
       expect(json.data.attributes.visibilityData.reason).to(
-        eq('All titles in this package are hidden')
+        eq('Set by System')
       )
     end
   end
@@ -497,6 +497,44 @@ RSpec.describe 'Packages', type: :request do
 
     it 'returns a not found error' do
       expect(response).to have_http_status(404)
+    end
+  end
+
+  describe 'getting a hidden by ep package' do
+    before do
+      VCR.use_cassette('get-package-reason-hidden-by-ep') do
+        get '/eholdings/packages/19-2516',
+            headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+    let!(:visibility) { json.data.attributes.visibilityData }
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(200)
+    end
+    it 'has reason hidden by customer' do
+      expect(visibility.reason).to eq('Set by System')
+    end
+  end
+
+  describe 'getting a hidden by customer package' do
+    before do
+      VCR.use_cassette('get-package-reason-hidden-by-customer') do
+        get '/eholdings/packages/19-2697502',
+            headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+    let!(:visibility) { json.data.attributes.visibilityData }
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(200)
+    end
+    it 'has reason hidden by customer' do
+      expect(visibility.reason).to eq('')
     end
   end
 end


### PR DESCRIPTION
## Purpose
Update hidden reason returned as package level from rm api.  When package is hidden and reason is 'Hidden by EP' set to 'Set By System' otherwise it is set to empty.  Currently message returned is 'All titles in this package are hidden' and there is no way to distinguish if it is hidden by ep or a customer.
Related Jira ticket:
https://issues.folio.org/browse/UIEH-52

## Approach
Used same approach as was done for package title level hide reason. Added VCR cassettes for testing response with Hidden by EP and Hidden by Customer

## Learning
Ruby setup on linux https://gorails.com/setup/ubuntu/16.04
https://github.com/vcr/vcr


