### PR TITLE
Stop pushing to Docker Hub from Travis

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,28 +4,10 @@ bash_escape() ( printf '\\033[%dm' $1; );
 RESET=$(bash_escape 0); BLUE=$(bash_escape 34);
 put_info() ( printf "${BLUE}[INFO]${RESET} $1\n");
 
-put_info "Authenticating to DockerHub";
-docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-
-put_info "Building new image";
-docker build .;
-
-image=$(docker images --format="{{.ID}}" | head -n 1);
-
-commit_sha=${TRAVIS_COMMIT:0:7}
-
-put_info "Tagging image '$image' as '$MODULE_VERSION_${commit_sha}'";
-docker tag "$image" ${DOCKER_IMAGE_NAME}:${MODULE_VERSION}_${commit_sha};
-put_info "Tagging image '$image' as 'latest'";
-docker tag "$image" ${DOCKER_IMAGE_NAME}:latest;
-
-put_info "Pushing image to DockerHub";
-docker push ${DOCKER_IMAGE_NAME};
-
 put_info "Pulling new image into container '${KUBE_DEPLOYMENT_CONTAINER_NAME}' on deployment '${KUBE_DEPLOYMENT_NAME}'";
 kubectl config view;
 kubectl config current-context;
-kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=${DOCKER_IMAGE_NAME}:${MODULE_VERSION}_${commit_sha};
+kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=${DOCKER_IMAGE_NAME}:latest;
 
 # variables needed for Okapi registration
 service_id="${FOLIO_MODULE_NAME}-${MODULE_VERSION}"


### PR DESCRIPTION
## Purpose
This deploy script should be moved from `folio-org/mod-kb-ebsco` to `thefrontside/folio-mod-kb-ebsco-deploy`.

The first step is to split the publishing of a docker image from the pushing of that image to Frontside's Okapi cluster. The docker image _should_ be published from `folio-org/mod-kb-ebsco`, but the cluster step should happen in `thefrontside/folio-mod-kb-ebsco-deploy`.

Related to https://issues.folio.org/browse/UIEH-113

## Approach
*Needs Confirmation*: I want second and third and fourth opinions on this, but I believe with Jenkins now publishing an image to https://hub.docker.com/r/folioci/mod-kb-ebsco/, we no longer need to be publishing an image to `thefrontside/mod-kb-ebsco`.

That means we can completely remove the image push step from Travis.

## Next Steps
1. Move the rest of the deploy script over to `thefrontside/folio-mod-kb-ebsco-deploy`.
2. Set up Circle CI for `thefrontside/folio-mod-kb-ebsco-deploy`.
3. Set up Superfeedr to send to the CircleCI API
4. Remove .travis.yml from `thefrontside/folio-mod-kb-ebsco-deploy`