### PR TITLE
Allow fetch and update of allowEbscoToAddTitles with RM API

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -56,6 +56,7 @@ class PackagesController < ApplicationController
       .require(:package)
       .permit(
         :isSelected,
+        :allowEbscoToAddTitles,
         visibilityData: [:isHidden],
         customCoverage: %i[beginCoverage endCoverage]
       )

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -6,13 +6,15 @@ module Validation
   class PackageParameters
     include ActiveModel::Validations
 
-    attr_accessor :isSelected, :isHidden, :beginCoverage, :endCoverage
+    attr_accessor :isSelected, :isHidden, :allowEbscoToAddTitles,
+                  :beginCoverage, :endCoverage
 
     # Deselected packages cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
     # to confusing behavior unless we signal a failure code here.
     # TODO: clearer messaging might be nice here
     with_options unless: :isSelected do
+      validates :allowEbscoToAddTitles, absence: true, unless: :isSelected
       validates :isHidden, absence: true, unless: :isSelected
       validates :beginCoverage, absence: true, unless: :isSelected
       validates :endCoverage, absence: true, unless: :isSelected
@@ -20,6 +22,7 @@ module Validation
 
     def initialize(params = {})
       @isSelected = params[:isSelected]
+      @allowEbscoToAddTitles = params[:allowEbscoToAddTitles]
       @isHidden = params.dig(:visibilityData, :isHidden)
       @beginCoverage = params.dig(:customCoverage, :beginCoverage)
       @endCoverage = params.dig(:customCoverage, :endCoverage)

--- a/app/deserializable/deserializable_package.rb
+++ b/app/deserializable/deserializable_package.rb
@@ -4,4 +4,8 @@ class DeserializablePackage < JSONAPI::Deserializable::Resource
   attributes :isSelected,
              :customCoverage,
              :visibilityData
+
+  attribute :allowKbToAddTitles do |value|
+    { allowEbscoToAddTitles: value }
+  end
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -61,16 +61,23 @@ class Package < RmApiResource
       vendor_id: vendorId,
       package_id: packageId,
       isSelected: attributes[:isSelected],
+      allowEbscoToAddTitles: attributes[:allowEbscoToAddTitles],
       isHidden: attributes[:visibilityData][:isHidden],
       customCoverage: attributes[:customCoverage]
     )
-
-    # re-fetch from RM API to surface side-effects
-    saved_package = self.class.find(vendor_id: vendorId, package_id: packageId)
-    merge_fields(saved_package)
+    refresh!
   end
 
   private
+
+  def refresh!
+    # re-fetch from RM API to surface side-effects
+    saved_package = self.class.find(
+      vendor_id: vendorId,
+      package_id: packageId
+    )
+    merge_fields(saved_package)
+  end
 
   def merge_fields(new_values)
     update_fields.deep_merge(new_values.to_hash).each do |k, v|
@@ -81,6 +88,7 @@ class Package < RmApiResource
   def update_fields
     to_hash.with_indifferent_access.slice(
       :isSelected,
+      :allowEbscoToAddTitles,
       :visibilityData,
       :customCoverage
     )

--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -14,6 +14,7 @@ class SerializablePackage < SerializableResource
              :selectedCount,
              :customCoverage,
              :isSelected,
+             :allowKbToAddTitles,
              :vendorName
 
   attribute :providerId do
@@ -26,6 +27,10 @@ class SerializablePackage < SerializableResource
 
   attribute :name do
     @object.packageName
+  end
+
+  attribute :allowKbToAddTitles do
+    @object.allowEbscoToAddTitles
   end
 
   attribute :visibilityData do

--- a/spec/fixtures/vcr_cassettes/get-package-allow-add-titles.yml
+++ b/spec/fixtures/vcr_cassettes/get-package-allow-add-titles.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 14 Feb 2018 20:44:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 355461us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 44490us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 136070/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 20:44:50 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/40/packages/1118425
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '469'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Feb 2018 20:44:50 GMT
+      X-Amzn-Requestid:
+      - e7068b7b-11c7-11e8-8c51-193e21e5971d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Wed, 14 Feb 2018 20:44:50 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8f18deab0e501ffbd2fa94cfd46e4785.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _WkjJJkJjMgqeNGpkwnjzfywapXOpriEuUt8Uew1vGINeTK4NNT42Q==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":1118425,"packageName":"Royal Society of Chemistry (CRKN)","isCustom":false,"vendorId":40,"vendorName":"Royal
+        Society of Chemistry","titleCount":54,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":54,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2012-01-01","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 20:44:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-allow-add-titles.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-allow-add-titles.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 14 Feb 2018 19:47:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 355253us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42470us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 208806/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:49 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '468'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Feb 2018 19:47:49 GMT
+      X-Amzn-Requestid:
+      - efa195fe-11bf-11e8-8b73-13a6bebcfdf8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Wed, 14 Feb 2018 19:47:49 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1011122594527947f68957a1e79e0577.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Qapi8EQeey61zMo8IgjL42uJS3OSmuFM9QrNG2pgS2rs8sIBUd56ng==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-add-titles.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-add-titles.yml
@@ -1,0 +1,259 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 356284us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42880us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 635441/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:52 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '451'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Amzn-Requestid:
+      - f194da0a-11bf-11e8-8c07-7fe4023c14cb
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e2bc21de81a2b5a06f939e3377436b82.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9KGcob7ck03R3nwgokUN0DQ-EEwtu74Apz8cV2A3oXYuDeFZq6z5Jw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:52 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"allowEbscoToAddTitles":true,"isHidden":true,"customCoverage":{"beginCoverage":null,"endCoverage":null}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Amzn-Requestid:
+      - f1b29b6d-11bf-11e8-aa84-1f2ba45a4677
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f231ce4c791455c77c15d9bd0b16cf52.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - BYzIlmwTeyXgvuC_1qM1cR4T7aQB-l1F4d0_eMNte77rrpi-WHXtMA==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:52 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '468'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Amzn-Requestid:
+      - f1cd01c2-11bf-11e8-88ca-d7afdae58121
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Wed, 14 Feb 2018 19:47:52 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 79ee364b2ad2daf670457e2618b8bea6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - nJphRZ0PtHdmeevk5215Uqmg4ING7ob9hDetpbd6oL04Zirep_uVvg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":159,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":159,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 14 Feb 2018 19:47:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -75,6 +75,24 @@ RSpec.describe 'Packages', type: :request do
     end
   end
 
+  describe 'getting a specific package with allow add titles' do
+    before do
+      VCR.use_cassette('get-package-allow-add-titles') do
+        get '/eholdings/packages/40-1118425', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'gets the resource' do
+      expect(response).to have_http_status(200)
+      expect(json.data.attributes.vendorId).to eq(40)
+      expect(json.data.attributes.packageId).to eq(1_118_425)
+      expect(json.data.attributes.allowKbToAddTitles).to be true
+      expect(json.data.attributes.isSelected).to be true
+    end
+  end
+
   describe 'getting a package with included customer resources' do
     before do
       VCR.use_cassette('get-packages-customer-resources') do
@@ -255,6 +273,39 @@ RSpec.describe 'Packages', type: :request do
         end
       end
 
+      describe 'allowing to add titles should fail' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'packages',
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": '2003-01-01',
+                  "endCoverage": '2004-01-01'
+                },
+                "isSelected": false,
+                "allowKbToAddTitles": true,
+                "visibilityData": {
+                  "isHidden": false,
+                  "reason": ''
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-packages-isnotselected-allow-add-titles') do
+            put '/eholdings/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with unprocessable entity status' do
+          expect(response).to have_http_status(422)
+        end
+      end
+
       describe 'combined update' do
         let(:params) do
           {
@@ -266,6 +317,7 @@ RSpec.describe 'Packages', type: :request do
                   "endCoverage": '2004-01-01'
                 },
                 "isSelected": false,
+                "allowKbToAddTitles": true,
                 "visibilityData": {
                   "isHidden": true,
                   "reason": ''
@@ -298,6 +350,7 @@ RSpec.describe 'Packages', type: :request do
                   "endCoverage": nil
                 },
                 "isSelected": true,
+                "allowKbToAddTitles": true,
                 "visibilityData": {
                   "isHidden": false,
                   "reason": ''
@@ -370,6 +423,49 @@ RSpec.describe 'Packages', type: :request do
         end
       end
 
+      describe 'allow kb to add titles to a package' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'packages',
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": nil,
+                  "endCoverage": nil
+                },
+                "isSelected": true,
+                "allowKbToAddTitles": true,
+                "visibilityData": {
+                  "isHidden": true,
+                  "reason": ''
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-packages-isselected-toggle-add-titles') do
+            put '/eholdings/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with OK status' do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'is still selected' do
+          expect(json.data.attributes.isSelected).to be true
+        end
+
+        it 'is allowed to add titles' do
+          expect(json.data.attributes.allowKbToAddTitles).to be true
+        end
+      end
+
       describe 'adding custom coverage' do
         let(:params) do
           {
@@ -425,6 +521,7 @@ RSpec.describe 'Packages', type: :request do
                   "endCoverage": '2004-01-01'
                 },
                 "isSelected": true,
+                "allowKbToAddTitles": true,
                 "visibilityData": {
                   "isHidden": true,
                   "reason": ''
@@ -457,6 +554,10 @@ RSpec.describe 'Packages', type: :request do
           expect(visibility.isHidden).to be true
         end
 
+        it 'is allowed to add titles' do
+          expect(json.data.attributes.allowKbToAddTitles).to be true
+        end
+
         it 'is populated with custom coverage' do
           expect(coverage.beginCoverage).to eq '2003-01-01'
           expect(coverage.endCoverage).to eq '2004-01-01'
@@ -474,6 +575,7 @@ RSpec.describe 'Packages', type: :request do
                   "endCoverage": nil
                 },
                 "isSelected": false,
+                "allowKbToAddTitles": false,
                 "visibilityData": {
                   "isHidden": false,
                   "reason": ''
@@ -502,6 +604,10 @@ RSpec.describe 'Packages', type: :request do
 
         it 'is not hidden' do
           expect(json.data.attributes.visibilityData.isHidden).to be false
+        end
+
+        it 'is not allowed to add titles' do
+          expect(json.data.attributes.allowKbToAddTitles).to be false
         end
       end
     end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-54, users should be able to view and update "allowEbscoToAddTitles" at the package level, permission which allows knowledge base to add new titles only when a package is selected. These changes are necessary to get and put "allowEbscoToAddTitles" with RM API.
"allowEbscoToAddTitles" is a param needed by RM API and in order to keep it generic, we used "allowKbToAddTitles" as a param for mod-kb-ebsco

## Approach
This change allows us to parse allowEbscoToAddTitles" from response of RM API as well as pass it to RM API. 
Also, has associated unit tests.

## Learning
http://jsonapi.org/format/

## Screenshots
![allowtitles](https://user-images.githubusercontent.com/33662516/36311630-e53dd6b0-12f9-11e8-91d3-d9d56cfed0dc.gif)


