### PR TITLE
Implement package search filters

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -8,7 +8,12 @@ class PackagesController < ApplicationController
                                     class: DeserializablePackage
 
   def index
-    @packages = packages.all(q: params[:q], page: params[:page])
+    @packages = packages.all(
+      q: params[:q],
+      page: params[:page],
+      filter: params[:filter]
+    )
+
     render jsonapi: @packages.packagesList.to_a,
            meta: { totalResults: @packages.totalResults }
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -10,7 +10,25 @@ class Package < RmApiResource
 
   before_request do |name, request|
     if %i[all find_by_vendor].include?(name)
+      filters = request.get_params.delete(:filter) || {}
+
+      unless filters.is_a?(ActionController::Parameters) || filters.is_a?(Hash)
+        raise ActionController::BadRequest, 'Invalid filter parameter'
+      end
+
+      request.get_params[:selection] =
+        if filters[:selected] == 'true'
+          'selected'
+        elsif filters[:selected] == 'false'
+          'notselected'
+        elsif filters[:selected] == 'ebsco'
+          'orderedthroughebsco'
+        else
+          'all'
+        end
+
       request.get_params[:search] = request.get_params.delete(:q)
+      request.get_params[:contenttype] = filters[:type] || 'all'
       request.get_params[:orderby] ||=
         (request.get_params[:search] ? 'relevance' : 'packagename')
       request.get_params[:count] ||= 25

--- a/spec/fixtures/vcr_cassettes/get-providers-include-packages-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-providers-include-packages-success.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:09:16 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 350394us'
+        : 202 358181us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 42358us'
+        : 200 41519us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 352885/configurations
+      - 287315/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:37 GMT
+  recorded_at: Thu, 15 Feb 2018 21:09:16 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -139,27 +139,27 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:09:17 GMT
       X-Amzn-Requestid:
-      - 70f96980-01fc-11e8-83d3-fb86b93717d7
+      - 7b820b9b-1294-11e8-88b2-ad4e59542dba
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:09:17 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a5d569cb3db7d3a17cfa847456b00932.cloudfront.net (CloudFront)
+      - 1.1 2d2e1e199c18b4b9392796150bff22d6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - a8uee8lWcU3cGxgx3v0D6Bu_5lFG789PvwwuPAInG7MeYgDJTyboUg==
+      - 8UKyCTZxtHHDqZGHKCD_9JY0pdl9aYklYSK9Mlvu3mjKQ02lrnrxpg==
     body:
       encoding: UTF-8
-      string: '{"isCustomer":false,"packagesSelected":33,"packagesTotal":628,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
+      string: '{"isCustomer":false,"packagesSelected":38,"packagesTotal":632,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:37 GMT
+  recorded_at: Thu, 15 Feb 2018 21:09:17 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=1&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=1&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -184,63 +184,66 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '9172'
+      - '9206'
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:09:17 GMT
       X-Amzn-Requestid:
-      - 7109bcba-01fc-11e8-a20d-bb4cb7bc81f2
+      - 7ba71f8d-1294-11e8-b98f-c168d6c50c7c
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:09:17 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5a27d8f87b0f1db56d469d1fefb312ac.cloudfront.net (CloudFront)
+      - 1.1 5bd9bab11fd8ad5d2dea405e259e8910.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - iLy72bSuswrAHLlfyceUfyjTAl8y30yj1Oya7zdEOkkQnpRWVxDWsA==
+      - yGks-2ub4-3rBkPghzfHnkK26dOFXo2BdtRX8ATaDIP0hA2CzwPFgQ==
     body:
       encoding: UTF-8
-      string: '{"totalResults":628,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
+      string: '{"totalResults":632,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
         WORLD RELIGIONS","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2697501,"packageName":"ABC-CLIO
         WORLD RELIGIONS - ACADEMIC ED","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2516,"packageName":"Abstracts
         in Social Gerontology","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1073,"packageName":"Academic
-        Search Alumni Edition","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3755,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":3755,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1615,"packageName":"Academic
+        Search Alumni Edition","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3753,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":3753,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1615,"packageName":"Academic
         Search Complete","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":10667,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":10667,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":158,"packageName":"Academic
-        Search Elite","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3520,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":10665,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":158,"packageName":"Academic
+        Search Elite","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3522,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1327231,"packageName":"Academic
         Search Index","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":4065,"packageName":"Academic
-        Search Main Edition ","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3010,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":3010,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":160,"packageName":"Academic
-        Search Premier","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":6137,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":6137,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2333054,"packageName":"Academic
-        Search Ultimate","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":13392,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":13392,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1153,"packageName":"Advanced
-        Placement Source","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":4347,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":6529,"packageName":"Advanstar
+        Search Main Edition ","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3007,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":3007,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":160,"packageName":"Academic
+        Search Premier","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":6136,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":6136,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2333054,"packageName":"Academic
+        Search Ultimate","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":13402,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1153,"packageName":"Advanced
+        Placement Source","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":4343,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":6529,"packageName":"Advanstar
         Communications Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":56,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":56,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22440,"packageName":"Advertising
-        Periodicals, 1815-1888","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":297,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5188,"packageName":"African
-        American Archives","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5738,"packageName":"African
+        by EP"},"selectedCount":56,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22440,"packageName":"Advertising
+        Periodicals, 1815-1888","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":297,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":297,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5188,"packageName":"African
+        American Archives","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5738,"packageName":"African
         American Historical Serials Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":177,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2552,"packageName":"Africa-Wide
-        Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2699,"packageName":"AgeLine
+        Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2699,"packageName":"AgeLine
         (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2681,"packageName":"Agricola
         (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22427,"packageName":"Agricultural
         Periodicals from the Northeastern U.S., 1789-1879","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":231,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22449,"packageName":"Agricultural
         Periodicals from the Southern, Midwestern, and Western U.S., 1800-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":188,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1376381,"packageName":"Agriculture
-        Plus","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":279,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":4270,"packageName":"AHFS
+        Plus","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":278,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":4270,"packageName":"AHFS
         Consumer Medication Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":2,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":500,"packageName":"Alt
         HealthWatch","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":192,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"selectedCount":192,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22428,"packageName":"Alternative
         Faith and Philosophy Periodicals, 1789-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":164,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1321944,"packageName":"Alternative
         Medicine and Health, 1810-1877","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":179,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:37 GMT
+  recorded_at: Thu, 15 Feb 2018 21:09:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-providers-related-packages-success-page2.yml
+++ b/spec/fixtures/vcr_cassettes/get-providers-related-packages-success-page2.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Thu, 25 Jan 2018 18:20:39 GMT
+      - Thu, 15 Feb 2018 21:01:37 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 354411us'
+        : 202 353834us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 42108us'
+        : 200 42654us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 151186/configurations
+      - 225375/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:39 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:37 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -139,27 +139,27 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:39 GMT
+      - Thu, 15 Feb 2018 21:01:37 GMT
       X-Amzn-Requestid:
-      - 72149d09-01fc-11e8-aee3-5148f924a944
+      - 69907fc7-1293-11e8-a0e8-1f6bec1ab36c
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:39 GMT
+      - Thu, 15 Feb 2018 21:01:37 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 d1c6b0af1d2d0f3694496e7cbde73924.cloudfront.net (CloudFront)
+      - 1.1 404d53add95aa4775e7d032723912171.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - svaBNwBdk7vYGWWW9LIbUAJKsFhJBY6rMgBaCrHzJ9lsB9DVwq2qNQ==
+      - nleVhxPA1wWEYljEVRhoGua9sT2Neuhyw0erpmXhBtpaTFifChwlDQ==
     body:
       encoding: UTF-8
-      string: '{"isCustomer":false,"packagesSelected":33,"packagesTotal":628,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
+      string: '{"isCustomer":false,"packagesSelected":38,"packagesTotal":632,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:39 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:37 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=2&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=2&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -188,19 +188,19 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:39 GMT
+      - Thu, 15 Feb 2018 21:01:37 GMT
       X-Amzn-Requestid:
-      - 7227d755-01fc-11e8-a2c2-414c3acc8671
+      - 69b71a25-1293-11e8-aef8-391b9458728a
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:38 GMT
+      - Thu, 15 Feb 2018 21:01:37 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 74f392c3bbde3f12fab5155d1847c2cd.cloudfront.net (CloudFront)
+      - 1.1 4044eed354d869010f01c2513b58d6da.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - TYT_jPX9TEX2E71shzinVDCQ0u2x5el4wQ61YnTrwbsWTdIQ0oUMOA==
+      - 9xzppSg1O42LZt61rh18sHzS9K2pZo_LFPQ6kYCyPMsu4CjAVzJSbQ==
     body:
       encoding: UTF-8
       string: '{"totalResults":628,"packagesList":[{"packageId":4242,"packageName":"Alternative
@@ -233,5 +233,5 @@ http_interactions:
         Theological Library Association (ATLA) Historical Monographs Collection: Series
         1","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":14729,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:39 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-providers-related-packages-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-providers-related-packages-success.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Thu, 25 Jan 2018 18:20:38 GMT
+      - Thu, 15 Feb 2018 21:01:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 348918us'
+        : 202 352691us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 41809us'
+        : 200 42994us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.0.1
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.36.0.1
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 633755/configurations
+      - 911604/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:38 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:36 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -139,27 +139,27 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:38 GMT
+      - Thu, 15 Feb 2018 21:01:36 GMT
       X-Amzn-Requestid:
-      - 71838111-01fc-11e8-b7c2-c9b5a042104c
+      - 68e30192-1293-11e8-a518-5b6bf8e2f160
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:38 GMT
+      - Thu, 15 Feb 2018 21:01:36 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5a27d8f87b0f1db56d469d1fefb312ac.cloudfront.net (CloudFront)
+      - 1.1 267a504f48f1bc76fa46685685b3432c.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - HK6sdlb-eu3gEmIfu0AOnVkmFVt7mJcYdAsnppLCq84DO9Ye-8rQMQ==
+      - W5lBMbpF82iQSGR9ApdVQuTDdqIRZxEx8eJyN8x2VpJXCQMV4z6xEA==
     body:
       encoding: UTF-8
       string: '{"isCustomer":false,"packagesSelected":33,"packagesTotal":628,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:38 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:36 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=1&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=1&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -188,19 +188,19 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 25 Jan 2018 18:20:38 GMT
+      - Thu, 15 Feb 2018 21:01:36 GMT
       X-Amzn-Requestid:
-      - 7194e638-01fc-11e8-b586-f75f36a4611b
+      - 68fca3a7-1293-11e8-9345-7146c30188b1
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amzn-Remapped-Date:
-      - Thu, 25 Jan 2018 18:20:37 GMT
+      - Thu, 15 Feb 2018 21:01:36 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 15b0145f4a440167477203d93c9e877a.cloudfront.net (CloudFront)
+      - 1.1 80db24d34a8214ca1ef4ec19a50b3cbb.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - iTDQRFy1y15xOZTXrLMnn2MEhIk-86s2mLmyIaqT5a0qW_QH5so7Ig==
+      - LzZLWVmlHTNnddQGM46rK9a-9lt8NHvNPcFlwfrPOeG7kgOR1AOqIA==
     body:
       encoding: UTF-8
       string: '{"totalResults":628,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
@@ -242,5 +242,5 @@ http_interactions:
         Faith and Philosophy Periodicals, 1789-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":164,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1321944,"packageName":"Alternative
         Medicine and Health, 1810-1877","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":179,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
     http_version: 
-  recorded_at: Thu, 25 Jan 2018 18:20:38 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-vendors-include-packages-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-vendors-include-packages-success.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 10 Jan 2018 21:11:11 GMT
+      - Thu, 15 Feb 2018 21:01:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 349911us'
+        : 202 356694us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 43489us'
+        : 200 42930us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 704216/configurations
+      - 263093/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:11 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:40 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -133,47 +133,33 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
-      - '116'
+      - '154'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:11 GMT
+      - Thu, 15 Feb 2018 21:01:40 GMT
       X-Amzn-Requestid:
-      - c8ce1023-f64a-11e7-af0c-5925d84ddf6d
-      X-Amzn-Remapped-Content-Length:
-      - '116'
+      - 6b1c9d70-1293-11e8-a27f-e34710e9a79a
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:40 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1ed98fc00b2a1a4ba9773a032570cc00.cloudfront.net (CloudFront)
+      - 1.1 d76bf0100595ded869c3bdda089e4c7a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 9MfG6eesoN_QKBdCw5W0LGGEoNeAZOMLnW0GOdpfHHacBLUdYw7qzA==
+      - 93eyD0rl8JdyihFEIAUA5EqsBinUW8tTDP4pvCgiRJq94ANRAZwJOw==
     body:
       encoding: UTF-8
-      string: '{"vendorId":19,"vendorName":"EBSCO","vendorToken":null,"isCustomer":false,"packagesTotal":628,"packagesSelected":27}'
+      string: '{"isCustomer":false,"packagesSelected":38,"packagesTotal":632,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:11 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:40 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=1&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=1&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -196,73 +182,68 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
-      - '8561'
+      - '9206'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:11 GMT
+      - Thu, 15 Feb 2018 21:01:40 GMT
       X-Amzn-Requestid:
-      - c900923f-f64a-11e7-a1e5-b762cd247c28
-      X-Amzn-Remapped-Content-Length:
-      - '8561'
+      - 6b3f19e8-1293-11e8-bb0c-7d174602aff1
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:11 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:40 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 7dd202542eedb4379b92613a759c7ff6.cloudfront.net (CloudFront)
+      - 1.1 80db24d34a8214ca1ef4ec19a50b3cbb.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - vePjD5-Ev-xDtHwCaDh551ambzB_JBL6akkFnjXw-DFUxgALIvBk6Q==
+      - sSlubtvA71oAkiolJv0CYkxwANU1gbBIisdE4oGwdDu9hCu4eNRd-g==
     body:
       encoding: UTF-8
-      string: '{"totalResults":628,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
+      string: '{"totalResults":632,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
         WORLD RELIGIONS","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2697501,"packageName":"ABC-CLIO
-        WORLD RELIGIONS - ACADEMIC ED","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2516,"packageName":"Abstracts
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2697501,"packageName":"ABC-CLIO
+        WORLD RELIGIONS - ACADEMIC ED","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2516,"packageName":"Abstracts
         in Social Gerontology","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"2018-01-04","endCoverage":""}},{"packageId":1073,"packageName":"Academic
-        Search Alumni Edition","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3755,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":3755,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1615,"packageName":"Academic
-        Search Complete","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":10666,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":158,"packageName":"Academic
-        Search Elite","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3520,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":3520,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1327231,"packageName":"Academic
-        Search Index","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":4065,"packageName":"Academic
-        Search Main Edition ","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3010,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":160,"packageName":"Academic
-        Search Premier","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":6137,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":6137,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2333054,"packageName":"Academic
-        Search Ultimate","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":13390,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":13390,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1153,"packageName":"Advanced
-        Placement Source","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":4347,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":6529,"packageName":"Advanstar
-        Communications Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":56,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":56,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":22440,"packageName":"Advertising
-        Periodicals, 1815-1888","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":297,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":5188,"packageName":"African
-        American Archives","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":5738,"packageName":"African
-        American Historical Serials Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":177,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2552,"packageName":"Africa-Wide
-        Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2699,"packageName":"AgeLine
-        (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":2681,"packageName":"Agricola
-        (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":22427,"packageName":"Agricultural
-        Periodicals from the Northeastern U.S., 1789-1879","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":231,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"selectedCount":230,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":22449,"packageName":"Agricultural
-        Periodicals from the Southern, Midwestern, and Western U.S., 1800-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":188,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1376381,"packageName":"Agriculture
-        Plus","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":279,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":4270,"packageName":"AHFS
-        Consumer Medication Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":2,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":500,"packageName":"Alt
-        HealthWatch","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":192,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":22428,"packageName":"Alternative
-        Faith and Philosophy Periodicals, 1789-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":164,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1321944,"packageName":"Alternative
-        Medicine and Health, 1810-1877","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":179,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1073,"packageName":"Academic
+        Search Alumni Edition","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3753,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":3753,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1615,"packageName":"Academic
+        Search Complete","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":10667,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":10665,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":158,"packageName":"Academic
+        Search Elite","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3522,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1327231,"packageName":"Academic
+        Search Index","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":4065,"packageName":"Academic
+        Search Main Edition ","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":3007,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":3007,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":160,"packageName":"Academic
+        Search Premier","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":6136,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":6136,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2333054,"packageName":"Academic
+        Search Ultimate","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":13402,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1153,"packageName":"Advanced
+        Placement Source","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":4343,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":6529,"packageName":"Advanstar
+        Communications Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":56,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"selectedCount":56,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22440,"packageName":"Advertising
+        Periodicals, 1815-1888","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":297,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":297,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5188,"packageName":"African
+        American Archives","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5738,"packageName":"African
+        American Historical Serials Collection","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":177,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2552,"packageName":"Africa-Wide
+        Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2699,"packageName":"AgeLine
+        (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2681,"packageName":"Agricola
+        (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22427,"packageName":"Agricultural
+        Periodicals from the Northeastern U.S., 1789-1879","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":231,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22449,"packageName":"Agricultural
+        Periodicals from the Southern, Midwestern, and Western U.S., 1800-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":188,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1376381,"packageName":"Agriculture
+        Plus","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":278,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":4270,"packageName":"AHFS
+        Consumer Medication Information","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":2,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":500,"packageName":"Alt
+        HealthWatch","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":192,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":192,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":22428,"packageName":"Alternative
+        Faith and Philosophy Periodicals, 1789-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":164,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":1321944,"packageName":"Alternative
+        Medicine and Health, 1810-1877","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":179,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:12 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-vendors-related-packages-success-page2.yml
+++ b/spec/fixtures/vcr_cassettes/get-vendors-related-packages-success-page2.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 10 Jan 2018 21:11:14 GMT
+      - Thu, 15 Feb 2018 21:01:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 356559us'
+        : 202 355157us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 43021us'
+        : 200 42504us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.2.1
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.36.2.1
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 294415/configurations
+      - 972154/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:14 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:42 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -133,47 +133,33 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '116'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:14 GMT
+      - Thu, 15 Feb 2018 21:01:42 GMT
       X-Amzn-Requestid:
-      - ca9a9330-f64a-11e7-bba9-ef2dc386a533
-      X-Amzn-Remapped-Content-Length:
-      - '116'
+      - 6c601aa9-1293-11e8-87d6-dd16673b2eb4
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:14 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:42 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 724ad4e1173fd5ccae88e687b8a9f430.cloudfront.net (CloudFront)
+      - 1.1 64a15e08bf29b0f17269963c144b4e8f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - __F95gcY81EIk1ahYFHe27Kp8FTZvNH1Bu9jAx9IGqXZZMoXd0UHGg==
+      - eiauNlqVSqbXtvydjCFfE56lHNNTY23r6F8bG0-xTa2Pnn7r_g2m4g==
     body:
       encoding: UTF-8
       string: '{"vendorId":19,"vendorName":"EBSCO","vendorToken":null,"isCustomer":false,"packagesTotal":628,"packagesSelected":27}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:14 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:42 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=2&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=2&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -196,39 +182,25 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '8980'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:14 GMT
+      - Thu, 15 Feb 2018 21:01:42 GMT
       X-Amzn-Requestid:
-      - cad24510-f64a-11e7-ab36-c5939488f560
-      X-Amzn-Remapped-Content-Length:
-      - '8980'
+      - 6c8afac8-1293-11e8-aaaa-8daf9272f5cb
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:14 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:42 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 7f3d624eb6fc6c8e9702f2193b2e7f1a.cloudfront.net (CloudFront)
+      - 1.1 404d53add95aa4775e7d032723912171.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - tgviHdIPSjl79RlEM0y34YHCkLyNzRdEDHdLuD8MjZQA-BmP6HWmnQ==
+      - Y4Ie42bJ3snwqEUFdstt09E94mUst1TJP2P4Fytx4bnBCXmeyeq2wg==
     body:
       encoding: UTF-8
       string: '{"totalResults":628,"packagesList":[{"packageId":4242,"packageName":"Alternative
@@ -261,5 +233,5 @@ http_interactions:
         Theological Library Association (ATLA) Historical Monographs Collection: Series
         1","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":14729,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:15 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-vendors-related-packages-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-vendors-related-packages-success.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 10 Jan 2018 21:11:12 GMT
+      - Thu, 15 Feb 2018 21:01:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
-        : 202 351945us'
+        : 202 356484us'
       - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
-        : 200 43454us'
+        : 200 43098us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 148625/configurations
+      - 126452/configurations
       X-Okapi-Url:
       - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "fa776aae-7473-4bf9-aa33-08f2a314cb04",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-02T15:56:49.186+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-02T15:56:49.186+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:12 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:41 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
@@ -133,47 +133,33 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '116'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:13 GMT
+      - Thu, 15 Feb 2018 21:01:41 GMT
       X-Amzn-Requestid:
-      - c9ac894e-f64a-11e7-95cc-b1db69647911
-      X-Amzn-Remapped-Content-Length:
-      - '116'
+      - 6bb77de3-1293-11e8-8314-814697ac311f
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:12 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:41 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c0ee97140ef471ebb86ca4054f8131cf.cloudfront.net (CloudFront)
+      - 1.1 a658139699129536c4b1341e7df68ce6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - oDiWas57Cy0T33RZgKdIbDtvXlKY2DXEddi_qHpgfurspB883Edceg==
+      - _Ui5HfoFS3_8JYTBVvdE0bD_dfsBWz5HUvNIt_gI1KTIod1pia1bIA==
     body:
       encoding: UTF-8
       string: '{"vendorId":19,"vendorName":"EBSCO","vendorToken":null,"isCustomer":false,"packagesTotal":628,"packagesSelected":27}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:13 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:41 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?count=25&offset=1&orderby=packagename&search=
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=25&offset=1&orderby=packagename&search=&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -196,39 +182,25 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '8561'
       Connection:
       - keep-alive
       Date:
-      - Wed, 10 Jan 2018 21:11:13 GMT
+      - Thu, 15 Feb 2018 21:01:41 GMT
       X-Amzn-Requestid:
-      - c9e09205-f64a-11e7-9b22-37d318e8939b
-      X-Amzn-Remapped-Content-Length:
-      - '8561'
+      - 6bdd2eaa-1293-11e8-8347-d7d2a30d9e34
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 10 Jan 2018 21:11:13 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:41 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 816ca09e5b67486f3629e8753062f768.cloudfront.net (CloudFront)
+      - 1.1 cc677e85c9c12859afa7439705918b57.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 3dQclD1TvoLfc0vEGkPAYKoOXiZOIJZdoVbTeZwSvU3_OPn76b60Ww==
+      - 7bmcl6xHLf_9Clhp9IwGcRowrtXgXYdRn2kN7vaObQJ06MaXZuhPzQ==
     body:
       encoding: UTF-8
       string: '{"totalResults":628,"packagesList":[{"packageId":2697502,"packageName":"ABC-CLIO
@@ -264,5 +236,5 @@ http_interactions:
         Faith and Philosophy Periodicals, 1789-1878","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":164,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":1321944,"packageName":"Alternative
         Medicine and Health, 1810-1877","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":179,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
     http_version: 
-  recorded_at: Wed, 10 Jan 2018 21:11:13 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages-filter-ebook-selection.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-filter-ebook-selection.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 15 Feb 2018 21:01:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 357483us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42546us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 161157/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 15 Feb 2018 21:01:31 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?contenttype=ebook&count=25&offset=1&orderby=relevance&search=ebsco&selection=selected
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '372'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 15 Feb 2018 21:01:32 GMT
+      X-Amzn-Requestid:
+      - 660cb01c-1293-11e8-9153-131d2dd57d70
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 15 Feb 2018 21:01:32 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 64a15e08bf29b0f17269963c144b4e8f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5G9svbbT7hp6I_HJW_9XKdVb1XbjVaEzMpl8SjFsT0lJM0FXhp2pcw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"packagesList":[{"packageId":5207,"packageName":"EBSCO
+        eBooks","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1382631,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1382631,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Selectable"}]}'
+    http_version: 
+  recorded_at: Thu, 15 Feb 2018 21:01:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages-filter-ebook.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-filter-ebook.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 15 Feb 2018 21:01:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 355165us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 43491us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.0.1
+      X-Forwarded-For:
+      - 10.36.0.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 026353/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 15 Feb 2018 21:01:30 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?contenttype=ebook&count=25&offset=1&orderby=relevance&search=ebsco&selection=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1752'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 15 Feb 2018 21:01:30 GMT
+      X-Amzn-Requestid:
+      - 656329fa-1293-11e8-91e5-eb7f5b4521cd
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 15 Feb 2018 21:01:30 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5ead76a58ac4f48d1b89fffd1e73667c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NY6fsGQlODDq1En3K3J1cdjgpGqFTDlZ-QLn30pF7VW9wWFY_JbwRA==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":5,"packagesList":[{"packageId":5207,"packageName":"EBSCO
+        eBooks","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1382631,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1382631,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Selectable"},{"packageId":2415701,"packageName":"EBSCO
+        eBooks 2008 (TAEBC)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":496,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2415702,"packageName":"EBSCO
+        eBooks 2009 (TAEBC)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":236,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2415703,"packageName":"EBSCO
+        eBooks 2010 (TAEBC)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":583,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2299217,"packageName":"EBSCO
+        eClassics Collection (EBSCOhost)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":25,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
+    http_version: 
+  recorded_at: Thu, 15 Feb 2018 21:01:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages-filter-invalid.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-filter-invalid.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 15 Feb 2018 21:01:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 363817us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 43636us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 289287/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 15 Feb 2018 21:01:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages-page2.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-page2.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 15 Dec 2017 23:11:29 GMT
+      - Thu, 15 Feb 2018 21:01:29 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
-        : 202'
-      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41408us'
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 351779us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42612us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.2.1
+      - 10.36.1.1
       X-Forwarded-For:
-      - 10.36.2.1
+      - 10.36.1.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,13 +66,13 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 461793/configurations
+      - 586393/configurations
       X-Okapi-Url:
-      - http://10.39.247.213:80
+      - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
       X-Okapi-Permissions:
       - '["configuration.entries.collection.get"]'
       X-Okapi-User-Id:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "0f7643e0-25b5-487a-816e-17484ec17e1b",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-12-12T18:31:12.750+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-12-12T18:31:12.750+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,10 +107,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 15 Dec 2017 23:11:30 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:29 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?count=25&offset=2&orderby=relevance&search=ebsco
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?contenttype=all&count=25&offset=2&orderby=relevance&search=ebsco&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -133,39 +133,25 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '8795'
       Connection:
       - keep-alive
       Date:
-      - Fri, 15 Dec 2017 23:11:30 GMT
+      - Thu, 15 Feb 2018 21:01:29 GMT
       X-Amzn-Requestid:
-      - 48bcc96a-e1ed-11e7-a2e8-fbde0637f4fd
-      X-Amzn-Remapped-Content-Length:
-      - '8795'
+      - 64dda5ac-1293-11e8-ab82-45b2d6b834e0
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 15 Dec 2017 23:11:30 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:28 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 586f1a150b4ba39f3a668b8055d4d5ea.cloudfront.net (CloudFront)
+      - 1.1 d69f6891c7ef74beef854ee879e6e419.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - ZL3S00bRlxvY8Jy3hioM6_gs6wh18RbLFm3KIzOIAhoSsyLW7BhmUA==
+      - HTOV66V5Xv_RnRtBcjIL9J8MaJqxXhQFIv2iZFgB_z2I1inwHgRmCg==
     body:
       encoding: UTF-8
       string: '{"totalResults":111,"packagesList":[{"packageId":1680,"packageName":"EBSCO
@@ -208,5 +194,5 @@ http_interactions:
         Religion Database (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":null,"endCoverage":null}},{"packageId":666,"packageName":"ATLA
         Religion Database with ATLASerials (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":328,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
     http_version: 
-  recorded_at: Fri, 15 Dec 2017 23:11:30 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 15 Dec 2017 23:11:28 GMT
+      - Thu, 15 Feb 2018 21:01:28 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
-        : 202'
-      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 42801us'
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 359168us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 45109us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.0.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.0.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,13 +66,13 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 127589/configurations
+      - 194340/configurations
       X-Okapi-Url:
-      - http://10.39.247.213:80
+      - http://10.39.248.95:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
       X-Okapi-Permissions:
       - '["configuration.entries.collection.get"]'
       X-Okapi-User-Id:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "0f7643e0-25b5-487a-816e-17484ec17e1b",
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-12-12T18:31:12.750+0000",
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-12-12T18:31:12.750+0000",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,10 +107,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 15 Dec 2017 23:11:28 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:28 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?count=25&offset=1&orderby=relevance&search=ebsco
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/packages?contenttype=all&count=25&offset=1&orderby=relevance&search=ebsco&selection=all
     body:
       encoding: US-ASCII
       string: ''
@@ -133,39 +133,25 @@ http_interactions:
       message: OK
     headers:
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json;charset=UTF-8
       Content-Length:
       - '8640'
       Connection:
       - keep-alive
       Date:
-      - Fri, 15 Dec 2017 23:11:29 GMT
+      - Thu, 15 Feb 2018 21:01:28 GMT
       X-Amzn-Requestid:
-      - 47df3b32-e1ed-11e7-98ec-c3172474c310
-      X-Amzn-Remapped-Content-Length:
-      - '8640'
+      - 642181c0-1293-11e8-8fd6-97e636f6bea2
       X-Amzn-Remapped-Connection:
       - keep-alive
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 15 Dec 2017 23:11:29 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
+      - Thu, 15 Feb 2018 21:01:28 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 15e35639aa606561dce966229363ebe8.cloudfront.net (CloudFront)
+      - 1.1 9c49cf68cf2287c443a3527dd202d688.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KZ9EnR9i28vexOSOL-nX8O6BcZEkHVIaFsUhUG_mQxzHEnzlYPiE0g==
+      - FYVbZs5p_5LKVPeW3EXPx26C4C-ceS1FO-51DK36WZMV4uQkd0r-Jg==
     body:
       encoding: UTF-8
       string: '{"totalResults":111,"packagesList":[{"packageId":6581,"packageName":"EBSCO
@@ -205,5 +191,5 @@ http_interactions:
         Open Access Journals","isCustom":false,"vendorId":273,"vendorName":"EBSCO
         Open Access Lists","titleCount":15654,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":null,"endCoverage":null}}]}'
     http_version: 
-  recorded_at: Fri, 15 Dec 2017 23:11:29 GMT
+  recorded_at: Thu, 15 Feb 2018 21:01:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Titles', type: :request do
 
       let!(:json_f) { Map JSON.parse response.body }
 
-      it 'gets a list of unselected book resources' do
+      it 'returns a bad request error' do
         expect(response).to have_http_status(400)
         expect(json_f.errors.first.title).to eql('Invalid filter parameter')
       end


### PR DESCRIPTION
## Purpose
Adds `filter[type]=contenttype` and `filter[selected]=selection` to package search params

## Approach
Mimicked title search filters for packages but with `contenttype` instead of `pubtype`

Also needed to re-record package search requests since this adds a couple of default params to all package search requests.
