### PR TITLE
Implement Provider Sort Options

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -4,7 +4,12 @@ class ProvidersController < ApplicationController
   before_action :set_provider, only: %i[show packages]
 
   def index
-    @providers = providers.all(q: params[:q], page: params[:page])
+    @providers = providers.all(
+      q: params[:q],
+      page: params[:page],
+      sort: params[:sort]
+    )
+
     render jsonapi: @providers.vendors.to_a,
            meta: { totalResults: @providers.totalResults }
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,8 +7,17 @@ class Provider < RmApiResource
   before_request do |name, request|
     if name == :all
       request.get_params[:search] = request.get_params.delete(:q)
-      request.get_params[:orderby] ||=
-        (request.get_params[:search] ? 'relevance' : 'vendorname')
+
+      sort = request.get_params.delete(:sort)
+      request.get_params[:orderby] =
+        if sort == 'relevance'
+          'relevance'
+        elsif sort == 'name'
+          'vendorname'
+        else
+          request.get_params[:search] ? 'relevance' : 'vendorname'
+        end
+
       request.get_params[:count] ||= 25
       request.get_params[:offset] = request.get_params[:page] || 1
       request.get_params.delete(:page)

--- a/spec/fixtures/vcr_cassettes/search-providers-sort-default.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-sort-default.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 22 Feb 2018 18:10:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 351614us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42522us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.0.1
+      X-Forwarded-For:
+      - 10.36.0.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 245038/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:56 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=higher%20education
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '3012'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 22 Feb 2018 18:10:56 GMT
+      X-Amzn-Requestid:
+      - ba2ea806-17fb-11e8-a14d-f33e2f407eb9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 22 Feb 2018 18:10:55 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 332c2a81639993be433911889dec5fcd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4XlHiPl9rclDFSOUB26oY7M7fZmM00eenqw00fPyQvXbT2sckHOzrw==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbFJlc3VsdHMiOjIwLCJ2ZW5kb3JzIjpbeyJ2ZW5kb3JJZCI6MTIzNTc5LCJ2ZW5kb3JOYW1lIjoiSGlnaGVyIEVkdWNhdGlvbiBQcmVzcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoyLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MjIxMjUsInZlbmRvck5hbWUiOiJBZnJpY2FuIEhpZ2hlciBFZHVjYXRpb24gUmVzZWFyY2ggKEFIRVJPKSIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NzM2NiwidmVuZG9yTmFtZSI6IkNocm9uaWNsZSBvZiBIaWdoZXIgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo5NTgsInZlbmRvck5hbWUiOiJPYnNlcnZhdG9yeSBvbiBCb3JkZXJsZXNzIEhpZ2hlciBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjg5MjM5LCJ2ZW5kb3JOYW1lIjoiQnJpZGdlbWFuIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIxNTkxLCJ2ZW5kb3JOYW1lIjoiQ2VudGVyIGZvciBPcGVuIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6OTMyNzUsInZlbmRvck5hbWUiOiJDb2xvcmFkbyBEZXBhcnRtZW50IG9mIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NDEyNSwidmVuZG9yTmFtZSI6IkNvbnNvcnRpdW0gZm9yIFBvbGljeSBSZXNlYXJjaCBpbiBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjExMTIsInZlbmRvck5hbWUiOiJEaXNjb3ZlcnkgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxNTMsInZlbmRvck5hbWUiOiJHZW5ldmEgRm91bmRhdGlvbiBmb3IgTWVkaWNhbCBFZHVjYXRpb24gYW5kIFJlc2VhcmNoIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMjM5MDQsInZlbmRvck5hbWUiOiJIb2RkZXIgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo3MTIsInZlbmRvck5hbWUiOiJJbnN0aXR1dGUgb2YgRWR1Y2F0aW9uIFNjaWVuY2VzIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMDM1LCJ2ZW5kb3JOYW1lIjoiSW93YSBBcmVhIEVkdWNhdGlvbiBBZ2VuY2llcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIzMjA1LCJ2ZW5kb3JOYW1lIjoiS29yZWEgRWR1Y2F0aW9uIFJlc2VhcmNoIEluZm9ybWF0aW9uIFNlcnZpY2UgKEtFUklTKSIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoyLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NTg3LCJ2ZW5kb3JOYW1lIjoiTUVOQzogVGhlIE5hdGlvbmFsIEFzc29jaWF0aW9uIGZvciBNdXNpYyBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjYxNCwidmVuZG9yTmFtZSI6Ik5hdGlvbmFsIEFzc29jaWF0aW9uIG9mIFN0YXRlIERpcmVjdG9ycyBvZiBUZWFjaGVyIEVkdWNhdGlvbiBhbmQgQ2VydGlmaWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIxNjkwLCJ2ZW5kb3JOYW1lIjoiTmF0aW9uYWwgRGFuY2UgRWR1Y2F0aW9uIE9yZ2FuaXphdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTEwMzE2LCJ2ZW5kb3JOYW1lIjoiT3B0aW11cyBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjY4NywidmVuZG9yTmFtZSI6IlNvdXRoZXJuIFB1YmxpYyBBZG1pbmlzdHJhdGlvbiBFZHVjYXRpb24gRm91bmRhdGlvbiAoU1BBRUYpIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo1OTI4NCwidmVuZG9yTmFtZSI6IumrmOetieaVmeiCsuefpeitmOW6qyBIaWdoZXIgRWR1Y2F0aW9uIFB1Ymxpc2hpbmcgQ28uLCBMdGQuIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-sort-name.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-sort-name.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 22 Feb 2018 18:10:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 362830us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 43793us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '068177/configurations'
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:54 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=vendorname&search=higher%20education
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '3012'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 22 Feb 2018 18:10:54 GMT
+      X-Amzn-Requestid:
+      - b927e6b4-17fb-11e8-8e0e-f5fc9aa6c07c
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 22 Feb 2018 18:10:54 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 571228f0590cddc7e73aed23e051dd65.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ylq16NYyHL0H1nFp73y1UC75gGFWg7aW0S_ajeekBtx-wUj8JswXGQ==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbFJlc3VsdHMiOjIwLCJ2ZW5kb3JzIjpbeyJ2ZW5kb3JJZCI6MjIxMjUsInZlbmRvck5hbWUiOiJBZnJpY2FuIEhpZ2hlciBFZHVjYXRpb24gUmVzZWFyY2ggKEFIRVJPKSIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6ODkyMzksInZlbmRvck5hbWUiOiJCcmlkZ2VtYW4gRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMjE1OTEsInZlbmRvck5hbWUiOiJDZW50ZXIgZm9yIE9wZW4gRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo3MzY2LCJ2ZW5kb3JOYW1lIjoiQ2hyb25pY2xlIG9mIEhpZ2hlciBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjkzMjc1LCJ2ZW5kb3JOYW1lIjoiQ29sb3JhZG8gRGVwYXJ0bWVudCBvZiBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjQxMjUsInZlbmRvck5hbWUiOiJDb25zb3J0aXVtIGZvciBQb2xpY3kgUmVzZWFyY2ggaW4gRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMTEyLCJ2ZW5kb3JOYW1lIjoiRGlzY292ZXJ5IEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTUzLCJ2ZW5kb3JOYW1lIjoiR2VuZXZhIEZvdW5kYXRpb24gZm9yIE1lZGljYWwgRWR1Y2F0aW9uIGFuZCBSZXNlYXJjaCIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIzNTc5LCJ2ZW5kb3JOYW1lIjoiSGlnaGVyIEVkdWNhdGlvbiBQcmVzcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoyLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIzOTA0LCJ2ZW5kb3JOYW1lIjoiSG9kZGVyIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NzEyLCJ2ZW5kb3JOYW1lIjoiSW5zdGl0dXRlIG9mIEVkdWNhdGlvbiBTY2llbmNlcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTAzNSwidmVuZG9yTmFtZSI6Iklvd2EgQXJlYSBFZHVjYXRpb24gQWdlbmNpZXMiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEyMzIwNSwidmVuZG9yTmFtZSI6IktvcmVhIEVkdWNhdGlvbiBSZXNlYXJjaCBJbmZvcm1hdGlvbiBTZXJ2aWNlIChLRVJJUykiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MiwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjU4NywidmVuZG9yTmFtZSI6Ik1FTkM6IFRoZSBOYXRpb25hbCBBc3NvY2lhdGlvbiBmb3IgTXVzaWMgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo2MTQsInZlbmRvck5hbWUiOiJOYXRpb25hbCBBc3NvY2lhdGlvbiBvZiBTdGF0ZSBEaXJlY3RvcnMgb2YgVGVhY2hlciBFZHVjYXRpb24gYW5kIENlcnRpZmljYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEyMTY5MCwidmVuZG9yTmFtZSI6Ik5hdGlvbmFsIERhbmNlIEVkdWNhdGlvbiBPcmdhbml6YXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjk1OCwidmVuZG9yTmFtZSI6Ik9ic2VydmF0b3J5IG9uIEJvcmRlcmxlc3MgSGlnaGVyIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTEwMzE2LCJ2ZW5kb3JOYW1lIjoiT3B0aW11cyBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjY4NywidmVuZG9yTmFtZSI6IlNvdXRoZXJuIFB1YmxpYyBBZG1pbmlzdHJhdGlvbiBFZHVjYXRpb24gRm91bmRhdGlvbiAoU1BBRUYpIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo1OTI4NCwidmVuZG9yTmFtZSI6IumrmOetieaVmeiCsuefpeitmOW6qyBIaWdoZXIgRWR1Y2F0aW9uIFB1Ymxpc2hpbmcgQ28uLCBMdGQuIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-sort-noquery.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-sort-noquery.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 22 Feb 2018 18:10:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 354128us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42106us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 228193/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:57 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=vendorname&search=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '3385'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 22 Feb 2018 18:10:57 GMT
+      X-Amzn-Requestid:
+      - baaab61e-17fb-11e8-a687-ef445310f803
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 22 Feb 2018 18:10:57 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d56db0d65906a3edce526dc6600d65c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - l_Of0LJodmybRUNpASVKx-NHA2Mq3uBbe-lP5DiRrLVqBkBHWTbqvg==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbFJlc3VsdHMiOjE3MTYsInZlbmRvcnMiOlt7InZlbmRvcklkIjo1ODI1MSwidmVuZG9yTmFtZSI6IjEyM0xpYnJhcnkiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEyMzUxNywidmVuZG9yTmFtZSI6IjFzY2llbmNlIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo4NTgsInZlbmRvck5hbWUiOiI0Q2FzdCBMVEQiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEyNjIxMCwidmVuZG9yTmFtZSI6IkFBQ0MgSW50ZXJuYXRpb25hbCIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NTcwMjcsInZlbmRvck5hbWUiOiJBQVJEUyAoQXVzdHJhbGlhbiBBZHZlcnRpc2luZyBSYXRlICYgRGF0YSBTZXJ2aWNlcykiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEwNzUsInZlbmRvck5hbWUiOiJBQkMgQ2hlbWlzdHJ5IiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjIsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo1ODMsInZlbmRvck5hbWUiOiJBQkMtQ0xJTyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjozMywicGFja2FnZXNTZWxlY3RlZCI6MSwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEwODcsInZlbmRvck5hbWUiOiJBYmR1bCBMYXRpZiBKYW1lZWwgUG92ZXJ0eSBBY3Rpb24gTGFiIChKLVBBTCkiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjcxOSwidmVuZG9yTmFtZSI6IkFiaWxlbmUgQ2hyaXN0aWFuIFVuaXZlcnNpdHkiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjI5MywidmVuZG9yTmFtZSI6IkFjYWRlbWljIEpvdXJuYWxzIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo1MjQsInZlbmRvck5hbWUiOiJBY2FkZW1pYyBMaWJyYXJ5IiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMjM1MTYsInZlbmRvck5hbWUiOiJBY2FkZW1pYyBSaWdodHMgUHJlc3MiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjMzNiwidmVuZG9yTmFtZSI6IkFjYWRlbWljIFNvY2lldHkgVmlsbGFnZS8g6rO87ZWZ6riw7Iig7ZWZ7ZqM66eI7J2EIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjIsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxNjU5LCJ2ZW5kb3JOYW1lIjoiQWNhZGVtaWMgU3R1ZGllcyBQcmVzcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MzQ3MTEsInZlbmRvck5hbWUiOiJBY2FkZW15IG9mIE51dHJpdGlvbiBhbmQgRGlldGV0aWNzIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjIsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoyMjMsInZlbmRvck5hbWUiOiJBY2Nlc3MgSW50ZWxsaWdlbmNlIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMzEsInZlbmRvck5hbWUiOiJBY2Nlc3NpYmxlIEFyY2hpdmVzIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjI2LCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTExNDYxLCJ2ZW5kb3JOYW1lIjoiQWNlcnRhL0p1cmlkaXNjaGUgUHVibGljYXRpZXMiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjExNzM2OSwidmVuZG9yTmFtZSI6IkFDSSBJbmZvcm1hdGlvbiBHcm91cCIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6OTE2MDYsInZlbmRvck5hbWUiOiJBY3RpdmVIaXN0b3J5LmNvLnVrIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo0MzcsInZlbmRvck5hbWUiOiJBZGFtIE1hdHRoZXcgRGlnaXRhbCBMdGQuIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjY1LCJwYWNrYWdlc1NlbGVjdGVkIjoxLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTEwNjY5LCJ2ZW5kb3JOYW1lIjoiQWRhbUNvcnAiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjExMTQzOSwidmVuZG9yTmFtZSI6IkFkZm9ybWF0aWUgR3JvdXAiLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjEyMzQ5MywidmVuZG9yTmFtZSI6IkFkdmFuY2VkIGVQdWJsaXNoaW5nIEluZnJhc3RydWN0dXJlcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6OTA4LCJ2ZW5kb3JOYW1lIjoiQWZyaWNhIFJlc291cmNlIENlbnRlciIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-sort-relevance.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-sort-relevance.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 22 Feb 2018 18:10:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.2.0-SNAPSHOT.14 http://10.39.255.104:8081/configurations/entries..
+        : 202 357077us'
+      - 'GET mod-configuration-4.0.1-SNAPSHOT.23 http://10.39.243.63:8081/configurations/entries..
+        : 200 42504us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.1.1
+      X-Forwarded-For:
+      - 10.36.1.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 352004/configurations
+      X-Okapi-Url:
+      - http://10.39.248.95:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.2.0-SNAPSHOT.14":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "c495bf9e-25f0-4c9a-9885-05f72f438df9",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-01-31T19:02:09.015+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-01-31T19:02:09.014+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:55 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=higher%20education
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '3012'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 22 Feb 2018 18:10:55 GMT
+      X-Amzn-Requestid:
+      - b9b1141f-17fb-11e8-9073-c3afbf3a1962
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amzn-Remapped-Date:
+      - Thu, 22 Feb 2018 18:10:55 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c89cbbc4e4ec6f9b44fad110d349819a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ZDRZkctOEdySMvVQkEuqVVwjYJtJ7veEUwuCNeOVYdDv0gq7WfEHoQ==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0b3RhbFJlc3VsdHMiOjIwLCJ2ZW5kb3JzIjpbeyJ2ZW5kb3JJZCI6MTIzNTc5LCJ2ZW5kb3JOYW1lIjoiSGlnaGVyIEVkdWNhdGlvbiBQcmVzcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoyLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MjIxMjUsInZlbmRvck5hbWUiOiJBZnJpY2FuIEhpZ2hlciBFZHVjYXRpb24gUmVzZWFyY2ggKEFIRVJPKSIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NzM2NiwidmVuZG9yTmFtZSI6IkNocm9uaWNsZSBvZiBIaWdoZXIgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo5NTgsInZlbmRvck5hbWUiOiJPYnNlcnZhdG9yeSBvbiBCb3JkZXJsZXNzIEhpZ2hlciBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjg5MjM5LCJ2ZW5kb3JOYW1lIjoiQnJpZGdlbWFuIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIxNTkxLCJ2ZW5kb3JOYW1lIjoiQ2VudGVyIGZvciBPcGVuIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6OTMyNzUsInZlbmRvck5hbWUiOiJDb2xvcmFkbyBEZXBhcnRtZW50IG9mIEVkdWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NDEyNSwidmVuZG9yTmFtZSI6IkNvbnNvcnRpdW0gZm9yIFBvbGljeSBSZXNlYXJjaCBpbiBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjExMTIsInZlbmRvck5hbWUiOiJEaXNjb3ZlcnkgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxNTMsInZlbmRvck5hbWUiOiJHZW5ldmEgRm91bmRhdGlvbiBmb3IgTWVkaWNhbCBFZHVjYXRpb24gYW5kIFJlc2VhcmNoIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMjM5MDQsInZlbmRvck5hbWUiOiJIb2RkZXIgRWR1Y2F0aW9uIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo3MTIsInZlbmRvck5hbWUiOiJJbnN0aXR1dGUgb2YgRWR1Y2F0aW9uIFNjaWVuY2VzIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjoxMDM1LCJ2ZW5kb3JOYW1lIjoiSW93YSBBcmVhIEVkdWNhdGlvbiBBZ2VuY2llcyIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIzMjA1LCJ2ZW5kb3JOYW1lIjoiS29yZWEgRWR1Y2F0aW9uIFJlc2VhcmNoIEluZm9ybWF0aW9uIFNlcnZpY2UgKEtFUklTKSIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoyLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6NTg3LCJ2ZW5kb3JOYW1lIjoiTUVOQzogVGhlIE5hdGlvbmFsIEFzc29jaWF0aW9uIGZvciBNdXNpYyBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjYxNCwidmVuZG9yTmFtZSI6Ik5hdGlvbmFsIEFzc29jaWF0aW9uIG9mIFN0YXRlIERpcmVjdG9ycyBvZiBUZWFjaGVyIEVkdWNhdGlvbiBhbmQgQ2VydGlmaWNhdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTIxNjkwLCJ2ZW5kb3JOYW1lIjoiTmF0aW9uYWwgRGFuY2UgRWR1Y2F0aW9uIE9yZ2FuaXphdGlvbiIsImlzQ3VzdG9tZXIiOmZhbHNlLCJwYWNrYWdlc1RvdGFsIjoxLCJwYWNrYWdlc1NlbGVjdGVkIjowLCJ2ZW5kb3JUb2tlbiI6bnVsbH0seyJ2ZW5kb3JJZCI6MTEwMzE2LCJ2ZW5kb3JOYW1lIjoiT3B0aW11cyBFZHVjYXRpb24iLCJpc0N1c3RvbWVyIjpmYWxzZSwicGFja2FnZXNUb3RhbCI6MSwicGFja2FnZXNTZWxlY3RlZCI6MCwidmVuZG9yVG9rZW4iOm51bGx9LHsidmVuZG9ySWQiOjY4NywidmVuZG9yTmFtZSI6IlNvdXRoZXJuIFB1YmxpYyBBZG1pbmlzdHJhdGlvbiBFZHVjYXRpb24gRm91bmRhdGlvbiAoU1BBRUYpIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfSx7InZlbmRvcklkIjo1OTI4NCwidmVuZG9yTmFtZSI6IumrmOetieaVmeiCsuefpeitmOW6qyBIaWdoZXIgRWR1Y2F0aW9uIFB1Ymxpc2hpbmcgQ28uLCBMdGQuIiwiaXNDdXN0b21lciI6ZmFsc2UsInBhY2thZ2VzVG90YWwiOjEsInBhY2thZ2VzU2VsZWN0ZWQiOjAsInZlbmRvclRva2VuIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 22 Feb 2018 18:10:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -44,6 +44,92 @@ RSpec.describe 'Providers', type: :request do
         expect(json2.data.first.relationships). to include('packages')
       end
     end
+
+    describe 'with alphabetical sorting' do
+      before do
+        VCR.use_cassette('search-providers-sort-name') do
+          get '/eholdings/providers/?q=higher%20education&sort=name',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_n) { Map JSON.parse response.body }
+
+      it 'contains a list of alphabetically A-Z sorted resources' do
+        expect(response).to have_http_status(200)
+        expect(json_n.data.length).to equal(20)
+        expect(json_n.meta.totalResults).to equal(20)
+        expect(json_n.data.first.type).to eq('providers')
+        sorted_array = json_n.data.sort_by { |p| p.attributes.name.downcase }
+        expect(json_n.data).to eq(sorted_array)
+      end
+    end
+
+    describe 'with relevance sorting' do
+      before do
+        VCR.use_cassette('search-providers-sort-relevance') do
+          get '/eholdings/providers/?q=higher%20education&sort=relevance',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_n) { Map JSON.parse response.body }
+
+      it 'contains a list of relevancy sorted resources' do
+        expect(response).to have_http_status(200)
+        expect(json_n.data.length).to equal(20)
+        expect(json_n.meta.totalResults).to equal(20)
+        expect(json_n.data.first.type).to eq('providers')
+        expect(json_n.data[0].attributes.name.downcase).to include(
+          'higher education'
+        )
+        sorted_array = json_n.data.sort_by { |p| p.attributes.name.downcase }
+        expect(json_n.data).not_to eq(sorted_array)
+      end
+    end
+
+    describe 'with default sorting' do
+      before do
+        VCR.use_cassette('search-providers-sort-default') do
+          get '/eholdings/providers/?q=higher%20education',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_n) { Map JSON.parse response.body }
+
+      it 'contains a list of relevancy sorted resources' do
+        expect(response).to have_http_status(200)
+        expect(json_n.data.length).to equal(20)
+        expect(json_n.meta.totalResults).to equal(20)
+        expect(json_n.data.first.type).to eq('providers')
+        expect(json_n.data[0].attributes.name.downcase).to include(
+          'higher education'
+        )
+        sorted_array = json_n.data.sort_by { |p| p.attributes.name.downcase }
+        expect(json_n.data).not_to eq(sorted_array)
+      end
+    end
+
+    describe 'with sorting and no query' do
+      before do
+        VCR.use_cassette('search-providers-sort-noquery') do
+          get '/eholdings/providers/',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_n) { Map JSON.parse response.body }
+
+      it 'contains a list of alphabetically sorted resources' do
+        expect(response).to have_http_status(200)
+        expect(json_n.data.length).to equal(25)
+        expect(json_n.meta.totalResults).to equal(1716)
+        expect(json_n.data.first.type).to eq('providers')
+        sorted_array = json_n.data.sort_by { |p| p.attributes.name.downcase }
+        expect(json_n.data).to eq(sorted_array)
+      end
+    end
   end
 
   describe 'getting a specific provider' do


### PR DESCRIPTION
## Purpose
Add support for `?sort=relevance` and `?sort=name` to `/eholdings/providers` endpoint
https://issues.folio.org/browse/UIEH-84

## Approach
- Support provider sort options which are translated into RM API `orderby` parameters. (relevance, vendorname) .
- Updates required to provider.rb and added associated tests with recordings.
- If a sort option is not supplied, it defaults to relevance (if a search is present) or vendorname (if a search is not present)
