### PR TITLE
Update error messages to sentence case instead of title case

### DIFF
--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -38,7 +38,7 @@ class Configuration
 
     return true if response.ok?
 
-    errors[:base] << 'RM-API Credentials Are Invalid'
+    errors[:base] << 'RM-API credentials are invalid'
   end
 
   def save

--- a/app/serializable/serializable_customer_resource.rb
+++ b/app/serializable/serializable_customer_resource.rb
@@ -128,7 +128,7 @@ class SerializableCustomerResource < SerializableResource
     visibility = @object.resource.visibilityData
     if visibility[:isHidden]
       visibility[:reason] =
-        visibility[:reason] == 'Hidden by EP' ? 'Set by System' : ''
+        visibility[:reason] == 'Hidden by EP' ? 'Set by system' : ''
     end
     visibility
   end

--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -38,7 +38,7 @@ class SerializablePackage < SerializableResource
 
     if visibility[:isHidden]
       visibility[:reason] =
-        visibility[:reason] == 'Hidden by EP' ? 'Set by System' : ''
+        visibility[:reason] == 'Hidden by EP' ? 'Set by system' : ''
     end
     visibility
   end

--- a/app/services/rm_api_service.rb
+++ b/app/services/rm_api_service.rb
@@ -76,7 +76,7 @@ class RmApiService
       return [] if ok?
       data.Errors.map { |err| { title: err.Message } }
     rescue StandardError
-      [{ title: 'Unhandled Error' }]
+      [{ title: 'Unhandled error' }]
     end
   end
 

--- a/spec/requests/customer_resources_spec.rb
+++ b/spec/requests/customer_resources_spec.rb
@@ -573,7 +573,7 @@ RSpec.describe 'Customer Resources', type: :request do
       expect(response).to have_http_status(200)
     end
     it 'has reason hidden by ep' do
-      expect(visibility.reason).to eq('Set by System')
+      expect(visibility.reason).to eq('Set by system')
     end
   end
 end

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'Packages', type: :request do
 
     it 'returns a valid visibility reason' do
       expect(json.data.attributes.visibilityData.reason).to(
-        eq('Set by System')
+        eq('Set by system')
       )
     end
   end
@@ -776,7 +776,7 @@ RSpec.describe 'Packages', type: :request do
       expect(response).to have_http_status(200)
     end
     it 'has reason hidden by customer' do
-      expect(visibility.reason).to eq('Set by System')
+      expect(visibility.reason).to eq('Set by system')
     end
   end
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-168, since FOLIO's standard is to use sentence case, modify error messages to use sentence case instead of title case. 

## Approach
- Since we cleaned up all error messages to be in sentence case, ui-eholdings can display them without further modification in ui.

## Screenshots
![sentence_case_backend](https://user-images.githubusercontent.com/33662516/37106946-0e254bec-2201-11e8-92bb-9d10f6e91e49.gif)

