### PR TITLE
Implement Custom Labels backend to be displayed in Settings page in ui-eholdings; GET, PUT and DELETE

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -15,6 +15,10 @@
           "pathPattern": "/eholdings/status"
         },
         {
+          "methods": [ "GET", "PUT", "DELETE" ],
+          "pathPattern": "/eholdings/custom-labels"
+        },
+        {
           "methods": [ "GET" ],
           "pathPattern": "/eholdings/vendors*"
         },

--- a/app/controllers/custom_labels_controller.rb
+++ b/app/controllers/custom_labels_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class CustomLabelsController < ApplicationController
+  def index
+    render jsonapi: custom_labels.all, include: params[:include]
+  end
+
+  def update # rubocop:disable Metrics/AbcSize
+    data_attributes = JSON.parse(request.body.read)['data']['attributes'] || {}
+    label_id = params[:id].to_i
+
+    custom_label_validation =
+      Validation::CustomLabelUpdateParameters.new(data_attributes, label_id)
+
+    if custom_label_validation.valid?
+      @custom_label = custom_labels.update(
+        label_id,
+        data_attributes
+      )
+      render jsonapi: @custom_label
+    else
+      render jsonapi_errors: custom_label_validation.errors,
+             status: :unprocessable_entity
+    end
+
+  # NoMethodError is raised when [] is invoked on 'data' or
+  # `data_attributes` and they are `nil`
+  rescue JSON::ParserError, NoMethodError
+    error = {
+      title: 'Invalid JSON',
+      detail: 'The provided JSON payload could not be parsed'
+    }
+
+    render jsonapi_errors: [error],
+           status: :unprocessable_entity
+  end
+
+  def destroy
+    label_id = params[:id].to_i
+
+    custom_label_validation =
+      Validation::CustomLabelDestroyParameters.new(label_id, custom_labels.all)
+
+    if custom_label_validation.valid?
+      custom_labels.delete(label_id)
+    else
+      render jsonapi_errors: custom_label_validation.errors,
+             status: :not_found
+    end
+  end
+
+  private
+
+  def custom_labels
+    CustomLabel.configure config
+  end
+end

--- a/app/controllers/validation/custom_label_destroy_parameters.rb
+++ b/app/controllers/validation/custom_label_destroy_parameters.rb
@@ -21,7 +21,7 @@ module Validation
       custom_label_list.each do |label|
         next unless label.id == label_id
         if label.display_label == ''
-          errors.add(:label_id, ':Label with this id does not exist')
+          errors.add(:label_id, ':Label with this id has already been deleted')
         end
       end
     end

--- a/app/controllers/validation/custom_label_destroy_parameters.rb
+++ b/app/controllers/validation/custom_label_destroy_parameters.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Validation
+  class CustomLabelDestroyParameters
+    include ActiveModel::Validations
+
+    attr_accessor :label_id, :custom_label_list
+
+    validates :label_id, presence: true
+    validate :label_id_range?
+    validate :label_deleted?
+
+    def label_id_range?
+      # there can be only 5 custom labels
+      errors.add(:label_id, ':Invalid custom label id') unless
+        label_id.to_i.between?(1, 5)
+    end
+
+    def label_deleted?
+      # check if the label has already been deleted
+      custom_label_list.each do |label|
+        next unless label.id == label_id
+        if label.display_label == ''
+          errors.add(:label_id, ':Label with this id does not exist')
+        end
+      end
+    end
+
+    def initialize(label_id, custom_label_list)
+      @label_id = label_id
+      @custom_label_list = custom_label_list
+    end
+  end
+end

--- a/app/controllers/validation/custom_label_update_parameters.rb
+++ b/app/controllers/validation/custom_label_update_parameters.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/VariableName
+
+module Validation
+  class CustomLabelUpdateParameters
+    include ActiveModel::Validations
+
+    attr_accessor :label_id,
+                  :id,
+                  :displayLabel,
+                  :displayOnFullTextFinder,
+                  :displayOnPublicationFinder
+
+    validates :displayLabel, :id, presence: true
+    validate :ids_match?
+    validate :id_range?
+    validates :displayOnFullTextFinder,
+              inclusion: { in: [true, false], message: 'Invalid value' }
+    validates :displayOnPublicationFinder,
+              inclusion: { in: [true, false], message: 'Invalid value' }
+
+    def ids_match?
+      # label_id is what is passed in the url
+      # id is what is passed in the payload
+      # this should be done in Rails 5 using the following syntax
+      # validates :id, numericality: { only_integer:true }
+      # But unfortunately, it does not work, hence this is needed
+      errors.add(:id, ':Label ids should match') unless
+        (id.is_a? Integer) && (id == label_id)
+    end
+
+    def id_range?
+      # there can be only 5 custom labels
+      errors.add(:id, ':Invalid custom label id') unless
+        id.to_i.between?(1, 5)
+    end
+
+    def initialize(params, label_id)
+      @label_id = label_id
+      # For consistency, this should be an integer
+      @id = params['id']
+      @displayLabel = params['displayLabel']
+      @displayOnFullTextFinder =
+        params['displayOnFullTextFinder']
+      @displayOnPublicationFinder =
+        params['displayOnPublicationFinder']
+    end
+  end
+end
+
+# rubocop:enable Naming/VariableName

--- a/app/models/custom_label.rb
+++ b/app/models/custom_label.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class CustomLabel
+  def initialize(attrs)
+    @attrs = attrs
+  end
+
+  def id
+    @attrs['id']
+  end
+
+  def display_label
+    @attrs['displayLabel']
+  end
+
+  def display_on_full_text_finder
+    @attrs['displayOnFullTextFinder']
+  end
+
+  def display_on_publication_finder
+    @attrs['displayOnPublicationFinder']
+  end
+
+  def self.all
+    rmapi_customer_root.all.labels.map { |attrs| new attrs }
+  end
+
+  def self.update(id, attrs)
+    root = rmapi_customer_root.all
+    root.update_label(id, attrs)
+    # return updated custom label
+    new attrs
+  end
+
+  def self.delete(id)
+    root = rmapi_customer_root.all
+    root.delete_label(id)
+  end
+
+  def self.configure(config)
+    configured = Class.new(self)
+    # JSONAPI blows up if we use an anonymous class because its
+    # renderer needs class name
+    name = self.name
+    configured.send(:define_singleton_method, :name) { name }
+    configured.send(:define_singleton_method, :rmapi_customer_root) do
+      @rmapi_customer_root ||= RmApiCustomerRoot.configure(config)
+    end
+    configured
+  end
+end

--- a/app/models/rm_api_customer_root.rb
+++ b/app/models/rm_api_customer_root.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class RmApiCustomerRoot < RmApiResource
+  request_body_type :json
+
+  get :all, '/'
+  put :update, '/'
+
+  def update_label(label_id, attrs)
+    # prune the root to not include labels with displayLabel=""
+    # because RM API would throw an error in PUT request
+    prune(label_id)
+    # patch in the new object here
+    patch(label_id, attrs)
+    # update the root
+    update
+  end
+
+  def prune(id)
+    labels.delete_if { |item| item.id != id && item.displayLabel == '' }
+  end
+
+  def patch(id, attrs)
+    labels.each do |label|
+      next unless label.id == id
+      label.displayLabel = attrs['displayLabel']
+      label.displayOnFullTextFinder = attrs['displayOnFullTextFinder']
+      label.displayOnPublicationFinder = attrs['displayOnPublicationFinder']
+    end
+  end
+
+  def delete_label(label_id)
+    # prune the root to not include labels with displayLabel=""
+    # because RM API would throw an error in PUT request
+    prune(label_id)
+    # delete the object that mathces the id
+    delete(label_id)
+    # update the root
+    update
+  end
+
+  def delete(label_id)
+    # delete a custom label if it matches id passed in
+    labels.delete_if { |item| item.id == label_id }
+  end
+end

--- a/app/serializable/serializable_custom_label.rb
+++ b/app/serializable/serializable_custom_label.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SerializableCustomLabel < SerializableResource
+  type 'customLabel'
+
+  # Custom Label attributes
+  attributes :id,
+             :display_label,
+             :display_on_full_text_finder,
+             :display_on_publication_finder
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,10 @@ Rails.application.routes.draw do
               path: '/customer-resources',
               only: %i[show update]
 
+    resources :custom_labels,
+              path: '/custom-labels',
+              only: %i[index update destroy]
+
     resource :configuration, only: %i[show update]
     resource :status, only: [:show]
   end

--- a/spec/fixtures/vcr_cassettes/delete-custom-labels-bad-request.yml
+++ b/spec/fixtures/vcr_cassettes/delete-custom-labels-bad-request.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 03 Apr 2018 19:56:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 363120us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43149us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 753722/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:56:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '560'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 03 Apr 2018 19:56:53 GMT
+      X-Amzn-Requestid:
+      - 27d9b679-3779-11e8-b960-738f23f76e37
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ex9k1E7pIAMFQSg=
+      X-Amzn-Remapped-Date:
+      - Tue, 03 Apr 2018 19:56:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ded72cd2ec35ccfc935b5442dfad81c9.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mMLoAHXl5e2krMAZ9VsAp5gEYrmxbThZLncfqL_fZOxMGSAYMD8ypQ==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"<n>"},"labels":[{"id":1,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:56:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-custom-labels-success.yml
+++ b/spec/fixtures/vcr_cassettes/delete-custom-labels-success.yml
@@ -1,0 +1,275 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 03 Apr 2018 19:52:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 361111us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 46668us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 431087/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:52:48 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '582'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 03 Apr 2018 19:52:48 GMT
+      X-Amzn-Requestid:
+      - 95e843ee-3778-11e8-b5f3-7d5081e1bbfe
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ex8-lEIKIAMFSiQ=
+      X-Amzn-Remapped-Date:
+      - Tue, 03 Apr 2018 19:52:48 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 da6fd4689552fc29462fc5d11b2e27dd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pm3jvS29XMDYuHVL_VZAre5NIJ2Js1Chk9A7tWrPwZXUVODOiCf_vg==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"<n>"},"labels":[{"id":1,"displayLabel":"Hello 1st label
+        testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:52:48 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '582'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 03 Apr 2018 19:52:48 GMT
+      X-Amzn-Requestid:
+      - 96108b96-3778-11e8-954b-431730647470
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ex8-oGoaIAMFfPQ=
+      X-Amzn-Remapped-Date:
+      - Tue, 03 Apr 2018 19:52:48 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8afd14030d0efa39cea23517afb3058c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0SpkAYmz4i9Kd90Zz42TeCLdJRDepeSgYzZ-jsFFhuNHslfpKvE4sA==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"<n>"},"labels":[{"id":1,"displayLabel":"Hello 1st label
+        testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:52:48 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"\u003cn\u003e"},"labels":[{"id":2,"displayLabel":"Hello
+        2nd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 03 Apr 2018 19:52:50 GMT
+      X-Amzn-Requestid:
+      - 96a922e7-3778-11e8-bbe3-a1f44f4328f9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ex8-yEpHoAMF2rw=
+      X-Amzn-Remapped-Date:
+      - Tue, 03 Apr 2018 19:52:50 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 da6fd4689552fc29462fc5d11b2e27dd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hQFaXWOLLJP5u3auDbVV8P9uvM1-FjWmOmUZUmymQYSsdAipSvvq1w==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:52:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-custom-labels-unprocessable-request.yml
+++ b/spec/fixtures/vcr_cassettes/delete-custom-labels-unprocessable-request.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 03 Apr 2018 19:58:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 363135us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 44349us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 052336/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:58:25 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '560'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 03 Apr 2018 19:58:26 GMT
+      X-Amzn-Requestid:
+      - 5f1d3427-3779-11e8-b165-dfeb0eef1983
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ex9zVFqtoAMFkcw=
+      X-Amzn-Remapped-Date:
+      - Tue, 03 Apr 2018 19:58:26 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 56347d7c38419a198890fcdfedd638c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Vs2pXJGAZtoRaA1Ss_LfF3a6tF-jkNs61A3ivNMGcklr3Hym-fXdKg==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"<n>"},"labels":[{"id":1,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label testing","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Tue, 03 Apr 2018 19:58:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-custom-labels-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-custom-labels-success.yml
@@ -1,0 +1,167 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 23 Mar 2018 14:49:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.247.20:8081/configurations/entries..
+        : 202 381546us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.248.16:8081/configurations/entries..
+        : 200 45628us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 178760/configurations
+      X-Okapi-Url:
+      - http://10.39.253.90:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "f319326e-a420-440d-b034-4f4a62619cb4",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-16T05:38:48.299+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-16T05:38:48.299+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 08:38:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '582'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 23 Mar 2018 14:49:05 GMT
+      X-Amzn-Requestid:
+      - 558a2e5e-2ea9-11e8-a96d-6f9240e3352e
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - ENALOFlhIAMFqKw=
+      X-Amzn-Remapped-Date:
+      - Fri, 23 Mar 2018 14:49:05 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 83d82856eafc6ceb7ba06a257022fa7c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - D2vASv_rAlfBIm2_r_ZKckHraJ8yP2VkWGZDuzvO3e5IauaabiQ_2Q==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        awesome label","displayOnFullTextFinder":false,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"Hello
+        grr label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false}]}'
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 08:38:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-label-update-third.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-label-update-third.yml
@@ -1,0 +1,223 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 23 Mar 2018 20:43:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.247.20:8081/configurations/entries..
+        : 202 364521us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.248.16:8081/configurations/entries..
+        : 200 44958us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 418935/configurations
+      X-Okapi-Url:
+      - http://10.39.253.90:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "f319326e-a420-440d-b034-4f4a62619cb4",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-16T05:38:48.299+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-16T05:38:48.299+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 14:33:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '580'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 23 Mar 2018 20:43:48 GMT
+      X-Amzn-Requestid:
+      - e2ae1e10-2eda-11e8-964c-0371b853c5c8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EN0IjEWxIAMFq9w=
+      X-Amzn-Remapped-Date:
+      - Fri, 23 Mar 2018 20:43:48 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 488ca64b2230001b81f1cbf87d34963b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - k4T17D4fzvyna__HAymM1F6gVg5EghKwbbZA9rcp89wecOJhhSee0w==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":4,"displayLabel":"Hello
+        fourth label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false}]}'
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 14:33:11 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":3,"displayLabel":"Hello
+        third label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        fourth label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 23 Mar 2018 20:43:49 GMT
+      X-Amzn-Requestid:
+      - e3769dcf-2eda-11e8-812f-bd261ebaa10c
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EN0IwFe8IAMFgSQ=
+      X-Amzn-Remapped-Date:
+      - Fri, 23 Mar 2018 20:43:48 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2206fe1cc0579e0d79537b15799c4e2f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7Je-A8HtsxlMtGDxnPJLsb6Mvww43Zn6yM6_YWMEzSOivwFg94s18Q==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 14:33:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_labels_spec.rb
+++ b/spec/requests/custom_labels_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Custom Labels', type: :request do
+  describe 'getting custom labels' do
+    before do
+      VCR.use_cassette('get-custom-labels-success') do
+        get '/eholdings/custom-labels',
+            headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+    let!(:attributes) { json.data.first.attributes }
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(200)
+    end
+    it "is of type 'customLabel'" do
+      expect(json.data.first.type).to eq('customLabel')
+    end
+    it 'has 5 custom labels' do
+      expect(json.data.length).to eq(5)
+    end
+
+    describe 'check each custom label attributes' do
+      it 'has id key' do
+        expect(attributes).to have_key(:id)
+      end
+      it 'has display label key' do
+        expect(attributes).to have_key(:displayLabel)
+      end
+      it 'has display on full text finder key' do
+        expect(attributes).to have_key(:displayOnFullTextFinder)
+      end
+      it 'has display on publication finder key' do
+        expect(attributes).to have_key(:displayOnPublicationFinder)
+      end
+    end
+  end
+
+  describe 'updating a custom label' do
+    let(:update_headers) do
+      okapi_headers.merge(
+        'Content-Type': 'application/vnd.api+json'
+      )
+    end
+
+    describe 'update the third custom label among five' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => '3',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 3,
+              'displayLabel' => 'Hello third label',
+              'displayOnFullTextFinder' => true,
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-update-third') do
+          put '/eholdings/custom-labels/3',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'gets a successful response' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      describe 'check attributes of updated custom label' do
+        it 'has id of 3' do
+          expect(attributes.id).to eq(3)
+        end
+        it 'has display label key that matches the recent update' do
+          expect(attributes.displayLabel).to eq('Hello third label')
+        end
+        it 'has display on full text finder key' do
+          expect(attributes.displayOnFullTextFinder).to eq(true)
+        end
+        it 'has display on publication finder key' do
+          expect(attributes.displayOnPublicationFinder).to eq(true)
+        end
+      end
+    end
+
+    describe 'update an invalid custom label' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 7,
+              'displayLabel' => 'Hello seventh label',
+              'displayOnFullTextFinder' => true,
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-update-seventh') do
+          put '/eholdings/custom-labels/7',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a custom label with non-matching ids' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 7,
+              'displayLabel' => 'Hello seventh label',
+              'displayOnFullTextFinder' => true,
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-non-matching') do
+          put '/eholdings/custom-labels/2',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a custom label where path param id is invalid' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 'blob',
+              'displayLabel' => 'Hello blob label',
+              'displayOnFullTextFinder' => true,
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-update-blob') do
+          put '/eholdings/custom-labels/2',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a custom label without all parameters' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 'blob',
+              'displayLabel' => 'Hello blob label',
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-without-all-parameters') do
+          put '/eholdings/custom-labels/2',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a custom label with empty display label' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+              'id' => 3,
+              'displayLabel' => '',
+              'displayOnPublicationFinder' => true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-with-empty-display-label') do
+          put '/eholdings/custom-labels/3',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a custom label without a body' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'customLabel',
+            'type' => 'customLabel',
+            'attributes' => {
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-label-with-empty-body') do
+          put '/eholdings/custom-labels/3',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe 'deleting a custom label that exists and is valid' do
+    before do
+      VCR.use_cassette('delete-custom-labels-success') do
+        delete '/eholdings/custom-labels/1',
+               headers: okapi_headers
+      end
+    end
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(204)
+    end
+  end
+
+  describe 'deleting a custom label that is already deleted' do
+    before do
+      VCR.use_cassette('delete-custom-labels-bad-request') do
+        delete '/eholdings/custom-labels/1',
+               headers: okapi_headers
+      end
+    end
+
+    it 'gets a resource not found status as response' do
+      expect(response).to have_http_status(404)
+    end
+  end
+
+  describe 'deleting a custom label that is invalid' do
+    before do
+      VCR.use_cassette('delete-custom-labels-unprocessable-request') do
+        delete '/eholdings/custom-labels/10',
+               headers: okapi_headers
+      end
+    end
+
+    it 'gets a resource not found status as response' do
+      expect(response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-203, users should be able to view and edit custom labels from the Settings page in ui-eholdings. This work in the backend allows ui to get and put custom label related data. 

## Approach
- Added code to get custom label information from RM API. This also gets "root proxy" information and we prune it at Serializable level
- To get a list of custom labels from mod-kb-ebsco: GET /eholdings/custom-labels/
- Added code to put custom label data to RM API. RM API needs "root proxy" and all 5 custom labels data in a PUT call, if we do not submit all, then it resets them. From ui-eholdings, in order to be able to update on a per custom label basis, in mod-kb-ebsco, we do a GET call prior to PUT, prune the information from the GET to not contain any custom labels that have a null "displayLabel", patch the data from the request body of the PUT call to the information from GET and send it to RM API as a PUT. 
- To PUT custom label in mod-kb-ebsco: PUT /eholdings/custom-labels/{id}
- Sample request body for put request ```{
  "data": {
    "id": "1",
    "type": "customLabel",
    "attributes": {
      "id": 1,
      "displayLabel": "Hello first label testing",
      "displayOnFullTextFinder": true,
      "displayOnPublicationFinder": false
    }
  }
}```
- Added associated unit tests for the GET and PUT calls and took care of Rubocop suggestions.
- Added code for incoming param validation and its associated tests
- Added support for deleting a custom label, validations and its associated unit tests
- To delete a custom label using mod-kb-ebsco: DELETE /eholdings/custom-labels/{id}; no request body is required; if the deletion is successful, 204 is returned, if the label we are trying to delete does not exist, 404 is returned.

## Learning
- Flexirest API, specially, ResultIterator
- Ruby on Rails tutorials to understand routing
- Ruby syntax as and when needed

## Screenshots
![custom_label_delete](https://user-images.githubusercontent.com/33662516/38274226-2527e97e-375c-11e8-99c7-e0b2d26ee308.gif)


