### PR TITLE
Implement GET and PUT for root proxy to be used from Settings in ui-eholdings

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -19,6 +19,10 @@
           "pathPattern": "/eholdings/custom-labels"
         },
         {
+          "methods": [ "GET", "PUT" ],
+          "pathPattern": "/eholdings/root-proxies"
+        },
+        {
           "methods": [ "GET" ],
           "pathPattern": "/eholdings/vendors*"
         },

--- a/app/controllers/root_proxies_controller.rb
+++ b/app/controllers/root_proxies_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class RootProxiesController < ApplicationController
+  def index
+    render jsonapi: root_proxies.all, include: params[:include]
+  end
+
+  def update # rubocop:disable Metrics/AbcSize
+    data_attributes = JSON.parse(request.body.read)['data']['attributes'] || {}
+    root_proxy_id = params[:id]
+
+    root_proxy_validation =
+      Validation::RootProxyParameters.new(data_attributes,
+                                          root_proxy_id,
+                                          root_proxies.all)
+
+    if root_proxy_validation.valid?
+      @root_proxy = root_proxies.update(
+        data_attributes
+      )
+      render jsonapi: @root_proxy
+    else
+      render jsonapi_errors: root_proxy_validation.errors,
+             status: :unprocessable_entity
+    end
+  # NoMethodError is raised when [] is invoked on 'data' or
+  # `data_attributes` and they are `nil`
+  rescue JSON::ParserError, NoMethodError
+    error = {
+      title: 'Invalid JSON',
+      detail: 'The provided JSON payload could not be parsed'
+    }
+
+    render jsonapi_errors: [error],
+           status: :unprocessable_entity
+  end
+
+  private
+
+  def root_proxies
+    RootProxy.configure config
+  end
+end

--- a/app/controllers/validation/root_proxy_parameters.rb
+++ b/app/controllers/validation/root_proxy_parameters.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Validation
+  class RootProxyParameters
+    include ActiveModel::Validations
+
+    attr_accessor :root_proxy_id,
+                  :id,
+                  :root_proxies_list
+
+    validates :id, presence: true
+    validate :ids_match?
+    validate :id_valid?
+
+    def ids_match?
+      # root_proxy_id is what is passed in the url
+      # id is what is passed in the payload
+      errors.add(:id, ':ids in url and body should match') unless
+        (id.is_a? String) && (id == root_proxy_id)
+    end
+
+    def id_valid?
+      errors.add(:id, ':Invalid proxy') unless
+        root_proxy_valid
+    end
+
+    def root_proxy_valid
+      # root proxy passed in should be part of the
+      # customer's root proxy list
+      is_valid = false
+      root_proxies_list.each do |root_proxy|
+        if root_proxy.id == root_proxy_id
+          is_valid = true
+          break
+        end
+      end
+      is_valid
+    end
+
+    def initialize(params, root_proxy_id, root_proxies_list)
+      @root_proxy_id = root_proxy_id
+      @id = params['id']
+      @root_proxies_list = root_proxies_list
+    end
+  end
+end

--- a/app/models/rm_api_customer_root.rb
+++ b/app/models/rm_api_customer_root.rb
@@ -6,6 +6,7 @@ class RmApiCustomerRoot < RmApiResource
   get :all, '/'
   put :update, '/'
 
+  # method to update custom label
   def update_label(label_id, attrs)
     # prune the root to not include labels with displayLabel=""
     # because RM API would throw an error in PUT request
@@ -16,10 +17,12 @@ class RmApiCustomerRoot < RmApiResource
     update
   end
 
+  # method to prune the request before updating custom labels
   def prune(id)
     labels.delete_if { |item| item.id != id && item.displayLabel == '' }
   end
 
+  # patching the custom label request
   def patch(id, attrs)
     labels.each do |label|
       next unless label.id == id
@@ -42,5 +45,19 @@ class RmApiCustomerRoot < RmApiResource
   def delete(label_id)
     # delete a custom label if it matches id passed in
     labels.delete_if { |item| item.id == label_id }
+  end
+
+  # method to update root proxy selection
+  def update_root_proxy_selection(attrs)
+    # update root proxy with the passed value in request
+    proxy.id = attrs['id']
+    # In RM API, custom labels and root proxy are part of one call
+    # we get the data, update what we need and send the data back to not lose it
+    # In the get call to RM API, we get display labels that are empty
+    # prune any custom labels that do not have display labels; if we do not
+    # prune RM API throws an error
+    labels.delete_if { |item| item.displayLabel == '' }
+    # update the root
+    update
   end
 end

--- a/app/models/rm_api_customer_root_proxy.rb
+++ b/app/models/rm_api_customer_root_proxy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RmApiCustomerRootProxy < RmApiResource
+  request_body_type :json
+
+  get :all, '/proxies'
+end

--- a/app/models/root_proxy.rb
+++ b/app/models/root_proxy.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class RootProxy
+  def initialize(attrs, selected_root_proxy)
+    @attrs = attrs
+    @selected_root_proxy = selected_root_proxy
+  end
+
+  def id
+    @attrs['id']
+  end
+
+  def name
+    @attrs['name']
+  end
+
+  def url_mask
+    @attrs['urlMask']
+  end
+
+  def selected
+    if id == @selected_root_proxy['id']
+      @attrs['selected'] = true
+    else
+      false
+    end
+  end
+
+  def self.all
+    rmapi_customer_root_proxies = rmapi_customer_root_proxy.all
+    selected_root_proxy = rmapi_customer_root.all.proxy
+    rmapi_customer_root_proxies.map { |attrs| new attrs, selected_root_proxy }
+  end
+
+  def self.update(attrs)
+    root = rmapi_customer_root.all
+    root.update_root_proxy_selection(attrs)
+    # Get the root proxy after update
+    selected_root_proxy = rmapi_customer_root.all.proxy
+    # return updated selection of root proxy
+    new attrs, selected_root_proxy
+  end
+
+  def self.configure(config)
+    configured = Class.new(self)
+    # JSONAPI blows up if we use an anonymous class because its
+    # renderer needs class name
+    name = self.name
+    configured.send(:define_singleton_method, :name) { name }
+    configured.send(:define_singleton_method, :rmapi_customer_root) do
+      @rmapi_customer_root ||= RmApiCustomerRoot.configure(config)
+    end
+    configured.send(:define_singleton_method, :rmapi_customer_root_proxy) do
+      @rmapi_customer_root_proxy ||= RmApiCustomerRootProxy.configure(config)
+    end
+    configured
+  end
+end

--- a/app/serializable/serializable_root_proxy.rb
+++ b/app/serializable/serializable_root_proxy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SerializableRootProxy < SerializableResource
+  type 'rootProxy'
+
+  # Custom Label attributes
+  attributes :id,
+             :name,
+             :url_mask,
+             :selected
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,10 @@ Rails.application.routes.draw do
               path: '/custom-labels',
               only: %i[index update destroy]
 
+    resources :root_proxies,
+              path: '/root-proxies',
+              only: %i[index update]
+
     resource :configuration, only: %i[show update]
     resource :status, only: [:show]
   end

--- a/spec/fixtures/vcr_cassettes/get-root-proxies-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-root-proxies-success.yml
@@ -1,0 +1,218 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 29 Mar 2018 19:50:28 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 374216us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 56019us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 242363/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 29 Mar 2018 19:50:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/proxies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '140'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 29 Mar 2018 19:50:28 GMT
+      X-Amzn-Requestid:
+      - 6e75fe1f-338a-11e8-bc0f-6b35a9c20d66
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ehd8uG5HIAMFcLw=
+      X-Amzn-Remapped-Date:
+      - Thu, 29 Mar 2018 19:50:28 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4a9cf7d692d7309a16ebde15ef85ff54.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mzFOGar7kxX39e4gHxn8JRkcKNXyZFviCSRRfOiAEtxAWpMJEkDqyg==
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<n>","name":"None","urlMask":""},{"id":"EZProxy","name":"EZProxy","urlMask":"http://ezproxy.myinstitute.edu/login?url={targetURL}"}]'
+    http_version: 
+  recorded_at: Thu, 29 Mar 2018 19:50:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 29 Mar 2018 19:50:29 GMT
+      X-Amzn-Requestid:
+      - 6ea21777-338a-11e8-b1b7-6f742fefc63f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Ehd8xGG8oAMFsYg=
+      X-Amzn-Remapped-Date:
+      - Thu, 29 Mar 2018 19:50:28 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ac3474fe463b33f1439c8d949f9a075f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2BJak5_dzS4vt2X7thJAd5Uiti2jXJOpMZJpbYNhBgYEgiMUAaxUIA==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Thu, 29 Mar 2018 19:50:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-root-proxy-invalid.yml
+++ b/spec/fixtures/vcr_cassettes/put-root-proxy-invalid.yml
@@ -1,0 +1,218 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 02 Apr 2018 18:56:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 395093us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 47096us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 408915/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:49:55 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/proxies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '140'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 18:56:05 GMT
+      X-Amzn-Requestid:
+      - 7eca8519-36a7-11e8-904e-89f6df52718b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuhuxGivIAMFeCw=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 18:56:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 15b0145f4a440167477203d93c9e877a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dFZVerhnIrvdWIlEYS9CpkhgDxRz-dYea0RoQfVfet4S1-cOf28oBQ==
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<n>","name":"None","urlMask":""},{"id":"EZProxy","name":"EZProxy","urlMask":"http://ezproxy.myinstitute.edu/login?url={targetURL}"}]'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:49:55 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 18:56:05 GMT
+      X-Amzn-Requestid:
+      - 7ef5b3f6-36a7-11e8-bd35-03c541c3939a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Euhu0GgyIAMFZxw=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 18:56:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8afd14030d0efa39cea23517afb3058c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hfDenFviuJAmoHF7LroqR7Xb1k4y_RFTpMhsa-o7hGdEC7eh4C5m4A==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:49:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-root-proxy-non-matching.yml
+++ b/spec/fixtures/vcr_cassettes/put-root-proxy-non-matching.yml
@@ -1,0 +1,218 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 02 Apr 2018 19:06:28 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 398766us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 45210us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 281343/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:19 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/proxies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '140'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Amzn-Requestid:
+      - f2b369ac-36a8-11e8-8544-5fb4ffc2f5d3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EujQRHyvoAMFntw=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 441af0d1342facc04e278fcc912c699d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sY2KlBlvfA4uliKL10BiKpyxuuXSGiO7eYkaATXIDhF4xMjjwdk5Og==
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<n>","name":"None","urlMask":""},{"id":"EZProxy","name":"EZProxy","urlMask":"http://ezproxy.myinstitute.edu/login?url={targetURL}"}]'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:19 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Amzn-Requestid:
+      - f2d80939-36a8-11e8-b5f3-7d5081e1bbfe
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EujQTE38oAMFSiQ=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ded72cd2ec35ccfc935b5442dfad81c9.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rN76m9RvLAJZr3KSqWEivsGyEp2n4W4DfxRNkbmjRilCdZijeGEWnw==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-root-proxy-success.yml
+++ b/spec/fixtures/vcr_cassettes/put-root-proxy-success.yml
@@ -1,0 +1,386 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 370833us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 46615us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 426055/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:07 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/proxies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '140'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Amzn-Requestid:
+      - 14c4af82-36a8-11e8-8a8d-bdf9536f6b8f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuiWFEMUIAMFvMQ=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 73a52047a4b5d0888cd6da66a23c4762.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YCrvk3UeZzm39FaEjP8FuMqSDqb_Pk-70PMZI0-J3zSZH9Y2ppGalA==
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<n>","name":"None","urlMask":""},{"id":"EZProxy","name":"EZProxy","urlMask":"http://ezproxy.myinstitute.edu/login?url={targetURL}"}]'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:07 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Amzn-Requestid:
+      - 14f3882d-36a8-11e8-a1ef-118fd8cbe6ac
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuiWIGSGIAMF46w=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a6a098cdc333f9948baa2a00729f4f25.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4P9fOSvcEDp2BVrdt6qqA0rkKoy7AOMNZRkcs3nAD2Y59rDSRYpiQg==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:07 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:00:17 GMT
+      X-Amzn-Requestid:
+      - 150f4d4d-36a8-11e8-9dc7-d1217534bf26
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuiWKF0pIAMF19w=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 93e404430d11dacb3232bae72aaaee90.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - BnAqvUaYux7grL1VCqdsBBxydDNFdE6US3JRXR42cjvfTnvhV0uCFQ==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:07 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:00:17 GMT
+      X-Amzn-Requestid:
+      - 152df873-36a8-11e8-b698-253e33f7eef9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuiWMGcPIAMFvIQ=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:00:16 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b5434ae2f27f51f7ce619d0889d77d8d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - T3RxAAtiT8NJX-xoFBOoSGFpE7dTLheMSe2sBy5Sh8P8DDXW16fK7A==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:08 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:00:17 GMT
+      X-Amzn-Requestid:
+      - 1577370e-36a8-11e8-8adb-bf426db03c00
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EuiWRHeeoAMFuiA=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:00:17 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5acd50d556cd25b3cd99abfe744c498d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wKRbIGoyAVljQ_Hzi7K50YkQ5gHBjd2XKQylF78gMgROpJkYIOG3mw==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 18:54:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-root-proxy-with-empty-body.yml
+++ b/spec/fixtures/vcr_cassettes/put-root-proxy-with-empty-body.yml
@@ -1,0 +1,218 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1792us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 45691us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 802267/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/proxies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '140'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Amzn-Requestid:
+      - f32c43eb-36a8-11e8-b2dc-83fd52db5130
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EujQYFFwoAMFn1w=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:06:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 55157b979573d984aaf7e9e716d67a4a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Jk8EIdMPzHqRjrCtPsGV6zDtvP4_qEeqyMWpSyfrTATuciVZZ5JTzw==
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<n>","name":"None","urlMask":""},{"id":"EZProxy","name":"EZProxy","urlMask":"http://ezproxy.myinstitute.edu/login?url={targetURL}"}]'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '573'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 02 Apr 2018 19:06:30 GMT
+      X-Amzn-Requestid:
+      - f393de87-36a8-11e8-8ca5-091b690b6005
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - EujQfE6CoAMFSqA=
+      X-Amzn-Remapped-Date:
+      - Mon, 02 Apr 2018 19:06:30 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3182c21f2ee69ff40cfaf404637c649f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KjCvs9DcgNfo5Yx1vw9r9dT-Am-CxDwPGRimS_VIzrVYNSaSduLUZA==
+    body:
+      encoding: UTF-8
+      string: '{"proxy":{"id":"EZProxy"},"labels":[{"id":1,"displayLabel":"Hello 1st
+        label","displayOnFullTextFinder":true,"displayOnPublicationFinder":false},{"id":2,"displayLabel":"Hello
+        2nd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":3,"displayLabel":"Hello
+        3rd label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":4,"displayLabel":"Hello
+        4th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true},{"id":5,"displayLabel":"Hello
+        5th label","displayOnFullTextFinder":true,"displayOnPublicationFinder":true}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 19:00:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/root_proxy_spec.rb
+++ b/spec/requests/root_proxy_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Root Proxies', type: :request do
+  describe 'getting list of root proxies' do
+    before do
+      VCR.use_cassette('get-root-proxies-success') do
+        get '/eholdings/root-proxies',
+            headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+    let!(:attributes) { json.data.first.attributes }
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(200)
+    end
+    it "is of type 'rootProxy'" do
+      expect(json.data.first.type).to eq('rootProxy')
+    end
+
+    describe 'check each root proxy attributes' do
+      it 'has id key' do
+        expect(attributes).to have_key(:id)
+      end
+      it 'has name key' do
+        expect(attributes).to have_key(:name)
+      end
+      it 'has url mask key' do
+        expect(attributes).to have_key(:urlMask)
+      end
+      it 'has selected key' do
+        expect(attributes).to have_key(:selected)
+      end
+    end
+  end
+
+  describe 'updating selection of root proxy' do
+    let(:update_headers) do
+      okapi_headers.merge(
+        'Content-Type': 'application/vnd.api+json'
+      )
+    end
+
+    describe 'select a different root proxy' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'EZProxy',
+            'type' => 'rootProxy',
+            'attributes' => {
+              'id' => 'EZProxy'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-root-proxy-success') do
+          put '/eholdings/root-proxies/EZProxy',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'gets a successful response' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      describe 'check attributes of new root proxy' do
+        it 'has id of EZProxy' do
+          expect(attributes.id).to eq('EZProxy')
+        end
+        it 'has name equals nil because its not updated' do
+          expect(attributes.name).to be_nil
+        end
+        it 'has urlmask equals nil because its not updated' do
+          expect(attributes.urlMask).to be_nil
+        end
+        it 'has selection set to true' do
+          expect(attributes.selected).to eq(true)
+        end
+      end
+    end
+
+    describe 'update a root proxy with non-matching ids' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'EZProxy',
+            'type' => 'rootProxy',
+            'attributes' => {
+              'id' => 'EZProxy'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-root-proxy-non-matching') do
+          put '/eholdings/root-proxies/some_value',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update root proxy with invalid value' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'test-123',
+            'type' => 'rootProxy',
+            'attributes' => {
+              'id' => 'test-123'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-root-proxy-invalid') do
+          put '/eholdings/root-proxies/test-123',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    describe 'update a root proxy without a body' do
+      let(:params) do
+        {
+          'data' => {
+            'id' => 'EZProxy',
+            'type' => 'rootProxy',
+            'attributes' => {
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-root-proxy-with-empty-body') do
+          put '/eholdings/root-proxies/EZProxy',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'results in error' do
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-219, users should be able to get the root proxy list to be displayed in drop-down in Settings of ui-eholdings, and they should be able to update the root proxy that is currently set. 

## Approach
- Implement the GET call /eholdings/root-proxies -- This gives a list of root proxies with params from RM API for each proxy like "id", "name" and "urlMask" as well as "selected", which allows ui-eholdings to highlight selection in drop down.
- This is a aggregated result of 2 calls to RM API
- By calling GET /{custid}/proxies in RM API -- gives the list of proxies available for a customer
- By calling GET /{custid} -- gives the current root proxy and custom labels
- Aggregate both these results, filter results and provide a response for GET
- Implement a PUT call /eholdings/root-proxies/id -- This allows user to update the current selection of root proxy
- Request body schema: ```{
  "data": {
    "id": "<n>",
    "type": "rootProxy",
    "attributes": {
      "id": "<n>"
    }
  }
}```
- Validations are done such that id in url should match id in request body; and id passed in should be one of the allowed root proxies for the customer; else error messages are returned
- If it passes validations, then update is made to the root proxy; the updated value with "selected" attribute set to true is returned in response. "name" and "urlMask" are set to null since they are not updated. If we are to populate "name" and "urlMask" with correct values, we need to make another call to RM API to get their real values and merge it in with the result. We are not making that additional GET call to save traffic to RM API for data that we might not use. They are in the payload for consistency between GET and PUT requests.
- In order to update in RM API, we get GET /{custid}, prune the response to ensure that custom labels with "displayLabel" equal to empty do not exist, patch the response with the updated proxy and make a PUT call to /{custid} with combined payload of custom labels and root proxy.
- Added associated unit tests. 

## Todo
- Confirm with Khalilah if "urlMask" is needed; remove it from GET and PUT requests if not needed. 

## Screenshots
![root_proxies](https://user-images.githubusercontent.com/33662516/38212830-30c8fdd8-368d-11e8-8daf-ef170c361ae2.gif)

