### PR TITLE
Update Moduledescriptor.json for root proxies and custom labels

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -16,11 +16,11 @@
         },
         {
           "methods": [ "GET", "PUT", "DELETE" ],
-          "pathPattern": "/eholdings/custom-labels"
+          "pathPattern": "/eholdings/custom-labels/*"
         },
         {
           "methods": [ "GET", "PUT" ],
-          "pathPattern": "/eholdings/root-proxies"
+          "pathPattern": "/eholdings/root-proxies/*"
         },
         {
           "methods": [ "GET" ],


### PR DESCRIPTION
## Purpose
Fix routing issue that occurred in Okapi for custom labels and root proxies, PUT and DELETE requests.

## Approach
We needed to update ModuleDescriptor.json to include paths like `/eholdings/custom-labels/*` and `/eholdings/root-proxies/*` from earlier version of `/eholdings/custom-labels` and `/eholdings/root-proxies` for routing to happen correctly in Okapi. Okapi was otherwise allowing GETs on these paths but not PUTs or DELETEs.


#### TODOS and Open Questions
- [ ] Deploy this change and verify that the issue is fixed after deployment.

