### PR TITLE
UIEH-230 - Add support for both Errors and errors from RM API response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,8 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
+Metrics/LineLength:
+  Enabled: false
 
 # Template tokens are fine
 Style/FormatStringToken:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,26 +39,28 @@ class ApplicationController < ActionController::API
            status: :bad_request
   end
 
-  def catch_flexirest_exceptions # rubocop:disable Metrics/AbcSize
+  def catch_flexirest_exceptions
     yield
   rescue Flexirest::HTTPClientException,
          Flexirest::HTTPServerException,
          Flexirest::HTTPNotFoundClientException => e
 
-    errors_hash = if e.result.respond_to?(:Errors)
-                    e.result.Errors.to_a.map do |err|
-                      { "title": map_provider(err.to_hash['Message']) }
-                    end
-                  elsif e.result.respond_to?(:errors)
-                    e.result[:errors].items.to_a.map do |err|
-                      { "title": map_provider(err.to_hash['message']) }
-                    end
-                  else
-                    []
-                  end
-
-    render jsonapi_errors: errors_hash,
+    render jsonapi_errors: get_errors_hash(e),
            status: e.status
+  end
+
+  def get_errors_hash(e) # rubocop:disable Metrics/AbcSize
+    if e.result.respond_to?(:Errors)
+      e.result.Errors.to_a.map do |err|
+        { "title": map_provider(err.to_hash['Message']) }
+      end
+    elsif e.result.respond_to?(:errors)
+      e.result[:errors].items.to_a.map do |err|
+        { "title": map_provider(err.to_hash['message']) }
+      end
+    else
+      []
+    end
   end
 
   def map_provider(string)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -481,10 +481,8 @@ RSpec.describe 'Providers', type: :request do
         let!(:json) { Map JSON.parse response.body }
 
         it 'responds with bad request' do
-          # rubocop:disable Metrics/LineLength
           expect(response).to have_http_status(400)
           expect(json.errors.first.title).to eql('Provider does not allow token')
-          # rubocop:enable Metrics/LineLength
         end
       end
     end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -441,8 +441,11 @@ RSpec.describe 'Providers', type: :request do
       end
     end
 
+    let!(:json) { Map JSON.parse response.body }
+
     it 'returns a not found error' do
       expect(response).to have_http_status(404)
+      expect(json.errors.first.title).to eql('Provider not found')
     end
   end
 
@@ -475,8 +478,13 @@ RSpec.describe 'Providers', type: :request do
           end
         end
 
+        let!(:json) { Map JSON.parse response.body }
+
         it 'responds with bad request' do
+          # rubocop:disable Metrics/LineLength
           expect(response).to have_http_status(400)
+          expect(json.errors.first.title).to eql('Provider does not allow token')
+          # rubocop:enable Metrics/LineLength
         end
       end
     end

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -232,12 +232,10 @@ RSpec.describe 'Titles', type: :request do
 
   describe 'with relevance sorting' do
     before do
-      # rubocop:disable Metrics/LineLength
       VCR.use_cassette('search-titles-sort-relevance') do
         get '/eholdings/titles/?filter[name]=victorian%20fashion&sort=relevance',
             headers: okapi_headers
       end
-      # rubocop:enable Metrics/LineLength
     end
 
     let!(:json_n) { Map JSON.parse response.body }


### PR DESCRIPTION
## Purpose
[UIEH-230](https://issues.folio.org/browse/UIEH-230)
The RM API `vendors` endpoint is returning an error message body which is inconsistent. Specifically a different case of keys is returned in the  JSON error response body. 
For example: 
`{"errors":[{"code":1001,"subCode":0,"message":"Vendor not found"}]}`
When this is expected:
`{"Errors":[{"Code":1001,"Message":"Vendor not found","SubCode":0}]}`
Because of this, we do not see  RM API error message text in mod-kb-ebsco error response body.

## Approach
- Update error handling in mod-kb-ebsco so that RM API message text in either format is available in response body from mod-kb-ebsco. 
- Made changes in application controller to handle both cases of error response. 
- Updated provider unit tests to verify RM API error message text
- Replace vendor with provider in error response text

#### TODOS and Open Questions
- [ ]  This is a temporary solution as longer term, casing will be resolved and consistent in RM API
- [x]  ~~RM API error text includes terminology of vendor vs provider - should this be replaced in text itself~~
- [ ]  Is there a better location in code for a mapping such as this



