### PR TITLE
UIEH-259 Expose isCustom field for packages

### DIFF
--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -15,7 +15,8 @@ class SerializablePackage < SerializableResource
              :customCoverage,
              :isSelected,
              :allowKbToAddTitles,
-             :vendorName
+             :vendorName,
+             :isCustom
 
   attribute :providerId do
     @object.vendorId

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -195,7 +195,8 @@ RSpec.describe 'Packages', type: :request do
         'customCoverage',
         'visibilityData',
         'isSelected',
-        'vendorName'
+        'vendorName',
+        'isCustom'
       )
       expect(json.data.attributes.vendorId).to eq(19)
       expect(json.data.attributes.packageId).to eq(6581)


### PR DESCRIPTION
We hadn't previously needed to see the `isCustom` attribute of packages.

Related to https://issues.folio.org/browse/UIEH-259