### PR TITLE
UIEH-262 Fix title list loading for custom packages

### DIFF
--- a/app/serializable/serializable_customer_resource.rb
+++ b/app/serializable/serializable_customer_resource.rb
@@ -44,12 +44,16 @@ class SerializableCustomerResource < SerializableResource
       7 => 'Invalid'
     }
 
-    @object.identifiersList.map do |identifier|
-      {
-        id: identifier['id'],
-        type: types[identifier['type']] || '',
-        subtype: subtypes[identifier['subtype']] || ''
-      }
+    if @object.identifiersList
+      @object.identifiersList.map do |identifier|
+        {
+          id: identifier['id'],
+          type: types[identifier['type']] || '',
+          subtype: subtypes[identifier['subtype']] || ''
+        }
+      end
+    else
+      []
     end
   end
   attribute :name do

--- a/spec/fixtures/vcr_cassettes/get-custom-package-related-customer-resources.yml
+++ b/spec/fixtures/vcr_cassettes/get-custom-package-related-customer-resources.yml
@@ -1,0 +1,247 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 11 Apr 2018 12:49:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 358914us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42571us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 321151/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 11 Apr 2018 12:49:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2723775
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 11 Apr 2018 12:49:10 GMT
+      X-Amzn-Requestid:
+      - bac11c86-3d86-11e8-b610-85f90bb6aed6
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FLWa-HwMoAMFjVQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 11 Apr 2018 12:49:10 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 64a15e08bf29b0f17269963c144b4e8f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DhBbXSzLleBFfadQtFFCCViBpL8SbQYBPMfBhKy5y2Ndf8McpliQfA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":8,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":8,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 11 Apr 2018 12:49:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2723775/titles?count=25&offset=1&orderby=titlename&resourcetype=all&search=&searchfield=titlename&selection=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '7602'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 11 Apr 2018 12:49:10 GMT
+      X-Amzn-Requestid:
+      - baddcc7a-3d86-11e8-8cbf-533dbc7fe07e
+      X-Amzn-Remapped-Content-Length:
+      - '7602'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FLWbAEncoAMFYPg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 11 Apr 2018 12:49:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 eceebc7fc75ad1b377e012ce418717cd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9BJ_Bv8KaoaxFfpd2hDRRJB3xbvpcV4R1WwTi3yJuwy_CTvDyxXkKg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":8,"titles":[{"titleId":17059813,"titleName":"custom-title-multi-packages","publisherName":null,"identifiersList":null,"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059813,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":17063795,"titleName":"custom-title-multi-packages2","publisherName":null,"identifiersList":null,"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063795,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":16901088,"titleName":"Mobile
+        Access","publisherName":null,"identifiersList":null,"subjectsList":null,"isTitleCustom":true,"pubType":"Unspecified","customerResourcesList":[{"titleId":16901088,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":17063797,"titleName":"test-create-custom-title","publisherName":"EBSCO
+        Publishing","identifiersList":[{"id":"1234","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063797,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38112826,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":"String1","userDefinedField2":"String2","userDefinedField3":"String3","userDefinedField4":"String4","userDefinedField5":"String5"}]},{"titleId":17063798,"titleName":"test-create-custom-title-2","publisherName":"EBSCO
+        Publishing","identifiersList":[{"id":"1234","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063798,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38112830,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":"String1","userDefinedField2":"String2","userDefinedField3":"String3","userDefinedField4":"String4","userDefinedField5":"String5"}]},{"titleId":17063799,"titleName":"test-create-custom-title-3","publisherName":"EBSCO
+        Publishing","identifiersList":[{"id":"1234","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063799,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38112834,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":"String1","userDefinedField2":"String2","userDefinedField3":"String3","userDefinedField4":"String4","userDefinedField5":"String5"}]},{"titleId":17063803,"titleName":"test-create-custom-title-5","publisherName":"EBSCO
+        Publishing","identifiersList":[{"id":"1234","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063803,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38112861,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":"String1","userDefinedField2":"String2","userDefinedField3":"String3","userDefinedField4":"String4","userDefinedField5":"String5"}]},{"titleId":17063872,"titleName":"test-create-custom-title-4","publisherName":"EBSCO
+        Publishing","identifiersList":[{"id":"1234","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":null,"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17063872,"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","packageType":"Custom","isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38113150,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":"String1","userDefinedField2":"String2","userDefinedField3":"String3","userDefinedField4":"String4","userDefinedField5":"String5"}]}]}'
+    http_version: 
+  recorded_at: Wed, 11 Apr 2018 12:49:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -391,6 +391,29 @@ RSpec.describe 'Packages', type: :request do
     end
   end
 
+  describe 'getting customer resources related to a custom package' do
+    before do
+      VCR.use_cassette('get-custom-package-related-customer-resources') do
+        get '/eholdings/packages/123355-2723775/customer-resources',
+            headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'responds with a list of customer resources' do
+      expect(json.data.length).to eq(8)
+    end
+
+    it 'does not return identifiers for the customer resources' do
+      expect(json.data.first.attributes.identifiers.length).to eq(0)
+    end
+
+    it 'returns the correct included type' do
+      expect(json.data.first.type).to eq('customerResources')
+    end
+  end
+
   describe 'getting a package with included vendor' do
     before do
       VCR.use_cassette('get-packages-vendor') do


### PR DESCRIPTION
## Purpose
The list of related customer resources for a custom package was not loading.

Resolves https://issues.folio.org/browse/UIEH-262.

## Approach
Custom titles don't return an `identifiersList` from the EBSCO RM API, so the serializer was getting hung up.

