### PR TITLE
UIEH-283 Return packageType from RM API

### DIFF
--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -16,7 +16,8 @@ class SerializablePackage < SerializableResource
              :isSelected,
              :allowKbToAddTitles,
              :vendorName,
-             :isCustom
+             :isCustom,
+             :packageType
 
   attribute :providerId do
     @object.vendorId

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -196,7 +196,8 @@ RSpec.describe 'Packages', type: :request do
         'visibilityData',
         'isSelected',
         'vendorName',
-        'isCustom'
+        'isCustom',
+        'packageType'
       )
       expect(json.data.attributes.vendorId).to eq(19)
       expect(json.data.attributes.packageId).to eq(6581)


### PR DESCRIPTION
## Purpose
We want to show a package's type (Complete, Partial, Variable, or Custom).

Needed for https://issues.folio.org/browse/UIEH-283

## Approach
Pass along `packageType` from RM API as-is.