### PR TITLE
Does a provider support custom packages?

### DIFF
--- a/app/serializable/serializable_provider.rb
+++ b/app/serializable/serializable_provider.rb
@@ -14,5 +14,9 @@ class SerializableProvider < SerializableResource
     @object.vendorToken
   end
 
+  attribute :supportsCustomPackages do
+    @object.isCustomer
+  end
+
   has_many :packages
 end

--- a/spec/fixtures/vcr_cassettes/support-custom-packages.yml
+++ b/spec/fixtures/vcr_cassettes/support-custom-packages.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 13 Apr 2018 13:30:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 357100us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42477us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 123991/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 13:30:36 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '177'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 13 Apr 2018 13:30:37 GMT
+      X-Amzn-Requestid:
+      - d9e2acb3-3f1e-11e8-908d-29f7dc558aa4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FSCXjEOPoAMFteg=
+      X-Amzn-Remapped-Date:
+      - Fri, 13 Apr 2018 13:30:37 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a6e6de55f7ddbeeba09f3954e960354f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - OlM8mXZ-etEjJtyjiBfZhz5zILUq4z-rCflWBkVtHKYegRm7CHIM1A==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":true,"packagesSelected":41,"packagesTotal":41,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","proxy":{"id":"<n>","inherited":true},"vendorToken":null}'
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 13:30:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -150,13 +150,18 @@ RSpec.describe 'Providers', type: :request do
           'name',
           'packagesTotal',
           'packagesSelected',
-          'providerToken'
+          'providerToken',
+          'supportsCustomPackages'
         )
       )
     end
 
     it 'returns null provider token' do
       expect(json.data.attributes.providerToken).to eq(nil)
+    end
+
+    it 'returns false for supports custom packages' do
+      expect(json.data.attributes.supportsCustomPackages).to eq(false)
     end
 
     it 'contains relationships data' do
@@ -182,7 +187,8 @@ RSpec.describe 'Providers', type: :request do
           'name',
           'packagesTotal',
           'packagesSelected',
-          'providerToken'
+          'providerToken',
+          'supportsCustomPackages'
         )
       )
     end
@@ -201,6 +207,35 @@ RSpec.describe 'Providers', type: :request do
 
     it 'contains relationships data' do
       expect(json.data.relationships). to include('packages')
+    end
+  end
+
+  describe 'getting a provider that supports custom packages ' do
+    before do
+      VCR.use_cassette('support-custom-packages') do
+        get '/eholdings/providers/123355', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'gets the resource' do
+      expect(response).to have_http_status(200)
+      expect(json.data.type).to eq('providers')
+      expect(json.data.id).to eq('123355')
+      expect(json.data.attributes).to(
+        include(
+          'name',
+          'packagesTotal',
+          'packagesSelected',
+          'providerToken',
+          'supportsCustomPackages'
+        )
+      )
+    end
+
+    it 'supports custom packages' do
+      expect(json.data.attributes.supportsCustomPackages).to eq(true)
     end
   end
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-291, RM API vendor provides a flag which lets us know whether a vendor allows custom packages to be added.  

## Approach
Map the field "isCustomer" holding a boolean value provided by RM API to "supportsCustomPackages" in mod-kb-ebsco and expose it from GET calls for provider so ui-eholdings can pick it up.

## Screenshots
![supprtscustompackages](https://user-images.githubusercontent.com/33662516/38739390-cf6019fe-3f02-11e8-9f9b-6d3f25eb2d9f.gif)
