### PR TITLE
Update ModuleDescriptor

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -40,7 +40,7 @@
         },
         {
           "methods": [ "GET", "PUT" ],
-          "pathPattern": "/eholdings/customer-resources*"
+          "pathPattern": "/eholdings/resources*"
         },
         {
           "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
@@ -70,4 +70,3 @@
     "dockerPull" : false
   }
 }
-


### PR DESCRIPTION
Missed a part of https://github.com/folio-org/mod-kb-ebsco/pull/100 that didn't get caught by tests.

Okapi needs to know the new URL for resources.