### PR TITLE
Delete endpoint for custom titles

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -39,7 +39,7 @@
           "pathPattern": "/eholdings/titles*"
         },
         {
-          "methods": [ "GET", "PUT" ],
+          "methods": [ "GET", "PUT", "DELETE" ],
           "pathPattern": "/eholdings/resources*"
         },
         {

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -3,7 +3,7 @@
 class ResourcesController < ApplicationController
   attr_accessor :resource
 
-  before_action :set_resource, only: %i[show update]
+  before_action :set_resource, only: %i[show update destroy]
 
   deserializable_resource :resource,
                           only: :update,
@@ -24,6 +24,18 @@ class ResourcesController < ApplicationController
     else
       render jsonapi_errors: resource_validation.errors,
              status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    resource_validation =
+      Validation::ResourceDestroyParameters.new(@resource)
+
+    if resource_validation.valid?
+      @resource.delete
+    else
+      render jsonapi_errors: resource_validation.errors,
+             status: :bad_request
     end
   end
 

--- a/app/controllers/validation/resource_destroy_parameters.rb
+++ b/app/controllers/validation/resource_destroy_parameters.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Validation
+  class ResourceDestroyParameters
+    include ActiveModel::Validations
+
+    validate :resource_deletable?
+
+    def resource_deletable?
+      # Resource can be deleted only if its custom
+      # Check for that
+      errors.add(:resource, 'cannot be deleted') unless
+        @resource.isTitleCustom
+    end
+
+    def initialize(resource)
+      @resource = resource
+    end
+  end
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -115,6 +115,15 @@ class Resource < RmApiResource
     refresh!
   end
 
+  def delete
+    self.class.update(
+      vendor_id: resource.vendorId,
+      package_id: resource.packageId,
+      title_id: titleId,
+      isSelected: false
+    )
+  end
+
   private
 
   def refresh!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
 
     resources :resources,
               path: '/resources',
-              only: %i[show update]
+              only: %i[show update destroy]
 
     resources :custom_labels,
               path: '/custom-labels',

--- a/spec/fixtures/vcr_cassettes/delete-custom-title.yml
+++ b/spec/fixtures/vcr_cassettes/delete-custom-title.yml
@@ -1,0 +1,241 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 13 Apr 2018 20:14:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1407us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42875us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 337567/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:14:29 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17070531
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '976'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 13 Apr 2018 20:14:30 GMT
+      X-Amzn-Requestid:
+      - 45d4aaec-3f57-11e8-b9ad-15e605d6be25
+      X-Amzn-Remapped-Content-Length:
+      - '976'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FS9h9HjooAMF8og=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 13 Apr 2018 20:14:30 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f360bbb3d1999b5324e1d7ae31da1d7e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DBFYY658iZMm2EirBMk7E2JzDHjE7J6sU13PHXUcQmaoy_ZqcNnbJw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17070531,"titleName":"my custom title","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17070531,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:14:30 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17070531
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 13 Apr 2018 20:14:30 GMT
+      X-Amzn-Requestid:
+      - 460cab1c-3f57-11e8-8a1c-5b15c667b33b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FS9iAH3zoAMFiGQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 13 Apr 2018 20:14:30 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 591e4cd98bc438a13e141b991f9397b3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CYqTooqmlw797VnoGpNqvSDr4LNfqYPzL3VDHj1VidDhxZQwBgsZlg==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:14:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-deleted-title.yml
+++ b/spec/fixtures/vcr_cassettes/delete-deleted-title.yml
@@ -1,0 +1,176 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 13 Apr 2018 20:16:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 355210us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43039us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 579493/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:16:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17070531
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '66'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 13 Apr 2018 20:16:20 GMT
+      X-Amzn-Requestid:
+      - 87ccf1c3-3f57-11e8-97a5-4d3c440fb2a7
+      X-Amzn-Remapped-Content-Length:
+      - '66'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FS9zPFXbIAMFRbQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 13 Apr 2018 20:16:20 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 fda67c020b3c631c975bccffd2891599.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ofVrbCZpgRt7_5nZ3eUyAB1WcdpqE94vzhgZ8vGBWGrIV5ZfdYpoQQ==
+    body:
+      encoding: UTF-8
+      string: '{"Errors":[{"Code":1001,"Message":"Title not found","SubCode":0}]}'
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:16:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-non-custom-title.yml
+++ b/spec/fixtures/vcr_cassettes/delete-non-custom-title.yml
@@ -1,0 +1,177 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 13 Apr 2018 20:19:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 360236us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42806us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 703697/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:19:31 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/72/packages/6057/titles/1360002
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '995'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 13 Apr 2018 20:19:31 GMT
+      X-Amzn-Requestid:
+      - f9ba97e5-3f57-11e8-9e8e-031a9cd1d096
+      X-Amzn-Remapped-Content-Length:
+      - '995'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FS-RHE0_IAMF4rQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 13 Apr 2018 20:19:31 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c7db0c4b178dd73a64add79be10805c2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 3vVx7hbwjU431KeLuysQVg-D94zQJo0keeOuuXxalkj6tn2eC6WSeQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":1360002,"titleName":"Early American Imprints","publisherName":"Unspecified","identifiersList":[{"id":"1360002","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","customerResourcesList":[{"titleId":1360002,"packageId":6057,"packageName":"Early
+        American Imprints","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":72,"vendorName":"NewsBank","locationId":4492574,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://infoweb.newsbank.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 13 Apr 2018 20:19:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_resources_spec.rb
+++ b/spec/requests/custom_resources_spec.rb
@@ -212,4 +212,45 @@ RSpec.describe 'Custom Resources', type: :request do
       end
     end
   end
+
+  describe 'deleting a custom title' do
+    describe 'deletes title if it is a custom title' do
+      before do
+        VCR.use_cassette('delete-custom-title') do
+          delete '/eholdings/resources/123355-2843714-17070531',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a successful response' do
+        expect(response).to have_http_status(204)
+      end
+    end
+
+    describe 'trying to delete a deleted title results in error' do
+      before do
+        VCR.use_cassette('delete-deleted-title') do
+          delete '/eholdings/resources/123355-2843714-17070531',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a not found response' do
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    describe 'trying to delete a non-custom title' do
+      before do
+        VCR.use_cassette('delete-non-custom-title') do
+          delete '/eholdings/resources/72-6057-1360002',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a bad request response' do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-294, users should be able to delete custom titles associated with custom packages, this is an endpoint for supporting the delete operation in backend.

## Approach
- Add a destroy method in the controller, which validates that it is a custom title which can be deleted and then sends a PUT request to RM API with "isSelected" set to false for this particular title.
- Sample request can be : DELETE /eholdings/resources/XX-YY-ZZ(vendorId-packageId-TitleId)
- Expected Response if title has been deleted successfully : 204 No Content
- Expected Response if its not a custom title and cannot be deleted: 400 Bad Request with detailed error message "Resource cannot be deleted"
- Expected Response if user tries to delete a title that does not exist: 404 Not Found with detailed error message: "Title not found"
- Associated unit tests

## Screenshots
![delete_title](https://user-images.githubusercontent.com/33662516/38756530-d866cef0-3f37-11e8-9dc7-aeae278b09bc.gif)

