### PR TITLE
Delete custom/managed title

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -29,7 +29,7 @@ class ResourcesController < ApplicationController
 
   def destroy
     resource_validation =
-      Validation::ResourceDestroyParameters.new(@resource)
+      Validation::ResourceDestroyParameters.new(@resource.customerResourcesList)
 
     if resource_validation.valid?
       @resource.delete

--- a/app/controllers/validation/resource_destroy_parameters.rb
+++ b/app/controllers/validation/resource_destroy_parameters.rb
@@ -7,14 +7,16 @@ module Validation
     validate :resource_deletable?
 
     def resource_deletable?
-      # Resource can be deleted only if its custom
+      # custom or managed titles can be deleted as long
+      # as the package its associated with is custom.
       # Check for that
       errors.add(:resource, 'cannot be deleted') unless
-        @resource.isTitleCustom
+        @is_package_custom
     end
 
-    def initialize(resource)
-      @resource = resource
+    def initialize(customer_resource_list)
+      customer_resource = customer_resource_list.first
+      @is_package_custom = customer_resource['isPackageCustom']
     end
   end
 end

--- a/spec/requests/custom_resources_spec.rb
+++ b/spec/requests/custom_resources_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Custom Resources', type: :request do
   end
 
   describe 'deleting a custom title' do
-    describe 'deletes title if it is a custom title' do
+    describe 'deletes title if it is part of a custom package' do
       before do
         VCR.use_cassette('delete-custom-title') do
           delete '/eholdings/resources/123355-2843714-17070531',
@@ -240,7 +240,7 @@ RSpec.describe 'Custom Resources', type: :request do
       end
     end
 
-    describe 'trying to delete a non-custom title' do
+    describe 'trying to delete a title not in a custom package' do
       before do
         VCR.use_cassette('delete-non-custom-title') do
           delete '/eholdings/resources/72-6057-1360002',


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-288, user should be able to delete a custom/managed title that is associated with a custom package.

## Approach
- Tweak code in custom resource delete param validation to check if title belongs to a custom package and if it does, support delete functionality with call to RM API setting "isSelected" for this specific title to false. 
- Modify tests accordingly.