### PR TITLE
UIEH-293 Enable more fields for custom title editing

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -64,6 +64,11 @@ class ResourcesController < ApplicationController
         :pubType,
         :isSelected,
         :coverageStatement,
+        :isPeerReviewed,
+        :publisherName,
+        :edition,
+        :description,
+        :url,
         visibilityData: [:isHidden],
         customCoverageList: [
           %i[beginCoverage endCoverage]

--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -4,7 +4,12 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
   attributes :isSelected,
              :customEmbargoPeriod,
              :visibilityData,
-             :coverageStatement
+             :coverageStatement,
+             :isPeerReviewed,
+             :publisherName,
+             :edition,
+             :description,
+             :url
 
   attribute :name do |value|
     { titleName: value }

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -110,7 +110,12 @@ class Resource < RmApiResource
       customEmbargoPeriod: resource_attributes[:customEmbargoPeriod],
       coverageStatement: resource_attributes[:coverageStatement],
       titleName: attributes[:titleName],
-      pubType: attributes[:pubType]
+      pubType: attributes[:pubType],
+      isPeerReviewed: attributes[:isPeerReviewed],
+      publisherName: attributes[:publisherName],
+      edition: attributes[:edition],
+      description: attributes[:description],
+      url: resource_attributes[:url]
     )
     refresh!
   end
@@ -158,7 +163,11 @@ class Resource < RmApiResource
   def update_fields
     to_hash.with_indifferent_access.slice(
       :titleName,
-      :pubType
+      :pubType,
+      :isPeerReviewed,
+      :publisherName,
+      :edition,
+      :description
     )
   end
 
@@ -169,7 +178,7 @@ class Resource < RmApiResource
       :customCoverageList,
       :customEmbargoPeriod,
       :coverageStatement,
-      :titleName
+      :url
     )
   end
 end

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-combined-update.yml
@@ -1,0 +1,316 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 361154us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42794us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 378389/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 14:18:59 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '993'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Amzn-Requestid:
+      - 1adc1ed1-4181-11e8-802a-cb01d6793628
+      X-Amzn-Remapped-Content-Length:
+      - '993'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FcCRAG5GIAMFQOg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 80db24d34a8214ca1ef4ec19a50b3cbb.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Mzuklbf5xYyIF-G9Tcqn-nDRZSswrOAdfijmMot_Dqyni_MI1Sx4Vg==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17053010,"titleName":"custom-title-74-something-something","publisherName":"EBSCO
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17053010,"packageId":2739728,"packageName":"testing
+        ","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38204652,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":"Issues
+        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"https://ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"description-test","edition":"1","isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 14:18:59 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"There
+        are many years.","titleName":"This is the best title ever","pubType":"newspaper","isPeerReviewed":true,"publisherName":"Frontside
+        Newspapers","edition":"5","description":"Something something something","url":"https://frontside.io"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Amzn-Requestid:
+      - 1afe4cfe-4181-11e8-86dd-1f85d2ee409a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FcCRCHHsIAMFg7A=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e5b6a8161bf68154b75e352615368bb3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mGTVl9UT1iiCNMmdCiVlj7UQsYpSzvVKW2XaBWu4hv2pljTxjoRjlA==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 14:18:59 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1078'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Amzn-Requestid:
+      - 1b419717-4181-11e8-a809-6535de2ed560
+      X-Amzn-Remapped-Content-Length:
+      - '1078'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FcCRGEwCoAMFR1g=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 14:18:59 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 93eca0e8ef8f4e7cd978be1da20a3a43.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4EJjrT3eQ94WagmRYJbnrh4_czc8DlaxikI7unamlRZ7QlB6FJbklg==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17053010,"titleName":"This is the best title ever","publisherName":"Frontside
+        Newspapers","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17053010,"packageId":2739728,"packageName":"testing
+        ","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38204653,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"There
+        are many years.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"https://frontside.io","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Something
+        something something","edition":"5","isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 14:18:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_resources_spec.rb
+++ b/spec/requests/custom_resources_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Custom Resources', type: :request do
       )
     end
 
-    describe 'changing the name and publication type' do
+    describe 'changing the name' do
       let(:params) do
         {
           "data": {
@@ -209,6 +209,85 @@ RSpec.describe 'Custom Resources', type: :request do
       it 'has a coverage statement' do
         expect(json.data.attributes.coverageStatement)
           .to eq('We have so much coverage.')
+      end
+    end
+
+    describe 'combined update' do
+      let(:params) do
+        {
+          "data": {
+            "type": 'resources',
+            "attributes": {
+              "isSelected": true,
+              "visibilityData": {
+                "isHidden": true
+              },
+              "name": 'This is the best title ever',
+              "isPeerReviewed": true,
+              "publicationType": 'Newspaper',
+              "publisherName": 'Frontside Newspapers',
+              "edition": '5',
+              "description": 'Something something something',
+              "url": 'https://frontside.io',
+              "customCoverages": [
+                {
+                  "beginCoverage": '2003-01-01',
+                  "endCoverage": '2004-01-01'
+                }
+              ],
+              "coverageStatement": 'There are many years.',
+              "customEmbargoPeriod": {
+                "embargoUnit": 'Weeks',
+                "embargoValue": 6
+              }
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-combined-update') do
+          put '/eholdings/resources/123355-2739728-17053010',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'has name' do
+        expect(json.data.attributes.name).to eq('This is the best title ever')
+      end
+
+      it 'is now hidden' do
+        expect(json.data.attributes.visibilityData.isHidden).to be true
+      end
+
+      it 'has peer review status' do
+        expect(json.data.attributes.isPeerReviewed).to be true
+      end
+
+      it 'has publication type' do
+        expect(json.data.attributes.publicationType).to eq('Newspaper')
+      end
+
+      it 'has publisher name' do
+        expect(json.data.attributes.publisherName).to eq('Frontside Newspapers')
+      end
+
+      it 'has edition' do
+        expect(json.data.attributes.edition).to eq('5')
+      end
+
+      it 'has description' do
+        expect(json.data.attributes.description).to eq('Something something something')
+      end
+
+      it 'has url' do
+        expect(json.data.attributes.url).to eq('https://frontside.io')
       end
     end
   end


### PR DESCRIPTION
## Purpose
Set up editing for more editable fields on "custom titles" (custom resources).

https://issues.folio.org/browse/UIEH-293

## Approach
Makes editable:
- `isPeerReviewed`
- `publisherName`
- `edition`
- `description`
- `url`

Does not handle the two remaining array fields, `identifiers` and `contributors`.

## Next Steps
Does not attempt to do any validation. The five fields mentioned are not editable for a managed resource, so they should reject changes there. Until we get to that, we at least know the UI being built won't attempt to make those changes to a managed resource.