### PR TITLE
UIEH-321 Fix RM API package edit rejection

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -117,13 +117,22 @@ class Package < RmApiResource
   end
 
   def update_fields
-    to_hash.with_indifferent_access.slice(
-      :isSelected,
-      :allowEbscoToAddTitles,
-      :visibilityData,
-      :customCoverage,
-      :packageName,
-      :contentType
-    )
+    if isCustom?
+      to_hash.with_indifferent_access.slice(
+        :isSelected,
+        :allowEbscoToAddTitles,
+        :visibilityData,
+        :customCoverage,
+        :packageName,
+        :contentType
+      )
+    else
+      to_hash.with_indifferent_access.slice(
+        :isSelected,
+        :allowEbscoToAddTitles,
+        :visibilityData,
+        :customCoverage
+      )
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/put-package-managed-content-type.yml
+++ b/spec/fixtures/vcr_cassettes/put-package-managed-content-type.yml
@@ -1,0 +1,266 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 16 Apr 2018 22:30:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 370749us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43671us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 550254/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:30:29 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '470'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:30:29 GMT
+      X-Amzn-Requestid:
+      - c4b467a6-41c5-11e8-bba2-fbe90dfc7903
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdKQ7H2_IAMFmvQ=
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:30:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 31feeac50108538bffd7ffa275a7d591.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - JW7NgBi-22_s4CzMMDQl-bvTsfTQoVSKVtzCQgy3bT7ZJa_kxhRvCg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:30:30 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"allowEbscoToAddTitles":false,"isHidden":false,"customCoverage":{"beginCoverage":"","endCoverage":""},"packageName":null,"contentType":null}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:30:30 GMT
+      X-Amzn-Requestid:
+      - c4cf1b19-41c5-11e8-ab11-470e61394c44
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdKQ9HnZoAMFlBA=
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:30:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6681f37801f4edfd8e476d3db594d0ab.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - N6IOHLcrf731eizqMI9iitw6lKtn7HKznXWU2gWrLZq16oXI-qom6w==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:30:30 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '470'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:30:30 GMT
+      X-Amzn-Requestid:
+      - c4ff2bc4-41c5-11e8-a454-79291a64e2df
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdKRAERNoAMFh9Q=
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:30:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4dd4aa8d0131dbf7b4466439f4d70b1c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0JfpuY7P8yz4H29Ply2PdVBGGiozSFBT3cYslxIM1D3qYRmoYrfGHQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:30:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
@@ -1,0 +1,318 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 16 Apr 2018 22:17:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 363441us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43277us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 961937/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:17:18 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1668'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:17:21 GMT
+      X-Amzn-Requestid:
+      - edaaebfa-41c3-11e8-98b8-2dd87aa2e398
+      X-Amzn-Remapped-Content-Length:
+      - '1668'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdIVcGznIAMFQEw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:17:19 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ad15c70abd681cb2e8c1d7aaa175778a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - th6c8YCcrVU0j2ADst7oM4NhSDeYPHFFEwbNtUUkpBt4UJlyg0kqJA==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
+        Ebook Central","packageType":"Variable","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Info & Learning Co","locationId":17545807,"isSelected":false,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
+        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:17:21 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false,"isHidden":false,"customCoverageList":[{"beginCoverage":"2005-01-01","endCoverage":""},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"coverageStatement":"Only
+        2000s issues available.","titleName":"I want a cool title name","pubType":"newspaper","isPeerReviewed":true,"publisherName":"Frontside
+        Newspapers","edition":"5","description":"Something something something","url":"https://frontside.io"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:17:22 GMT
+      X-Amzn-Requestid:
+      - eef8c8d9-41c3-11e8-9ce8-a32faf221e40
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdIVyGlcIAMFQlA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:17:22 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ae7fd0d88f365738edb8b211d5f7884a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fM3Nvf0yqn5I3YaEFwv9rvKwN8FmNasMO-J01kF8CBAe9MREfa9FhQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:17:22 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1668'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 16 Apr 2018 22:17:23 GMT
+      X-Amzn-Requestid:
+      - efb33fba-41c3-11e8-b815-af716704f074
+      X-Amzn-Remapped-Content-Length:
+      - '1668'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FdIV-F4RoAMFwuw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 16 Apr 2018 22:17:22 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 303f2602a6c74044df3bfb65e57f0d8e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tF3Ip-Gk9CXDPvelMfKDOzwck62RDmunWOKEZjNpGjB6L78TUouHaQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
+        Ebook Central","packageType":"Variable","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Info & Learning Co","locationId":17545807,"isSelected":false,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
+        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
+    http_version: 
+  recorded_at: Mon, 16 Apr 2018 22:17:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -923,6 +923,39 @@ RSpec.describe 'Packages', type: :request do
     end
   end
 
+  # RM API will reject PUTs to managed packages
+  # with a contentType in the request
+  describe 'sending a content type to a managed package' do
+    let(:update_headers) do
+      okapi_headers.merge(
+        'Content-Type': 'application/vnd.api+json'
+      )
+    end
+
+    let(:params) do
+      {
+        "data": {
+          "type": 'packages',
+          "attributes": {
+            "name": 'I want to rename this managed package',
+            "contentType": 'Book'
+          }
+        }
+      }
+    end
+
+    before do
+      VCR.use_cassette('put-package-managed-content-type') do
+        put '/eholdings/packages/75-2686',
+            params: params, as: :json, headers: update_headers
+      end
+    end
+
+    it 'gets a successful response' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'editing a custom package' do
     let(:update_headers) do
       okapi_headers.merge(

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -583,6 +583,36 @@ RSpec.describe 'Resources', type: :request do
             .to eq('Only 2000s issues available.')
         end
       end
+
+      describe 'trying to update fields only available to custom resources' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'resources',
+              "attributes": {
+                "name": 'I want a cool title name',
+                "isPeerReviewed": true,
+                "publicationType": 'Newspaper',
+                "publisherName": 'Frontside Newspapers',
+                "edition": '5',
+                "description": 'Something something something',
+                "url": 'https://frontside.io'
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-resources-managed-update-custom-fields') do
+            put '/eholdings/resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with OK status' do
+          expect(response).to have_http_status(200)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIEH-321

When we send `contentType` or `packageName` in the request to `PUT` a managed package, RM API rejects the request completely.

Managed resources surprisingly don't have a problem with accepting uneditable attributes - they're just ignored.

## Approach
Don't send `contentType` or `packageName` changes to managed packages.