### PR TITLE
UIEH-327 Fix managed resource editing

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -172,13 +172,23 @@ class Resource < RmApiResource
   end
 
   def resource_update_fields
-    resource.to_hash.with_indifferent_access.slice(
-      :isSelected,
-      :visibilityData,
-      :customCoverageList,
-      :customEmbargoPeriod,
-      :coverageStatement,
-      :url
-    )
+    if isTitleCustom?
+      resource.to_hash.with_indifferent_access.slice(
+        :isSelected,
+        :visibilityData,
+        :customCoverageList,
+        :customEmbargoPeriod,
+        :coverageStatement,
+        :url
+      )
+    else
+      resource.to_hash.with_indifferent_access.slice(
+        :isSelected,
+        :visibilityData,
+        :customCoverageList,
+        :customEmbargoPeriod,
+        :coverageStatement
+      )
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Mon, 16 Apr 2018 22:17:18 GMT
+      - Wed, 18 Apr 2018 04:03:13 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,9 +36,9 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 363441us'
+        : 202 403708us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 43277us'
+        : 200 43430us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 961937/configurations
+      - 569831/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,10 +107,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 16 Apr 2018 22:17:18 GMT
+  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
     body:
       encoding: US-ASCII
       string: ''
@@ -135,19 +135,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1668'
+      - '1227'
       Connection:
       - keep-alive
       Date:
-      - Mon, 16 Apr 2018 22:17:21 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Amzn-Requestid:
-      - edaaebfa-41c3-11e8-98b8-2dd87aa2e398
+      - 6ac72bd3-42bd-11e8-8ad1-2907b8b65f37
       X-Amzn-Remapped-Content-Length:
-      - '1668'
+      - '1227'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FdIVcGznIAMFQEw=
+      - FhN8WExdIAMFg-Q=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,34 +159,32 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 16 Apr 2018 22:17:19 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ad15c70abd681cb2e8c1d7aaa175778a.cloudfront.net (CloudFront)
+      - 1.1 9e9659bd2cd38b362d54042306676bd4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - th6c8YCcrVU0j2ADst7oM4NhSDeYPHFFEwbNtUUkpBt4UJlyg0kqJA==
+      - wlRPDVNeQdc7uIbTlGGrE1X-ftq9Hf4Ad0eudGLCfEtAV_c7NiFtgw==
     body:
       encoding: UTF-8
-      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
-        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
-        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","packageType":"Variable","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":false,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
-        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
+      string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
+        the World","publisherName":"ABS Energy Research","identifiersList":[{"id":"15KM","source":"MFS","subtype":0,"type":8},{"id":"417981","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Electrical
+        Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
+        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Mon, 16 Apr 2018 22:17:21 GMT
+  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
     body:
       encoding: UTF-8
-      string: '{"isSelected":false,"isHidden":false,"customCoverageList":[{"beginCoverage":"2005-01-01","endCoverage":""},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"coverageStatement":"Only
-        2000s issues available.","titleName":"I want a cool title name","pubType":"newspaper","isPeerReviewed":true,"publisherName":"Frontside
-        Newspapers","edition":"5","description":"Something something something","url":"https://frontside.io"}'
+      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[],"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":null,"titleName":"ESI:
+        Electrical Supply Industries of the World","pubType":"BookSeries","isPeerReviewed":false,"publisherName":"ABS
+        Energy Research","edition":null,"description":null,"url":null}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -212,13 +210,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 16 Apr 2018 22:17:22 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Amzn-Requestid:
-      - eef8c8d9-41c3-11e8-9ce8-a32faf221e40
+      - 6ae16aae-42bd-11e8-8d94-0d0619c2741b
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FdIVyGlcIAMFQlA=
+      - FhN8YFQmoAMF72A=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -230,23 +228,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 16 Apr 2018 22:17:22 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ae7fd0d88f365738edb8b211d5f7884a.cloudfront.net (CloudFront)
+      - 1.1 881f5449ef82fbe0a0cb15b728b80579.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fM3Nvf0yqn5I3YaEFwv9rvKwN8FmNasMO-J01kF8CBAe9MREfa9FhQ==
+      - wErngAHnPatDAsxETKRSh6Fn2WvTfIwGFe37N2vIYTksxaNMwG2UBQ==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Apr 2018 22:17:22 GMT
+  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
     body:
       encoding: US-ASCII
       string: ''
@@ -271,19 +269,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1668'
+      - '1227'
       Connection:
       - keep-alive
       Date:
-      - Mon, 16 Apr 2018 22:17:23 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Amzn-Requestid:
-      - efb33fba-41c3-11e8-b815-af716704f074
+      - 6b25033a-42bd-11e8-9994-d76265ad28c0
       X-Amzn-Remapped-Content-Length:
-      - '1668'
+      - '1227'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FdIV-F4RoAMFwuw=
+      - FhN8cEOGIAMFqAg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -295,24 +293,22 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 16 Apr 2018 22:17:22 GMT
+      - Wed, 18 Apr 2018 04:03:14 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 303f2602a6c74044df3bfb65e57f0d8e.cloudfront.net (CloudFront)
+      - 1.1 1a912d612b879ef62d1eb2f875df3326.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - tF3Ip-Gk9CXDPvelMfKDOzwck62RDmunWOKEZjNpGjB6L78TUouHaQ==
+      - ysmis19QW43VNrGAxDXfEqmEx3hIaEno-PFzBbAXpWbCiGxu3DWHYg==
     body:
       encoding: UTF-8
-      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
-        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
-        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","packageType":"Variable","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":false,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
-        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
+      string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
+        the World","publisherName":"ABS Energy Research","identifiersList":[{"id":"15KM","source":"MFS","subtype":0,"type":8},{"id":"417981","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Electrical
+        Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
+        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Mon, 16 Apr 2018 22:17:23 GMT
+  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -604,7 +604,7 @@ RSpec.describe 'Resources', type: :request do
 
         before do
           VCR.use_cassette('put-resources-managed-update-custom-fields') do
-            put '/eholdings/resources/22-1887786-1440285',
+            put '/eholdings/resources/19-530-417981',
                 params: params, as: :json, headers: update_headers
           end
         end


### PR DESCRIPTION
## Purpose
When we send `url` in the request to PUT a managed resource, RM API rejects the request completely.

Resolves https://issues.folio.org/browse/UIEH-327

## Approach
Mimicked pattern from https://github.com/folio-org/mod-kb-ebsco/pull/106