### PR TITLE
DELETE endpoint for custom packages - UIEH-239

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -31,7 +31,7 @@
           "pathPattern": "/eholdings/providers*"
         },
         {
-          "methods": [ "GET", "PUT" ],
+          "methods": [ "GET", "PUT", "DELETE" ],
           "pathPattern": "/eholdings/packages*"
         },
         {

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PackagesController < ApplicationController
-  before_action :set_package, only: %i[show update resources]
+  before_action :set_package, only: %i[show update destroy resources]
 
   deserializable_resource :package, only: :update,
                                     class: DeserializablePackage
@@ -31,6 +31,17 @@ class PackagesController < ApplicationController
     else
       render jsonapi_errors: package_validation.errors,
              status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    package_validation = Validation::PackageDestroyParameters.new(@package)
+
+    if package_validation.valid?
+      @package.delete
+    else
+      render jsonapi_errors: package_validation.errors,
+             status: :bad_request
     end
   end
 

--- a/app/controllers/validation/package_destroy_parameters.rb
+++ b/app/controllers/validation/package_destroy_parameters.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Validation
+  class PackageDestroyParameters
+    include ActiveModel::Validations
+
+    validate :package_deletable?
+
+    def package_deletable?
+      # Package can be deleted only if its custom
+      # Check for that
+      errors.add(:package, 'cannot be deleted') unless
+        @package.isCustom
+    end
+
+    def initialize(package)
+      @package = package
+    end
+  end
+end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -99,6 +99,14 @@ class Package < RmApiResource
     refresh!
   end
 
+  def delete
+    self.class.update(
+      vendor_id: vendorId,
+      package_id: packageId,
+      isSelected: false
+    )
+  end
+
   private
 
   def refresh!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :packages, only: %i[index show update] do
+    resources :packages, only: %i[index show update destroy] do
       member do
         get 'resources'
       end

--- a/spec/fixtures/vcr_cassettes/delete-custom-package.yml
+++ b/spec/fixtures/vcr_cassettes/delete-custom-package.yml
@@ -1,0 +1,214 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 363411us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42600us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 924553/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:42 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2848230
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '460'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      X-Amzn-Requestid:
+      - 65747db1-4339-11e8-8a1c-5b15c667b33b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FjP8dEXKIAMFiGQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 031c38bec1e4f8401157e1d767a53637.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ePULrjhqniu4QfoNapu5R51k8yDWrKSOo9jWDPw4N6fURP0qbj8-CQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2848230,"packageName":"SD''s test package","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:42 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2848230
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 18 Apr 2018 18:50:43 GMT
+      X-Amzn-Requestid:
+      - 658cc021-4339-11e8-9867-b56da89ce01f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FjP8eHN_oAMF9ig=
+      X-Amzn-Remapped-Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3d183dc06807f77c9361cf878faaed82.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - A9h7zPLuF95nS6E4UjsAYfSwLOiSVDeR5TwUBwJF52AOU1dWQXe3bg==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-deleted-custom-package.yml
+++ b/spec/fixtures/vcr_cassettes/delete-deleted-custom-package.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 18 Apr 2018 18:50:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1759us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 44419us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 847273/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:43 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2848230
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '68'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 18 Apr 2018 18:50:43 GMT
+      X-Amzn-Requestid:
+      - 65ca8d4c-4339-11e8-8098-ebb23b3c2b18
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FjP8iGfBoAMF36w=
+      X-Amzn-Remapped-Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 89dbe128b639cdc1367dfadc360947d0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bbWtFdH1035zdrqD-hdxMbOy3L5lubLiNE753WcqI_W2aQ4qAhi3ww==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1001,"subCode":0,"message":"Package not found"}]}'
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/delete-non-custom-package.yml
+++ b/spec/fixtures/vcr_cassettes/delete-non-custom-package.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 18 Apr 2018 18:50:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1405us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42961us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 158852/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:43 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/583/packages/4345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '470'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 18 Apr 2018 18:50:43 GMT
+      X-Amzn-Requestid:
+      - 65fd3593-4339-11e8-acbf-771d8d46cca4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - FjP8mG1SoAMF9RA=
+      X-Amzn-Remapped-Date:
+      - Wed, 18 Apr 2018 18:50:42 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 641a0f932299b827b56d2560405082d5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - k8HGjYYZWp_81sp5P8GLlUYQENGM6xUI1UdnUYG0W028xjbLyRaCWg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":4345,"packageName":"ABC-CLIO eBook Collection","isCustom":false,"vendorId":583,"vendorName":"ABC-CLIO","titleCount":9428,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":9402,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2010-01-21","endCoverage":"2018-02-21"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Wed, 18 Apr 2018 18:50:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1094,4 +1094,45 @@ RSpec.describe 'Packages', type: :request do
       end
     end
   end
+
+  describe 'deleting a custom package' do
+    describe 'delete a custom package successfully' do
+      before do
+        VCR.use_cassette('delete-custom-package') do
+          delete '/eholdings/packages/123355-2848230',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a successful response' do
+        expect(response).to have_http_status(204)
+      end
+    end
+
+    describe 'trying to delete a deleted package results in error' do
+      before do
+        VCR.use_cassette('delete-deleted-custom-package') do
+          delete '/eholdings/packages/123355-2848230',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a not found response' do
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    describe 'trying to delete a non-custom package' do
+      before do
+        VCR.use_cassette('delete-non-custom-package') do
+          delete '/eholdings/packages/583-4345',
+                 headers: okapi_headers
+        end
+      end
+
+      it 'gets a bad request response' do
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-329, users should be able to delete a custom package. This PR implements functionality to support that.

## Approach
- Implement DELETE call, route it to destroy in package controller, validate if it is a custom package.
- If it is a custom package, send PUT request to RM API with "isSelected"=false for the corresponding vendor id and package id; and if package is deleted successfully, we respond with a `204 No Content`
- If it is not a custom package, then give a response of `400 - stating that the package cannot be deleted`
- If they attempt to delete a package that's already deleted, give a `404 - Package not found` as response.
- Add associated unit tests.
- Sample request: `DELETE /eholdings/packages/123355-2848225`
- Sample response: `204 No Content`

## Screenshots
![custom_package_delete](https://user-images.githubusercontent.com/33662516/38952462-c4fba4b8-4319-11e8-855f-cd348caeb50f.gif)
