### PR TITLE
Repair custom package and resource editing

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -142,7 +142,7 @@ class Package < RmApiResource
   end
 
   def update_fields
-    if isCustom?
+    if isCustom
       to_hash.with_indifferent_access.slice(
         :isSelected,
         :allowEbscoToAddTitles,

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -172,7 +172,7 @@ class Resource < RmApiResource
   end
 
   def resource_update_fields
-    if isTitleCustom?
+    if isTitleCustom
       resource.to_hash.with_indifferent_access.slice(
         :isSelected,
         :visibilityData,


### PR DESCRIPTION
## Purpose
When attempting to save edits to a custom package, I was running into this:

![screen shot 2018-04-23 at 9 16 38 am](https://user-images.githubusercontent.com/230597/39148948-348ed15a-4703-11e8-99ba-7b9a0b7c9cce.png)

The package name and content type weren't making it through `mod-kb-ebsco` to be sent to RM API.

## Approach
Fix if statements in `update_fields`.

