### PR TITLE
Update contributors list in PUT request for custom title

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -86,6 +86,9 @@ class ResourcesController < ApplicationController
         customCoverageList: [
           %i[beginCoverage endCoverage]
         ],
+        contributorsList: [
+          %i[type contributor]
+        ],
         customEmbargoPeriod: %i[
           embargoUnit
           embargoValue

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -6,7 +6,7 @@ module Validation
   class ResourceUpdateParameters
     include ActiveModel::Validations
 
-    attr_accessor :isSelected, :isHidden, :customCoverageList,
+    attr_accessor :isSelected, :isHidden, :customCoverageList, :contributorsList,
                   :embargoUnit, :embargoValue, :coverageStatement
 
     # Deselected resources cannot be customized.  Though the UI is smart enough
@@ -16,6 +16,7 @@ module Validation
     with_options unless: :isSelected do
       validates :isHidden, absence: true, unless: :isSelected
       validates :customCoverageList, absence: true, unless: :isSelected
+      validates :contributorsList, absence: true, unless: :isSelected
       validates :embargoUnit, absence: true, unless: :isSelected
       validates :embargoValue, absence: true, unless: :isSelected
       validates :coverageStatement, absence: true, unless: :isSelected
@@ -25,6 +26,7 @@ module Validation
       @isSelected = params[:isSelected]
       @isHidden = params.dig(:visibilityData, :isHidden)
       @customCoverageList = params[:customCoverageList]
+      @contributorsList = params[:contributorsList]
       @embargoUnit = params.dig(:customEmbargoPeriod, :embargoUnit)
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]

--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -41,4 +41,8 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
   attribute :customCoverages do |value|
     { customCoverageList: value }
   end
+
+  attribute :contributors do |value|
+    { contributorsList: value }
+  end
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -142,7 +142,7 @@ class Package < RmApiResource
   end
 
   def update_fields
-    if isCustom?
+    if isCustom
       to_hash.with_indifferent_access.slice(
         :isSelected,
         :allowEbscoToAddTitles,

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -108,6 +108,7 @@ class Resource < RmApiResource
       isSelected: resource_attributes[:isSelected],
       isHidden: resource_attributes[:visibilityData][:isHidden],
       customCoverageList: sorted_coverage,
+      contributorsList: resource_attributes[:contributorsList],
       customEmbargoPeriod: resource_attributes[:customEmbargoPeriod],
       coverageStatement: resource_attributes[:coverageStatement],
       titleName: attributes[:titleName],
@@ -193,11 +194,12 @@ class Resource < RmApiResource
   end
 
   def resource_update_fields
-    if isTitleCustom?
+    if isTitleCustom
       resource.to_hash.with_indifferent_access.slice(
         :isSelected,
         :visibilityData,
         :customCoverageList,
+        :contributorsList,
         :customEmbargoPeriod,
         :coverageStatement,
         :url

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Mon, 23 Apr 2018 19:54:44 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1349us'
+        : 202 357279us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42636us'
+        : 200 51033us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.3.1
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.36.3.1
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 350296/configurations
+      - 419501/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:45 GMT
+  recorded_at: Mon, 23 Apr 2018 19:54:44 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
@@ -139,15 +139,15 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Amzn-Requestid:
-      - 813bd5f3-44e2-11e8-a396-81c2f28a652d
+      - 2b7b8e51-4730-11e8-94c2-89da6928a7db
       X-Amzn-Remapped-Content-Length:
       - '1078'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNtAFguoAMF81A=
+      - Fz4AwG8FIAMFfdg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,15 +159,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5a27d8f87b0f1db56d469d1fefb312ac.cloudfront.net (CloudFront)
+      - 1.1 8a1bcca0fe247aaeeb568c933bd30ad4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - qkhOA3_R3FTfFV_vYxErk01FqUP6CEYN6xJqbT1fdWD46Qow1Jg1oQ==
+      - PZMP-RCNVkAVTw7Stgru3kjSrrftLXN5kkIsUPF5x1UkT8l38sCmCA==
     body:
       encoding: UTF-8
       string: '{"titleId":17053010,"titleName":"This is the best title ever","publisherName":"Frontside
@@ -178,13 +178,14 @@ http_interactions:
         are many years.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"https://frontside.io","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Something
         something something","edition":"5","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:45 GMT
+  recorded_at: Mon, 23 Apr 2018 19:54:44 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"There
+      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"Lang
+        Z"},{"type":"Illustrator","contributor":"last first"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"There
         are many years.","titleName":"This is the best title ever","pubType":"newspaper","isPeerReviewed":true,"publisherName":"Frontside
         Newspapers","edition":"5","description":"Something something something","url":"https://frontside.io"}'
     headers:
@@ -212,13 +213,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:46 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Amzn-Requestid:
-      - 8184c60a-44e2-11e8-9ca4-113a60f672b5
+      - 2baf4830-4730-11e8-8f07-2b222fd2e9d5
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNtFH4PIAMF5Sw=
+      - Fz4AzFEuIAMFm5g=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -230,20 +231,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b5434ae2f27f51f7ce619d0889d77d8d.cloudfront.net (CloudFront)
+      - 1.1 d56db0d65906a3edce526dc6600d65c6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 1W2aDulAVTUfpM2IDo217RIi2i5JrCi-MIUua3oNbmsavlG_79f8bw==
+      - 47psrcXuOPAgZbhR3Uxm29J1Arsu2HPIIHOp3w8mb2Tzr421gpB0EA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:46 GMT
+  recorded_at: Mon, 23 Apr 2018 19:54:45 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2739728/titles/17053010
@@ -271,19 +272,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1078'
+      - '1168'
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:46 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Amzn-Requestid:
-      - 81b9e053-44e2-11e8-981b-e7dc074c8a33
+      - 2bd2fd3a-4730-11e8-b9ad-15e605d6be25
       X-Amzn-Remapped-Content-Length:
-      - '1078'
+      - '1168'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNtIHYlIAMF7wA=
+      - Fz4A2GKsIAMF8og=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -295,15 +296,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Mon, 23 Apr 2018 19:54:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a6a098cdc333f9948baa2a00729f4f25.cloudfront.net (CloudFront)
+      - 1.1 3ca41706981cad42d8ecaabd29f88efa.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - FxtnI8AYgF8kHC5Nd4i6a-I9reZbnsJXxmOao5Q9fU_wQE2k_wpuVg==
+      - kyAOGMlM-7PcHdQviJQnhwNZiuwZU9s2Md9c_-I-WK0tSiW2rFgu4A==
     body:
       encoding: UTF-8
       string: '{"titleId":17053010,"titleName":"This is the best title ever","publisherName":"Frontside
@@ -312,7 +313,8 @@ http_interactions:
         DEV CORPORATE CUSTOMER","locationId":38204653,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
         by Customer"},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"There
         are many years.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"https://frontside.io","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Something
-        something something","edition":"5","isPeerReviewed":true,"contributorsList":[]}'
+        something something","edition":"5","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"Lang
+        Z"},{"type":"illustrator","contributor":"last first"}]}'
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:46 GMT
+  recorded_at: Mon, 23 Apr 2018 19:54:45 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-contributors.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-contributors.yml
@@ -1,0 +1,252 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 23 Apr 2018 19:46:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 361741us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 44395us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 547740/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2170'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 23 Apr 2018 19:46:09 GMT
+      X-Amzn-Requestid:
+      - f83e737a-472e-11e8-89f6-8dbaa70bd4fc
+      X-Amzn-Remapped-Content-Length:
+      - '2170'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Fz2wNH8PIAMF7uw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 23 Apr 2018 19:46:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 00869352a9ca097c8b9084cf3a6e32d8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2n10B9_23rjbf7JsSXKf6ZJv6BG38GbOkCjK1Zskjo_6myUR_u95Cw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"some
+        type","contributor":"Lang Z"},{"type":"Illustrator","contributor":"last first"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
+        have so much coverage.","titleName":"Science","pubType":"Journal","isPeerReviewed":true,"publisherName":"American
+        Association for the Advancement of Science","edition":null,"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","url":"http://www.ebsco.com"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 23 Apr 2018 19:46:09 GMT
+      X-Amzn-Requestid:
+      - f85d1eee-472e-11e8-bce0-f52a1487f1c3
+      X-Amzn-Remapped-Content-Length:
+      - '77'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Fz2wPGcCIAMFgRA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 23 Apr 2018 19:46:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 6b55f12026efe25ff5fb4b22b811b2c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eGgvLy1zLjKqXHXpgSl7zmTHzwZhSH5l-ZoHC-4x7kMJmGm2EwDsPg==
+    body:
+      encoding: UTF-8
+      string: '{"Errors":[{"Code":1006,"Message":"Attribute Type is invalid.","SubCode":0}]}'
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-contributors.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-contributors.yml
@@ -1,0 +1,321 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 23 Apr 2018 19:40:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 354562us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42711us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 129938/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:40:49 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2170'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Amzn-Requestid:
+      - 39ecadb6-472e-11e8-bc48-43bbacffacb6
+      X-Amzn-Remapped-Content-Length:
+      - '2170'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Fz1-UEnJoAMFbFg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c06c27c7288c4be29d3b21ad2efad59f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Hwf9W9bFyYDN3fxN62M1ylAtSAhLrotXYn7PaIErDsjD1QwhBE69mA==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"Lang
+        Z"},{"type":"Illustrator","contributor":"last first"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
+        have so much coverage.","titleName":"Science","pubType":"Journal","isPeerReviewed":true,"publisherName":"American
+        Association for the Advancement of Science","edition":null,"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","url":"http://www.ebsco.com"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Amzn-Requestid:
+      - 3a10142d-472e-11e8-997b-151e71eb83eb
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Fz1-XF8xIAMFRDA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 28b1b9930ccdd3e560b3f8d56677a679.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xKmSMlkKiMXOCrVVgq0FDGDqPnibaO1xouBux0XIy3MEqDEIAvFUWQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2170'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Amzn-Requestid:
+      - 3a4b48ed-472e-11e8-a454-79291a64e2df
+      X-Amzn-Remapped-Content-Length:
+      - '2170'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Fz1-aFdZoAMFh9Q=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 23 Apr 2018 19:40:50 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 89cb9fcdbd0314a45e84448b824c18db.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - uZGl8UOR_51GIexWZ0XG1adqOHM_FFbkbE-bIjjnQL90FA2UC9j3cw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-319, users should be able to edit "contributors" for a custom title. This implementation supports that.

## Approach
- Allow "contributors" to be passed to mod-kb-ebsco
- De-serialize it to "contributorsList" for RM API and send it in the PUT call
- Serialize the response from RM API to "contributors" and pass it in response
- Depend on RM API to validate supported contributor types
- Associated unit tests

#### TODOS and Open Questions
- [x] We have to do something similar to support the same field in POST request while creating a custom title. Is that a separate user story? - Increased the scope of this story to include the same for POST, will be a separate PR though.

## Screenshots
![contributors_custom_title](https://user-images.githubusercontent.com/33662516/39153288-acb3511e-4718-11e8-817f-70be070bcf93.gif)