### PR TITLE
Add contributors while creating a custom title - POST - UIEH-319

### DIFF
--- a/app/controllers/validation/resource_create_parameters.rb
+++ b/app/controllers/validation/resource_create_parameters.rb
@@ -8,7 +8,7 @@ module Validation
 
     attr_accessor :titleName, :pubType, :packageId, :publisherName,
                   :isPeerReviewed, :edition, :description, :url,
-                  :customCoverageList,
+                  :customCoverageList, :contributorsList,
                   :embargoUnit, :embargoValue, :coverageStatement
 
     validates :titleName, presence: true, length: { maximum: 400 }
@@ -37,6 +37,7 @@ module Validation
       @description = params[:description]
       @url = params[:url]
       @customCoverageList = params[:customCoverageList]
+      @contributorsList = params[:contributorsList]
       @embargoUnit = params.dig(:customEmbargoPeriod, :embargoUnit)
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]

--- a/app/serializable/serializable_resource.rb
+++ b/app/serializable/serializable_resource.rb
@@ -17,7 +17,23 @@ class SerializableResource < SerializableJSONAPIResource
              :titleId
 
   attribute :contributors do
-    @object.contributorsList || []
+    contributor_types = {
+      editor: 'Editor',
+      illustrator: 'Illustrator',
+      author: 'Author'
+    }
+
+    if @object.contributorsList
+      @object.contributorsList.map do |contributor|
+        type_key = contributor['type'].downcase.to_sym
+        {
+          type: contributor_types[type_key],
+          contributor: contributor['contributor']
+        }
+      end
+    else
+      []
+    end
   end
   attribute :identifiers do
     types = {

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-all-fields.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-all-fields.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Mon, 23 Apr 2018 01:23:16 GMT
+      - Tue, 24 Apr 2018 15:10:34 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 376211us'
+        : 202 357183us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42714us'
+        : 200 44217us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 922194/configurations
+      - 182905/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 01:23:16 GMT
+  recorded_at: Tue, 24 Apr 2018 15:10:34 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -139,35 +139,36 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 01:23:16 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Amzn-Requestid:
-      - e648e162-4694-11e8-9b65-d53c74197b70
+      - a366cb7f-47d1-11e8-9367-d7813f113811
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FxVMvFTFoAMFlJw=
+      - F2hUtG0HoAMFTTg=
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 01:23:16 GMT
+      - Tue, 24 Apr 2018 15:10:35 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ded72cd2ec35ccfc935b5442dfad81c9.cloudfront.net (CloudFront)
+      - 1.1 5a27d8f87b0f1db56d469d1fefb312ac.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - GNtHSJ9Njr7eAzK6dV8WbOMzf0406rBx_kDOIo039sDwtFBMjrS6eg==
+      - ged2V0BmQGxWCQMu-EYLj3davF6T_7-4HEB0AOgR94l3I4b1V4Of5Q==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":64,"packagesSelected":64,"vendorToken":null}]}'
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 01:23:16 GMT
+  recorded_at: Tue, 24 Apr 2018 15:10:36 GMT
 - request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles
     body:
       encoding: UTF-8
-      string: '{"titleName":"New Custom Title Testing All Fields Again","pubType":"book","coverageStatement":"Test
+      string: '{"titleName":"Totally New Custom Title Testing All Fields","pubType":"book","coverageStatement":"Test
         coverage statement","publisherName":"test publisher","edition":"test edition","description":"test
-        description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"peerReviewed":true}'
+        description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"some
+        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"peerReviewed":true}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -193,26 +194,26 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 01:23:19 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Amzn-Requestid:
-      - e684ff45-4694-11e8-a2fb-61b565c1644f
+      - a4b7b5d1-47d1-11e8-9d25-87c414cee773
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FxVMzHBhoAMF4Nw=
+      - F2hVEFIjIAMF6tA=
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 01:23:18 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 da6fd4689552fc29462fc5d11b2e27dd.cloudfront.net (CloudFront)
+      - 1.1 ac3474fe463b33f1439c8d949f9a075f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 6TyI_-FObPnYopBfAn4V00Y9jU4k74Nxbd4j8Pvmxxoqs4oA0SvrFA==
+      - yyidAJSKkujhgXRpdMsV4VD1_ovsg9hJ6ewrRk_GQ_DY3LAvKnkJcw==
     body:
       encoding: UTF-8
-      string: '{"titleId":17098629}'
+      string: '{"titleId":17100757}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 01:23:19 GMT
+  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -244,30 +245,30 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 01:23:20 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Amzn-Requestid:
-      - e83399c7-4694-11e8-9c36-ff85391cec79
+      - a4f58227-47d1-11e8-a779-9593a2eaedbb
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FxVNPH0BIAMFmPw=
+      - F2hVIFjjoAMFYPg=
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 01:23:19 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 441af0d1342facc04e278fcc912c699d.cloudfront.net (CloudFront)
+      - 1.1 437f7a19314c94b424a3bd6ebc827aaa.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - crd4gOZJo54cf9SIe7-VOWPV5jARyFz6BbFPFpcQ63Az5Jw0FQ9d_w==
+      - V6qFydbJh-n_mVR_l3RmjlsHxZuzCx-4lNJCPTIq75wblOlOxB7WmQ==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":64,"packagesSelected":64,"vendorToken":null}]}'
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 01:23:20 GMT
+  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles/17098629
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles/17100757
     body:
       encoding: US-ASCII
       string: ''
@@ -292,19 +293,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1068'
+      - '1171'
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 01:23:20 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Amzn-Requestid:
-      - e8563d14-4694-11e8-8c3a-1be867a839f1
+      - a50befc1-47d1-11e8-a4b4-1165bfed6d2e
       X-Amzn-Remapped-Content-Length:
-      - '1068'
+      - '1171'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FxVNRHeIIAMFvEg=
+      - F2hVJE3KoAMFWwg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -316,23 +317,24 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 01:23:19 GMT
+      - Tue, 24 Apr 2018 15:10:37 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 91ccbcd6bac9f333587d2a41caeeb0c5.cloudfront.net (CloudFront)
+      - 1.1 e18a9585a869d9169e759f7003f46518.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xaWWuJD7n14NEuWc9Gwj_b-LOLIlk6gWQeUtqp7r_J9SuYUtNHnoIw==
+      - md5aRIuJ4cTLYOEoz64e9DmFGfsbGC_T2mRlV9uHAMUNFen7dQ3WSA==
     body:
       encoding: UTF-8
-      string: '{"titleId":17098629,"titleName":"New Custom Title Testing All Fields
-        Again","publisherName":"test publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17098629,"packageId":2843712,"packageName":"Carole
+      string: '{"titleId":17100757,"titleName":"Totally New Custom Title Testing All
+        Fields","publisherName":"test publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17100757,"packageId":2843712,"packageName":"Carole
         Custom Package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38326116,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"Test
+        DEV CORPORATE CUSTOMER","locationId":38332358,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"Test
         coverage statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
-        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[]}'
+        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
+        editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 01:23:20 GMT
+  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-invalid-contributor-type.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-invalid-contributor-type.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 24 Apr 2018 15:04:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 364725us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 45129us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 404680/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 24 Apr 2018 15:04:39 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 24 Apr 2018 15:04:40 GMT
+      X-Amzn-Requestid:
+      - cfcf9f11-47d0-11e8-8b75-f33badcf9188
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - F2gdQHp1oAMFVSQ=
+      X-Amzn-Remapped-Date:
+      - Tue, 24 Apr 2018 15:04:40 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d1c6b0af1d2d0f3694496e7cbde73924.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Gvc8kxp_9yZXOJmY0h9_7HANfNdu-u23sWumqqc5oj_y-W6PDQXbfQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Tue, 24 Apr 2018 15:04:39 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Custom Title Testing Invalid Contributor","pubType":"book","contributorsList":[{"type":"invalid
+        type","contributor":"some editor"},{"type":"Illustrator","contributor":"some
+        illustrator"}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '139'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 24 Apr 2018 15:04:40 GMT
+      X-Amzn-Requestid:
+      - cfec75e7-47d0-11e8-a3ab-f5168aa03fa3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - F2gdRHU5oAMFteg=
+      X-Amzn-Remapped-Date:
+      - Tue, 24 Apr 2018 15:04:40 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 001e3d2e0977f947f2e93be8539ac1de.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 3749uSjofUDlc2ZrKYspdzf541qdaLAwubnX1eJ68bSVjnXEsEGarg==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Parameter contributorsList.contributorType
+        must be one of (author, editor, illustrator)."}]}'
+    http_version: 
+  recorded_at: Tue, 24 Apr 2018 15:04:39 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Resources', type: :request do
         expect(attributes.contributors.length).to eq(2)
       end
       it 'contributor has a type' do
-        expect(attributes.contributors[0].type).to eq('author')
+        expect(attributes.contributors[0].type).to eq('Author')
       end
       it 'contributor has a name' do
         expect(attributes.contributors[0].contributor).to eq('Havard, Margaret')


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-319, users should be able to add a list of contributors while creating a custom title.

## Approach
- Add contributors to allowed param validations
- Pass it through to RM API using resource create_resource model
- RM API returns contributor type values in lower-case, serialize them for the first character to be upper case for consistency in mod-kb-ebsco
- Associated unit tests

## Screenshots
![post_contributor](https://user-images.githubusercontent.com/33662516/39199169-d1a5d368-47b6-11e8-81d8-655589d231e3.gif)
