### PR TITLE
Hotfix for customer resource updates

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -28,10 +28,10 @@ class ResourcesController < ApplicationController
 
   def update
     resource_validation =
-      Validation::ResourceUpdateParameters.new(resource_params)
+      Validation::ResourceUpdateParameters.new(update_params)
 
     if resource_validation.valid?
-      @resource.update resource_params
+      @resource.update update_params
       render jsonapi: @resource
     else
       render jsonapi_errors: resource_validation.errors,
@@ -82,7 +82,36 @@ class ResourcesController < ApplicationController
         :description,
         :url,
         :packageId,
-        visibilityData: [:isHidden],
+        visibilityData: %i[isHidden reason],
+        customCoverageList: [
+          %i[beginCoverage endCoverage]
+        ],
+        contributorsList: [
+          %i[type contributor]
+        ],
+        customEmbargoPeriod: %i[
+          embargoUnit
+          embargoValue
+        ]
+      )
+  end
+
+  def update_params
+    # NOTE: deserialization happens before param parsing, so we
+    # use the RMAPI property names here
+    params
+      .require(:resource)
+      .permit(
+        :titleName,
+        :pubType,
+        :isSelected,
+        :coverageStatement,
+        :isPeerReviewed,
+        :publisherName,
+        :edition,
+        :description,
+        :url,
+        visibilityData: %i[isHidden reason],
         customCoverageList: [
           %i[beginCoverage endCoverage]
         ],

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -92,7 +92,6 @@ class Resource < RmApiResource
     # Mimicking AR as closely as we can here. Invoking `update` on a
     # model (i.e. as an instance method) applies a hash of changes
     # to the instance and then persists that data to the store.
-
     merge_fields!(params)
     save!
   end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -596,7 +596,8 @@ RSpec.describe 'Resources', type: :request do
                 "publisherName": 'Frontside Newspapers',
                 "edition": '5',
                 "description": 'Something something something',
-                "url": 'https://frontside.io'
+                "url": 'https://frontside.io',
+                "packageId": '19-530'
               }
             }
           }


### PR DESCRIPTION
This is a quick fix for the broken edits we saw shortly before the demo today.  While `packageId` is a required field in the json payload for resource creation, it will break resource updates by overriding the existing packageId on the model - which is a computed property.  We're currently investigating why this didn't break in the tests, and that (along with hopefully a more elegant solution than the very un-DRY fix you see here) will be coming in a later PR.  For now, this is needed to unblock updates on resources wholesale.  It's currently running through telepresence on my box and at some point i'll have to close my laptop 😀 