### PR TITLE
Use okapi gem from rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'dotenv-rails', groups: %i[development test]
 
 gem 'flexirest'
 gem 'jsonapi-rails'
-gem 'okapi', git: 'git://github.com/thefrontside/okapi.rb/', branch: 'master'
+gem 'okapi', '~> 2.0'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/thefrontside/okapi.rb/
-  revision: 04e69b667f443ec859120e14dcf4639bca93bb2c
-  branch: master
-  specs:
-    okapi (1.0.2)
-      clamp (~> 1.1)
-      highline (~> 1.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -53,7 +44,7 @@ GEM
     ast (2.3.0)
     builder (3.2.3)
     byebug (9.1.0)
-    clamp (1.1.2)
+    clamp (1.2.1)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -111,6 +102,9 @@ GEM
     nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    okapi (2.0.0)
+      clamp (~> 1.1)
+      highline (~> 1.7)
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
@@ -232,7 +226,7 @@ DEPENDENCIES
   jsonapi-rails
   listen (>= 3.0.5, < 3.2)
   map (~> 6.0)
-  okapi!
+  okapi (~> 2.0)
   pry-byebug
   pry-remote
   puma (~> 3.7)


### PR DESCRIPTION
## Purpose

When we started out, the okapi gem was not released to rubygems.org, so we linked directly to the git repostitory. It's now stable, and relased for awhile now, so we shouldbe consuming it just like any
other ruby app.

## Approach
Lock in to any of the 2.x releases. Before 2.0, this was actually a completey unrelated gem
