### PR TITLE
lazily fetch package in packages controller.

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PackagesController < ApplicationController
-  before_action :set_package, only: %i[show update destroy resources]
-
   deserializable_resource :package, only: %i[create update],
                                     class: DeserializablePackage
 
@@ -38,15 +36,15 @@ class PackagesController < ApplicationController
   end
 
   def show
-    render jsonapi: @package, include: params[:include]
+    render jsonapi: package, include: params[:include]
   end
 
   def update
     package_validation = Validation::PackageParameters.new(package_params)
 
     if package_validation.valid?
-      @package.update package_params
-      render jsonapi: @package
+      package.update package_params
+      render jsonapi: package
     else
       render jsonapi_errors: package_validation.errors,
              status: :unprocessable_entity
@@ -54,10 +52,10 @@ class PackagesController < ApplicationController
   end
 
   def destroy
-    package_validation = Validation::PackageDestroyParameters.new(@package)
+    package_validation = Validation::PackageDestroyParameters.new(package)
 
     if package_validation.valid?
-      @package.delete
+      package.delete
     else
       render jsonapi_errors: package_validation.errors,
              status: :bad_request
@@ -66,7 +64,7 @@ class PackagesController < ApplicationController
 
   # Relationships
   def resources
-    @resources = @package.find_resources(
+    @resources = package.find_resources(
       page: params[:page],
       q: params[:q],
       filter: params[:filter],
@@ -78,8 +76,8 @@ class PackagesController < ApplicationController
 
   private
 
-  def set_package
-    @package = packages.find package_id
+  def package
+    @package ||= packages.find package_id
   end
 
   def package_id


### PR DESCRIPTION
## Purpose
There is currently a `before_action` that eagerly fetches the package
on an explicit set of requests (show, update, destroy,
resources). This has a couple of disadvantages.

1. The list of requests has to be manually curated, and if at some
point, the package isn't needed for one of the requests, it could
still be doing the work of fetching it unecessarily.
2. It uses rails magic `before_action :set_package` where none is
really necessary.

## Approach
Instead of magic, just use a regular ruby method that instantiates the
package lazily. This has the advantage of being normal Ruby, and also,
if only getting called when someone actually needs the package.