### PR TITLE
UIEH-343 Correct isPeerReviewed mapping on Resource Create

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -132,12 +132,8 @@ class Resource < RmApiResource
 
   def self.create_resource(params)
     package_id = params['packageId']
-    create_params = params.to_hash.except('packageId', 'isPeerReviewed')
+    create_params = params.to_hash.except('packageId')
     rm_api_create = { vendor_id: provider_id, package_id: package_id }.merge(create_params)
-    # RM API Post method expects peerReviewed instead of isPeerReviewed
-    # this is inconsistent with PUT and will eventually be corrected
-    peer_reviewed = params['isPeerReviewed']
-    rm_api_create['peerReviewed'] = peer_reviewed unless peer_reviewed.nil?
     resource_response = create rm_api_create
     find(
       vendor_id: provider_id,

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-all-fields.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-all-fields.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 24 Apr 2018 15:10:34 GMT
+      - Thu, 26 Apr 2018 16:58:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 357183us'
+        : 202 351184us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 44217us'
+        : 200 42713us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.3.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.3.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 182905/configurations
+      - 478585/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 24 Apr 2018 15:10:34 GMT
+  recorded_at: Thu, 26 Apr 2018 16:58:08 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -139,36 +139,36 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Amzn-Requestid:
-      - a366cb7f-47d1-11e8-9367-d7813f113811
+      - ff2a6dd8-4972-11e8-8420-bd40f8fc4175
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - F2hUtG0HoAMFTTg=
+      - F9W9KG5iIAMF0vg=
       X-Amzn-Remapped-Date:
-      - Tue, 24 Apr 2018 15:10:35 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5a27d8f87b0f1db56d469d1fefb312ac.cloudfront.net (CloudFront)
+      - 1.1 0b202e2428f14940b06527255fa020ea.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - ged2V0BmQGxWCQMu-EYLj3davF6T_7-4HEB0AOgR94l3I4b1V4Of5Q==
+      - M1KGpqhlUaudDuEc9ffFV2QudC0epH5qLYRbGITY5MmPFC9PXnZvkw==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Tue, 24 Apr 2018 15:10:36 GMT
+  recorded_at: Thu, 26 Apr 2018 16:58:09 GMT
 - request:
     method: post
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2852184/titles
     body:
       encoding: UTF-8
       string: '{"titleName":"Totally New Custom Title Testing All Fields","pubType":"book","coverageStatement":"Test
-        coverage statement","publisherName":"test publisher","edition":"test edition","description":"test
-        description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"some
-        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"peerReviewed":true}'
+        coverage statement","isPeerReviewed":true,"publisherName":"test publisher","edition":"test
+        edition","description":"test description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"some
+        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6}}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -194,26 +194,26 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Amzn-Requestid:
-      - a4b7b5d1-47d1-11e8-9d25-87c414cee773
+      - ff54b1b3-4972-11e8-98f8-d1c4379b1e21
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - F2hVEFIjIAMF6tA=
+      - F9W9NEGboAMF0Ig=
       X-Amzn-Remapped-Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ac3474fe463b33f1439c8d949f9a075f.cloudfront.net (CloudFront)
+      - 1.1 1bbfa275cce73ba7a423bc907239dedf.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - yyidAJSKkujhgXRpdMsV4VD1_ovsg9hJ6ewrRk_GQ_DY3LAvKnkJcw==
+      - wp7L5jvU6JPWaTr0AYzZrm4XUwMiQ0UJv5SC2-F9ImbgTAHAJ0vW1A==
     body:
       encoding: UTF-8
-      string: '{"titleId":17100757}'
+      string: '{"titleId":17140550}'
     http_version: 
-  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
+  recorded_at: Thu, 26 Apr 2018 16:58:09 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -245,30 +245,30 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Amzn-Requestid:
-      - a4f58227-47d1-11e8-a779-9593a2eaedbb
+      - ff7c5e71-4972-11e8-b27a-7b5cfc78c409
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - F2hVIFjjoAMFYPg=
+      - F9W9QF9QoAMFr_g=
       X-Amzn-Remapped-Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 437f7a19314c94b424a3bd6ebc827aaa.cloudfront.net (CloudFront)
+      - 1.1 bc6981f82440e44448ee5dd3577bf4f4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - V6qFydbJh-n_mVR_l3RmjlsHxZuzCx-4lNJCPTIq75wblOlOxB7WmQ==
+      - vLVeq7us10Wj9k5-xinGoDK9lKVOTCmjpKzFOJdHKPvTFeJpZ6-raw==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
+  recorded_at: Thu, 26 Apr 2018 16:58:09 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843712/titles/17100757
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2852184/titles/17140550
     body:
       encoding: US-ASCII
       string: ''
@@ -293,19 +293,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1171'
+      - '1184'
       Connection:
       - keep-alive
       Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Amzn-Requestid:
-      - a50befc1-47d1-11e8-a4b4-1165bfed6d2e
+      - ff94531d-4972-11e8-bcd5-bfb7abdb1722
       X-Amzn-Remapped-Content-Length:
-      - '1171'
+      - '1184'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - F2hVJE3KoAMFWwg=
+      - F9W9RHovIAMF6Lw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -317,24 +317,24 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 24 Apr 2018 15:10:37 GMT
+      - Thu, 26 Apr 2018 16:58:09 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 e18a9585a869d9169e759f7003f46518.cloudfront.net (CloudFront)
+      - 1.1 0b202e2428f14940b06527255fa020ea.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - md5aRIuJ4cTLYOEoz64e9DmFGfsbGC_T2mRlV9uHAMUNFen7dQ3WSA==
+      - 4fOm-mDfJmuoINey_xSwGUL68h9gGOT5bNBI5sxu3cP2KfZ2Wc_d6g==
     body:
       encoding: UTF-8
-      string: '{"titleId":17100757,"titleName":"Totally New Custom Title Testing All
-        Fields","publisherName":"test publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17100757,"packageId":2843712,"packageName":"Carole
-        Custom Package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38332358,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"Test
+      string: '{"titleId":17140550,"titleName":"Totally New Custom Title Testing All
+        Fields","publisherName":"test publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17140550,"packageId":2852184,"packageName":"carole
+        test another custom package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":38413466,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"Test
         coverage statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
         description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
         editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
     http_version: 
-  recorded_at: Tue, 24 Apr 2018 15:10:37 GMT
+  recorded_at: Thu, 26 Apr 2018 16:58:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/custom_resources_create_spec.rb
+++ b/spec/requests/custom_resources_create_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe 'Custom Resources Create', type: :request do
             'attributes' => {
               'name' => 'Totally New Custom Title Testing All Fields',
               'publicationType' => 'Book',
-              'packageId' => 2_843_712,
+              'packageId' => 2_852_184,
               'publisherName' => 'test publisher',
               'isPeerReviewed' => true,
               'edition' => 'test edition',


### PR DESCRIPTION
## Purpose
While testing changes for custom resources create https://github.com/folio-org/mod-kb-ebsco/pull/109 an issue was encountered in RM API (POST request was accepting peerReviewed instead of isPeerReviewed and was inconsistent with PUT request). PR made adjustments in mod-kb-ebsco to handle this inconsistency. Since this issue has been corrected, this PR removes the temporary change.

## Approach
Removed temporary code which passed peerReviewed attribute instead of isPeerReviewed. Also adjusted unit test and re-recorded test cassette. (note - needed a new package since earlier referenced package was deleted)

