### PR TITLE
Add identifiers for POST and PUT requests of custom titles - UIEH-318

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -89,6 +89,9 @@ class ResourcesController < ApplicationController
         contributorsList: [
           %i[type contributor]
         ],
+        identifiersList: [
+          %i[id subtype type]
+        ],
         customEmbargoPeriod: %i[
           embargoUnit
           embargoValue
@@ -117,6 +120,9 @@ class ResourcesController < ApplicationController
         ],
         contributorsList: [
           %i[type contributor]
+        ],
+        identifiersList: [
+          %i[id subtype type]
         ],
         customEmbargoPeriod: %i[
           embargoUnit

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -7,7 +7,7 @@ module Validation
     include ActiveModel::Validations
 
     attr_accessor :isSelected, :isHidden, :customCoverageList, :contributorsList,
-                  :embargoUnit, :embargoValue, :coverageStatement
+                  :identifiersList, :embargoUnit, :embargoValue, :coverageStatement
 
     # Deselected resources cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
@@ -17,9 +17,23 @@ module Validation
       validates :isHidden, absence: true, unless: :isSelected
       validates :customCoverageList, absence: true, unless: :isSelected
       validates :contributorsList, absence: true, unless: :isSelected
+      validates :identifiersList, absence: true, unless: :isSelected
       validates :embargoUnit, absence: true, unless: :isSelected
       validates :embargoValue, absence: true, unless: :isSelected
       validates :coverageStatement, absence: true, unless: :isSelected
+    end
+
+    validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
+
+    def identifiers_list_valid? # rubocop:disable Metrics/AbcSize
+      identifiersList.each do |identifier|
+        errors.add(:IdentifierId, ':Invalid/Exceeded Length of Identifier id') unless
+        identifier['id'] && identifier['id'].instance_of?(String) && identifier['id'].length <= 20
+        errors.add(:IdentifierType, ':Invalid Identifier type') unless
+          identifier['type']&.between?(0, 1)
+        errors.add(:IdentifierSubType, ':Invalid Identifier subtype') unless
+          identifier['subtype']&.between?(1, 2)
+      end
     end
 
     def initialize(params = {})
@@ -27,6 +41,7 @@ module Validation
       @isHidden = params.dig(:visibilityData, :isHidden)
       @customCoverageList = params[:customCoverageList]
       @contributorsList = params[:contributorsList]
+      @identifiersList = params[:identifiersList]
       @embargoUnit = params.dig(:customEmbargoPeriod, :embargoUnit)
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]

--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -45,4 +45,24 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
   attribute :contributors do |value|
     { contributorsList: value }
   end
+
+  attribute :identifiers do |values|
+    types = {
+      'ISSN': 0,
+      'ISBN': 1
+    }
+
+    subtypes = {
+      'Print': 1,
+      'Online': 2
+    }
+
+    values.map do |identifier|
+      type_key = identifier['type'].to_sym
+      subtype_key = identifier['subtype'].to_sym
+      identifier['type'] = types[type_key]
+      identifier['subtype'] = subtypes[subtype_key]
+    end
+    { identifiersList: values }
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -108,6 +108,7 @@ class Resource < RmApiResource
       isHidden: resource_attributes[:visibilityData][:isHidden],
       customCoverageList: sorted_coverage,
       contributorsList: resource_attributes[:contributorsList],
+      identifiersList: resource_attributes[:identifiersList],
       customEmbargoPeriod: resource_attributes[:customEmbargoPeriod],
       coverageStatement: resource_attributes[:coverageStatement],
       titleName: attributes[:titleName],
@@ -195,6 +196,7 @@ class Resource < RmApiResource
         :visibilityData,
         :customCoverageList,
         :contributorsList,
+        :identifiersList,
         :customEmbargoPeriod,
         :coverageStatement,
         :url

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-invalid-identifier-id-length.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-invalid-identifier-id-length.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 19:45:48 GMT
+      - Fri, 27 Apr 2018 20:04:18 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 356387us'
+        : 202 362446us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41108us'
+        : 200 89043us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 127705/configurations
+      - 769502/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:48 GMT
+  recorded_at: Fri, 27 Apr 2018 20:04:18 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -139,36 +139,33 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:04:19 GMT
       X-Amzn-Requestid:
-      - 965c4395-4a53-11e8-a4dd-bd804847fabb
+      - 2b86131c-4a56-11e8-b313-73017af588c4
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdMEKZIAMFaYA=
+      - GBFKgGYMIAMFqNw=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:04:19 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a576c90d056b9a2e1f473050b2981523.cloudfront.net (CloudFront)
+      - 1.1 877c586b5d7d8bda07c8e72d642fa220.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - VhbEmA3y55YXzEnyQRpL46eEjt-Pcrl4CDM02NWBCUqU_ABpr5wcyA==
+      - Sr15C3gftP_vlWocwHUng4W6o-J6bKzhdVG7yNN2ISWE1eibJ0uCAw==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:50 GMT
+  recorded_at: Fri, 27 Apr 2018 20:04:19 GMT
 - request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles
     body:
       encoding: UTF-8
-      string: '{"titleName":"Totally New Custom Title Testing All Fields Including
-        Identifiers","pubType":"book","coverageStatement":"Test coverage statement","isPeerReviewed":true,"publisherName":"test
-        publisher","edition":"test edition","description":"test description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":[{"type":"Editor","contributor":"some
-        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"identifiersList":[{"id":"12347","subtype":1,"type":1},{"id":"98547","subtype":2,"type":0}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6}}'
+      string: '{"titleName":"New Custom Title Testing Invalid Identifier Id Length","pubType":"book","identifiersList":[{"id":"12345","subtype":1,"type":1}]}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -194,26 +191,26 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:04:20 GMT
       X-Amzn-Requestid:
-      - 9734c99f-4a53-11e8-bafc-49b2eee7c355
+      - 2c69e398-4a56-11e8-bd18-55a5f4be371e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdaEoUIAMFhVA=
+      - GBFKvEwAoAMF-Bg=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:04:20 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f1049476caf714fd94ef8827360d9bb1.cloudfront.net (CloudFront)
+      - 1.1 f06e07dccfc8e669cf9b4cfe75b40700.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - EvYNh9O_hvEiKNdszsofetaLf5no94nAK0ZnoEA4wrrS-JK16zNYCw==
+      - 1PC77xfpp3ANlr8Z-7IWkiBCNwhcYfbbNz3m8Ga5kHtHo9DnEVYKGA==
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299}'
+      string: '{"titleId":17156318}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:52 GMT
+  recorded_at: Fri, 27 Apr 2018 20:04:21 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -245,30 +242,30 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:53 GMT
+      - Fri, 27 Apr 2018 20:04:22 GMT
       X-Amzn-Requestid:
-      - 988d2d36-4a53-11e8-bb64-71904c28478f
+      - 2d494713-4a56-11e8-a305-cfd237c4ec52
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdwEsYoAMFvJA=
+      - GBFK-HdSoAMFXyQ=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:52 GMT
+      - Fri, 27 Apr 2018 20:04:22 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 29b3cfc63bec8504629152c5048602a4.cloudfront.net (CloudFront)
+      - 1.1 2ecaa1674cb37ba76f1ab4f97b45f4c2.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - "-somB_zK_rmMc45N1RpTCtovE0hB21z1xtqCY_Xb9G1jFwhNr7wGEw=="
+      - VJHvxC7ZBb8kHZKUbktzAsWMbRNNUm5fEik062GJHHzPVS3QgQSC9g==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:54 GMT
+  recorded_at: Fri, 27 Apr 2018 20:04:22 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156299
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156318
     body:
       encoding: US-ASCII
       string: ''
@@ -293,19 +290,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1320'
+      - '1066'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:04:23 GMT
       X-Amzn-Requestid:
-      - 99a94be7-4a53-11e8-b294-c7c0eb465795
+      - 2e1c75af-4a56-11e8-a511-170ff34a26f0
       X-Amzn-Remapped-Content-Length:
-      - '1320'
+      - '1066'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCeDEwGIAMF__A=
+      - GBFLMGBDIAMFxSQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -317,24 +314,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:04:23 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1ed35878396a5c073c88fd1b51c4f47a.cloudfront.net (CloudFront)
+      - 1.1 003d7c1b393a4f2391f49338ba13b47b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xZhOKNmFFYq2D4PHMHFq2uXjj7FPVN4Z2a4bOcwNGryU7E4dCxS2uw==
+      - AeLO42cOel1_OXlsL2ywAV0eSFDdnnT9Nnous7R4ViqUT06Sz952jA==
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299,"titleName":"Totally New Custom Title Testing All
-        Fields Including Identifiers","publisherName":"test publisher","identifiersList":[{"id":"12347","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"98547","source":"ResourceIdentifier","subtype":2,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156299,"packageId":2850417,"packageName":"SD''s
+      string: '{"titleId":17156318,"titleName":"New Custom Title Testing Invalid Identifier
+        Id Length","publisherName":null,"identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156318,"packageId":2850417,"packageName":"SD''s
         test package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38443014,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Test
-        coverage statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
-        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
-        editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:55 GMT
+  recorded_at: Fri, 27 Apr 2018 20:04:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-valid-identifier-subtypes.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-valid-identifier-subtypes.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 19:45:48 GMT
+      - Fri, 27 Apr 2018 20:23:14 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 356387us'
+        : 202 357180us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41108us'
+        : 200 42620us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 127705/configurations
+      - 500545/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:48 GMT
+  recorded_at: Fri, 27 Apr 2018 20:23:14 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -139,36 +139,33 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:23:15 GMT
       X-Amzn-Requestid:
-      - 965c4395-4a53-11e8-a4dd-bd804847fabb
+      - d0efe445-4a58-11e8-9d70-8df33e217ccb
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdMEKZIAMFaYA=
+      - GBH8FFunIAMFtGg=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:23:15 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a576c90d056b9a2e1f473050b2981523.cloudfront.net (CloudFront)
+      - 1.1 ee57ed1ff7b57a61328d648a4db195fc.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - VhbEmA3y55YXzEnyQRpL46eEjt-Pcrl4CDM02NWBCUqU_ABpr5wcyA==
+      - 6paraxNRniRCu9TZAYFPn4V50DaaSCyvDxUUKwxpuuxRNhf0JnX1pw==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:50 GMT
+  recorded_at: Fri, 27 Apr 2018 20:23:16 GMT
 - request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles
     body:
       encoding: UTF-8
-      string: '{"titleName":"Totally New Custom Title Testing All Fields Including
-        Identifiers","pubType":"book","coverageStatement":"Test coverage statement","isPeerReviewed":true,"publisherName":"test
-        publisher","edition":"test edition","description":"test description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":[{"type":"Editor","contributor":"some
-        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"identifiersList":[{"id":"12347","subtype":1,"type":1},{"id":"98547","subtype":2,"type":0}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6}}'
+      string: '{"titleName":"New Custom Title Testing Valid Identifier SubTypes","pubType":"book","identifiersList":[{"id":"12345","subtype":1,"type":0},{"id":"12345","subtype":2,"type":1}]}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -194,26 +191,26 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:23:17 GMT
       X-Amzn-Requestid:
-      - 9734c99f-4a53-11e8-bafc-49b2eee7c355
+      - d2039e23-4a58-11e8-bce1-f171282b9f99
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdaEoUIAMFhVA=
+      - GBH8XGdwoAMFV1w=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:23:17 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f1049476caf714fd94ef8827360d9bb1.cloudfront.net (CloudFront)
+      - 1.1 e8211ae0170c9ccd38bcd06c168293e9.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - EvYNh9O_hvEiKNdszsofetaLf5no94nAK0ZnoEA4wrrS-JK16zNYCw==
+      - 5sgcx9me-FTg46y7sIHIp8JYHoJsJcwxHiJFTwHCRXBMMGHxLXkROw==
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299}'
+      string: '{"titleId":17156320}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:52 GMT
+  recorded_at: Fri, 27 Apr 2018 20:23:18 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -245,30 +242,30 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:53 GMT
+      - Fri, 27 Apr 2018 20:23:19 GMT
       X-Amzn-Requestid:
-      - 988d2d36-4a53-11e8-bb64-71904c28478f
+      - d2f26aff-4a58-11e8-b6ae-65e1bdb2d7f4
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdwEsYoAMFvJA=
+      - GBH8nEj0IAMFa7w=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:52 GMT
+      - Fri, 27 Apr 2018 20:23:18 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 29b3cfc63bec8504629152c5048602a4.cloudfront.net (CloudFront)
+      - 1.1 4430e3d18af970596bcf9bb4942da600.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - "-somB_zK_rmMc45N1RpTCtovE0hB21z1xtqCY_Xb9G1jFwhNr7wGEw=="
+      - ULh1x8cJJW1mBSKVX4nhOSaCyzCpxfLsJ5PrPn6QJmFe7N8uW-f0Zw==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:54 GMT
+  recorded_at: Fri, 27 Apr 2018 20:23:19 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156299
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156320
     body:
       encoding: US-ASCII
       string: ''
@@ -293,19 +290,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1320'
+      - '1129'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:23:20 GMT
       X-Amzn-Requestid:
-      - 99a94be7-4a53-11e8-b294-c7c0eb465795
+      - d3ca7b8b-4a58-11e8-95ae-29648778abaa
       X-Amzn-Remapped-Content-Length:
-      - '1320'
+      - '1129'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCeDEwGIAMF__A=
+      - GBH81GlOoAMF7fw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -317,24 +314,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:23:20 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1ed35878396a5c073c88fd1b51c4f47a.cloudfront.net (CloudFront)
+      - 1.1 29b3cfc63bec8504629152c5048602a4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xZhOKNmFFYq2D4PHMHFq2uXjj7FPVN4Z2a4bOcwNGryU7E4dCxS2uw==
+      - "-ZHBmof-MDB9FFDPswHr6W8NlqJhIVZxlr7McUoSTeqoTByEcoR5gQ=="
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299,"titleName":"Totally New Custom Title Testing All
-        Fields Including Identifiers","publisherName":"test publisher","identifiersList":[{"id":"12347","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"98547","source":"ResourceIdentifier","subtype":2,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156299,"packageId":2850417,"packageName":"SD''s
+      string: '{"titleId":17156320,"titleName":"New Custom Title Testing Valid Identifier
+        SubTypes","publisherName":null,"identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156320,"packageId":2850417,"packageName":"SD''s
         test package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38443014,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Test
-        coverage statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
-        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
-        editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:55 GMT
+  recorded_at: Fri, 27 Apr 2018 20:23:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-resource-valid-identifier-types.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-resource-valid-identifier-types.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 19:45:48 GMT
+      - Fri, 27 Apr 2018 20:20:23 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 356387us'
+        : 202 366742us'
       - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41108us'
+        : 200 41694us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 127705/configurations
+      - 694588/configurations
       X-Okapi-Url:
       - http://10.39.243.220:80
       X-Okapi-Permissions-Required:
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:48 GMT
+  recorded_at: Fri, 27 Apr 2018 20:20:23 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -139,36 +139,33 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:20:24 GMT
       X-Amzn-Requestid:
-      - 965c4395-4a53-11e8-a4dd-bd804847fabb
+      - 6ae9450a-4a58-11e8-891f-fb8a04537d04
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdMEKZIAMFaYA=
+      - GBHhWEUdoAMFfdg=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:50 GMT
+      - Fri, 27 Apr 2018 20:20:24 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a576c90d056b9a2e1f473050b2981523.cloudfront.net (CloudFront)
+      - 1.1 3a6be57f33a95df305974838096655cd.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - VhbEmA3y55YXzEnyQRpL46eEjt-Pcrl4CDM02NWBCUqU_ABpr5wcyA==
+      - S7BcTScGIXBPeyXCiEkUjvvEK3fF7J5hlaEaSMUEbBCp6u8ISgyhLA==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:50 GMT
+  recorded_at: Fri, 27 Apr 2018 20:20:24 GMT
 - request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles
     body:
       encoding: UTF-8
-      string: '{"titleName":"Totally New Custom Title Testing All Fields Including
-        Identifiers","pubType":"book","coverageStatement":"Test coverage statement","isPeerReviewed":true,"publisherName":"test
-        publisher","edition":"test edition","description":"test description","url":"http://test","customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":[{"type":"Editor","contributor":"some
-        editor"},{"type":"Illustrator","contributor":"some illustrator"}],"identifiersList":[{"id":"12347","subtype":1,"type":1},{"id":"98547","subtype":2,"type":0}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6}}'
+      string: '{"titleName":"New Custom Title Testing Valid Identifier Types","pubType":"book","identifiersList":[{"id":"12345","subtype":1,"type":0},{"id":"12345","subtype":1,"type":1}]}'
     headers:
       User-Agent:
       - Flexirest/1.5.5
@@ -194,26 +191,26 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:20:26 GMT
       X-Amzn-Requestid:
-      - 9734c99f-4a53-11e8-bafc-49b2eee7c355
+      - 6bbebd87-4a58-11e8-9c3d-4d10b30fbcdf
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdaEoUIAMFhVA=
+      - GBHhkHJKoAMFjsg=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:51 GMT
+      - Fri, 27 Apr 2018 20:20:26 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f1049476caf714fd94ef8827360d9bb1.cloudfront.net (CloudFront)
+      - 1.1 4988915d0d77750503cc39b108813e0f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - EvYNh9O_hvEiKNdszsofetaLf5no94nAK0ZnoEA4wrrS-JK16zNYCw==
+      - bHb8Vq-mUc4mxEpJSTlu9BX_plvoUuHZDH21WGuHbaxoyP7WiOv5Ug==
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299}'
+      string: '{"titleId":17156319}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:52 GMT
+  recorded_at: Fri, 27 Apr 2018 20:20:26 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
@@ -245,30 +242,30 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:53 GMT
+      - Fri, 27 Apr 2018 20:20:27 GMT
       X-Amzn-Requestid:
-      - 988d2d36-4a53-11e8-bb64-71904c28478f
+      - 6ca37860-4a58-11e8-9757-9dacb4c0bfee
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCdwEsYoAMFvJA=
+      - GBHhzFB5IAMFYpA=
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:52 GMT
+      - Fri, 27 Apr 2018 20:20:27 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 29b3cfc63bec8504629152c5048602a4.cloudfront.net (CloudFront)
+      - 1.1 4ee8675b5bc89c4b98326c6c036736a8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - "-somB_zK_rmMc45N1RpTCtovE0hB21z1xtqCY_Xb9G1jFwhNr7wGEw=="
+      - _QpZ4D0FJEH9sfmMfmFhQLack4l9ewUyGfxEa_TeAC24y3MJHp8g2w==
     body:
       encoding: UTF-8
       string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
         CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":62,"packagesSelected":62,"vendorToken":null}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:54 GMT
+  recorded_at: Fri, 27 Apr 2018 20:20:27 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156299
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2850417/titles/17156319
     body:
       encoding: US-ASCII
       string: ''
@@ -293,19 +290,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1320'
+      - '1126'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:20:28 GMT
       X-Amzn-Requestid:
-      - 99a94be7-4a53-11e8-b294-c7c0eb465795
+      - 6d7547b5-4a58-11e8-b938-fdeaa5a37222
       X-Amzn-Remapped-Content-Length:
-      - '1320'
+      - '1126'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBCeDEwGIAMF__A=
+      - GBHiAG75IAMFcHA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -317,24 +314,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 19:45:55 GMT
+      - Fri, 27 Apr 2018 20:20:28 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1ed35878396a5c073c88fd1b51c4f47a.cloudfront.net (CloudFront)
+      - 1.1 66e5950d2a2f44a694f4d9d434e9a3c9.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xZhOKNmFFYq2D4PHMHFq2uXjj7FPVN4Z2a4bOcwNGryU7E4dCxS2uw==
+      - zjO3T4EYZ_pCarJz8F4_HOwKjszntDLch5_SS_IfP_YxI5LGrtaeZg==
     body:
       encoding: UTF-8
-      string: '{"titleId":17156299,"titleName":"Totally New Custom Title Testing All
-        Fields Including Identifiers","publisherName":"test publisher","identifiersList":[{"id":"12347","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"98547","source":"ResourceIdentifier","subtype":2,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156299,"packageId":2850417,"packageName":"SD''s
+      string: '{"titleId":17156319,"titleName":"New Custom Title Testing Valid Identifier
+        Types","publisherName":null,"identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17156319,"packageId":2850417,"packageName":"SD''s
         test package","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38443014,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Test
-        coverage statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
-        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
-        editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 19:45:55 GMT
+  recorded_at: Fri, 27 Apr 2018 20:20:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id-length.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id-length.yml
@@ -1,0 +1,182 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 978us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42294us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 269207/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:12 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:13 GMT
+      X-Amzn-Requestid:
+      - 950ffe6d-4a5c-11e8-8c83-8df4f358acf3
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL41E4XoAMFjUA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:13 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b092cc2c048e7d189923dd32e59550c7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CjhhGZWM61a5vuCnZcreaa3H1Qmd8CQBxnJ7QV5vWZGO4v_pG_jRFA==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id.yml
@@ -1,0 +1,182 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 355817us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 54249us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 831187/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:11 GMT
+      X-Amzn-Requestid:
+      - 938cba36-4a5c-11e8-81df-63ff41ea76b1
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL4bFV6oAMF7GQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:10 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a576c90d056b9a2e1f473050b2981523.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2JVpjDNWcZkWC_lZZaSlMun8e5oOHf8IGnXKWxYvMLnFocLDvlXGEw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-type.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-type.yml
@@ -1,0 +1,182 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1435us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 41953us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 362881/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:15 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:17 GMT
+      X-Amzn-Requestid:
+      - 9742e3c1-4a5c-11e8-b3b3-0d0933261956
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL5ZFaYoAMF46w=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:17 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2ecaa1674cb37ba76f1ab4f97b45f4c2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - o8GPUHBh9mGeuo0nNdaJ59XOGUcgyAsy9dLlMjTJx1aBquEh7UIBxA==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-missing-identifier-id.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-missing-identifier-id.yml
@@ -1,0 +1,182 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1107us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42008us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 992872/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:15 GMT
+      X-Amzn-Requestid:
+      - 9643007a-4a5c-11e8-a5f4-bfe41b4c997d
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL5JF_doAMFo8w=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:15 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e8211ae0170c9ccd38bcd06c168293e9.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KXL6VSFvbxOY9qwxA5IY4iO3YGTmd7lddVoDRDrTuFlsUvoI1Jf-5g==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-subtypes.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-subtypes.yml
@@ -1,0 +1,321 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 358353us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42386us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 874728/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:22 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:23 GMT
+      X-Amzn-Requestid:
+      - 9b5ab5e8-4a5c-11e8-b6bd-8f64ab6d982c
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL6eF4SIAMF4UA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:23 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 003d7c1b393a4f2391f49338ba13b47b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XQ_yy4jc1gBt6us6sfNsly0JkGFS_NtzOMjXHA8y8nwV2vZyoGKV7Q==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:24 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":null,"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
+        have so much coverage.","titleName":"New Custom Title Testing Valid Identifier
+        SubTypes","pubType":"book","isPeerReviewed":true,"publisherName":"American
+        Association for the Advancement of Science","edition":null,"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","url":null}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:25 GMT
+      X-Amzn-Requestid:
+      - 9c2c36b7-4a5c-11e8-8920-b73fa89882a8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL6sGpCIAMF8pg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:25 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c17d987ff5ce8137613fd33ef9ba83cb.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sewaVdeltORzMOjFPRLtHaG46-_YfEPCjQTnDpSXjSUAOogbg460Qg==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:25 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:26 GMT
+      X-Amzn-Requestid:
+      - 9d0383bb-4a5c-11e8-9219-432559289b6a
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL66F-DoAMFmxQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:26 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 26d8fa99acc1b4ab3c750b71faab71a1.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - p_1-PQnewu8J0Dqk7jJLL4p3mpqCiXmG8sdhCb5GtT9gLZZVkMNJsg==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-types.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-types.yml
@@ -1,0 +1,321 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 27 Apr 2018 20:50:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1186us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42570us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 871433/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:17 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:18 GMT
+      X-Amzn-Requestid:
+      - 98388e58-4a5c-11e8-8b23-e9ddb6806052
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL5qFq5oAMFjeg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:18 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c6b63d687e90622c9c3a2477b537ca25.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YFx4GxNUnDwPodNZ0X6qUE7MElCHUQjvP2xlOVa78eeNOk48hX6uHw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:18 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":null,"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
+        have so much coverage.","titleName":"Update Custom Title Testing Valid Identifier
+        Types","pubType":"book","isPeerReviewed":true,"publisherName":"American Association
+        for the Advancement of Science","edition":null,"description":"Contains peer-reviewed
+        articles, original research reports, a news section, editorials, letters,
+        and book reviews on timely science-related topics.","url":null}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:20 GMT
+      X-Amzn-Requestid:
+      - 990776dd-4a5c-11e8-a2b5-55a8ebb0ed33
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL53EPHoAMFucg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:20 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 415c421af891d7c3f4ade60aba542014.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fjxqQa-2mGpqFHQZB3c5VWzo6iOke0kToGIfMN8s8nJQRCf4OP5E8w==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2145'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 27 Apr 2018 20:50:21 GMT
+      X-Amzn-Requestid:
+      - 99de76ca-4a5c-11e8-8f7d-eb7995e4ce44
+      X-Amzn-Remapped-Content-Length:
+      - '2145'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GBL6FEdFoAMFV4Q=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Fri, 27 Apr 2018 20:50:21 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bd90da9254f31df3f30a30f180fba558.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6eJL5VIMzn7aGLPGE8i3LMDMvy98fIn9bGY2uZ34fm3W_EY6Og29lQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
+        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
+        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
+        peer-reviewed articles, original research reports, a news section, editorials,
+        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 20:50:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_resources_spec.rb
+++ b/spec/requests/custom_resources_spec.rb
@@ -293,6 +293,317 @@ RSpec.describe 'Custom Resources', type: :request do
       end
     end
 
+    describe 'with invalid identifier id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'Update Custom Title Testing Invalid Identifier Id',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": 12_345, # cannot be an integer, has to be a string
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-invalid-identifier-id') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with invalid identifier id length' do
+      let(:longIdentifierId) { '0' * 21 }
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'Update Custom Title Testing Invalid Identifier Id Length',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": longIdentifierId,
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-invalid-identifier-id-length') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with missing identifier id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'Update Custom Title Testing Missing Identifier Id',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-missing-identifier-id') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with invalid identifier type' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'New Custom Title Testing Invalid Identifier Type',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'Invalid Type',
+                  "subtype": 'Print'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-invalid-identifier-type') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierType')
+      end
+    end
+
+    describe 'with valid identifier types' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'Update Custom Title Testing Valid Identifier Types',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '12345',
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-valid-identifier-types') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has the expected list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Print')
+      end
+    end
+
+    describe 'with invalid identifier subtype' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'New Custom Title Testing Invalid Identifier Type',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Invalid subtype'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-invalid-identifier-type') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierSubType')
+      end
+    end
+
+    describe 'with valid identifier subtypes' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'resources',
+            'attributes' => {
+              'name' => 'New Custom Title Testing Valid Identifier SubTypes',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '12345',
+                  "type": 'ISBN',
+                  "subtype": 'Online'
+                }
+              ],
+              "isSelected": true
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-resource-valid-identifier-subtypes') do
+          put '/eholdings/resources/123355-2845510-62477',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has the expected list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Online')
+      end
+    end
+
     describe 'combined update' do
       let(:params) do
         {
@@ -324,6 +635,18 @@ RSpec.describe 'Custom Resources', type: :request do
                 {
                   "type": 'Illustrator',
                   "contributor": 'last first'
+                }
+              ],
+              "identifiers": [
+                {
+                  "id": '12347',
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '98547',
+                  "type": 'ISSN',
+                  "subtype": 'Online'
                 }
               ],
               "coverageStatement": 'There are many years.',
@@ -397,6 +720,21 @@ RSpec.describe 'Custom Resources', type: :request do
           .to eq('Illustrator')
         expect(json.data.attributes.contributors[1].contributor)
           .to eq('last first')
+      end
+
+      it 'has the list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12347')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('98547')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Online')
       end
 
       it 'has a coverage statement' do


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-318, users should be able to add identifiers while creating and updating custom titles. This PR addresses that issue. 

## Approach
- Serialize "identifiers" in mod-kb-ebsco to "identifiersList" in RM API
- An identifier can consist of "id", "type" and "subtype" - validate them and then pass them to RM API
- Sample POST request: `http://0.0.0.0:8081/eholdings/resources/`
- Sample POST request body containing identifiers: 
`{
 "data": {
  "type":"resources",
  "attributes": {
    "identifiers": [{"id": "12345","type":"ISBN","subtype":"Print"}}, {"id":12347,"type":"ISSN","subtype":"Online"}],
    "name": "POST test title",
    "publicationType": "Book",
	"packageId": 2850417
  }
 }
}`
Sample PUT request: PUT `http://0.0.0.0:8081/eholdings/resources/123355-2850417-17155900`
Sample PUT request body: 
`{
 "data": {
  "type":"resources",
  "attributes": {
    "identifiers": [{"id": "12345","type":"ISBN","subtype":"Print"}}, {"id":12347,"type":"ISSN","subtype":"Online"}],
    "name": "POST test title",
    "publicationType": "Book",
	"isSelected": true
  }
 }
}`
- Added associated unit tests

#### TODOS and Open Questions
- [ ] While deserializing, we are de-serializing only those types and sub-types that we are going to support for ui-eholdings, where as while serializing, we support types and sub-types that are not needed by ui-eholdings. I left the serialization as it was, because it is possible for whatever reasons that RM API could provide other types or sub-types where as I modified de-serialization because ui-eholdings cannot provide other types and sub-types. Should we keep them consistent? If so, shall we support all types and subtypes supported by RM API or only those that ui-eholdings needs?

## Screenshots
![identifiers](https://user-images.githubusercontent.com/33662516/39385366-3d83ebae-4a3e-11e8-9c7f-5385644a1b5e.gif)

