### PR TITLE
Accept all possible identifier types and subtypes that RM API has

### DIFF
--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -30,9 +30,9 @@ module Validation
         errors.add(:IdentifierId, ':Invalid/Exceeded Length of Identifier id') unless
         identifier['id'] && identifier['id'].instance_of?(String) && identifier['id'].length <= 20
         errors.add(:IdentifierType, ':Invalid Identifier type') unless
-          identifier['type']&.between?(0, 1)
+          identifier['type']&.between?(0, 9)
         errors.add(:IdentifierSubType, ':Invalid Identifier subtype') unless
-          identifier['subtype']&.between?(1, 2)
+          identifier['subtype']&.between?(0, 7)
       end
     end
 

--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -49,12 +49,26 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
   attribute :identifiers do |values|
     types = {
       'ISSN': 0,
-      'ISBN': 1
+      'ISBN': 1,
+      'TSDID': 2,
+      'SPID': 3,
+      'EjsJournalID': 4,
+      'NewsbankID': 5,
+      'ZDBID': 6,
+      'EPBookID': 7,
+      'Mid': 8,
+      'BHM': 9
     }
 
     subtypes = {
+      'Empty': 0,
       'Print': 1,
-      'Online': 2
+      'Online': 2,
+      'Preceding': 3,
+      'Succeeding': 4,
+      'Regional': 5,
+      'Linking': 6,
+      'Invalid': 7
     }
 
     values.map do |identifier|


### PR DESCRIPTION
## Purpose
Updates to some resources return an error from `mod-kb-ebsco`.

Example: http://localhost:3000/eholdings/resources/18-2321-1239421
returns `Invalid Identifier type` and `Invalid Identifier subtype`.

The resource listed has identifier type "BHM" and subtype "Empty" from RM API. `PUT` requests to change anything about that resource will include that type and subtype.

## Approach
`mod-kb-ebsco` needs to be able to accept all the types/subtypes that RM API lists, not just ISSN/ISBN.