### PR TITLE
Serialize Edition in titles -- Needed for UIEH-253

### DIFF
--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -7,7 +7,10 @@ module Validation
     include ActiveModel::Validations
 
     attr_accessor :isSelected, :isHidden, :customCoverageList, :contributorsList,
-                  :identifiersList, :embargoUnit, :embargoValue, :coverageStatement
+                  :identifiersList, :embargoUnit, :embargoValue, :coverageStatement,
+                  :edition
+
+    validates :edition, length: { maximum: 250 }, allow_nil: true
 
     # Deselected resources cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
@@ -45,6 +48,7 @@ module Validation
       @embargoUnit = params.dig(:customEmbargoPeriod, :embargoUnit)
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]
+      @edition = params[:edition]
     end
   end
 end

--- a/app/serializable/serializable_title.rb
+++ b/app/serializable/serializable_title.rb
@@ -6,6 +6,7 @@ class SerializableTitle < SerializableJSONAPIResource
   has_many :resources
 
   attributes :name,
+             :edition,
              :description,
              :publisherName,
              :isTitleCustom,

--- a/spec/fixtures/vcr_cassettes/get-titles-edition-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-titles-edition-success.yml
@@ -1,0 +1,181 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Tue, 01 May 2018 16:01:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 356183us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43450us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 879303/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 01 May 2018 16:01:07 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17059786
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1856'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 01 May 2018 16:01:08 GMT
+      X-Amzn-Requestid:
+      - dc563c9d-4d58-11e8-b35b-87e02ff49732
+      X-Amzn-Remapped-Content-Length:
+      - '1856'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GNtSrG5MIAMFsLw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Tue, 01 May 2018 16:01:08 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ebfea1c8ef298b6d415684e80825a277.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - FS3xNMcHvlmajkVdPJYr8ZoljOEtBL49SAc1xMnNEy6QJnEgx__uCw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17059786,"titleName":"SD custom title","publisherName":null,"identifiersList":[{"id":"12347","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"9234","source":"ResourceIdentifier","subtype":1,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059786,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null},{"titleId":17059786,"packageId":2844893,"packageName":"SD''s
+        test package with root proxy for Mohan","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"gfgfsg","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":1},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"","edition":"some
+        edition","isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Tue, 01 May 2018 16:01:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -398,4 +398,33 @@ RSpec.describe 'Titles', type: :request do
       expect(json.errors).to include(title: 'Title not found')
     end
   end
+
+  describe 'getting a custom title with edition in it' do
+    before do
+      VCR.use_cassette('get-titles-edition-success') do
+        get '/eholdings/titles/17059786', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'gets the resource' do
+      expect(response).to have_http_status(200)
+      expect(json.data.type).to eq('titles')
+      expect(json.data.id).to eq('17059786')
+      expect(json.data.attributes).to include(
+        'name',
+        'edition',
+        'description',
+        'publisherName',
+        'publicationType',
+        'isTitleCustom',
+        'isPeerReviewed',
+        'contributors',
+        'identifiers',
+        'subjects'
+      )
+      expect(json.data.attributes.edition).to eq('some edition')
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
per https://issues.folio.org/browse/UIEH-253, users should be able to edit edition field and view the new value on detailed record. From UI, to update the value, we use the /resources route in mod-kb-ebsco where as to view, we use the /titles route which does not serialize edition in its response.

## Approach
- Add edition in serializer to get it as part of response in mod-kb
- Add associated unit tests

## TODO and Open Questions
- Maybe, eventually we want to validate most fields of a resource while updating just like we do while creating,  I am not doing it in this PR because it needs more thought around what fields can be updated.

## Screenshots
![edition_custom_title](https://user-images.githubusercontent.com/33662516/39480945-caea6b7a-4d37-11e8-8dde-5673886c39d5.gif)
