### PR TITLE
Add title create route 

### DIFF
--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -54,7 +54,7 @@ class TitlesController < ApplicationController
     json = JSON.parse request.body.read
 
     unless json['included']&.first
-      raise ActionController::BadRequest 'Missing resource'
+      raise ActionController::BadRequest, 'Missing resource'
     end
 
     resource_params = json['data']['attributes'].merge(

--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -15,6 +15,22 @@ class TitlesController < ApplicationController
            meta: { totalResults: @titles.totalResults }
   end
 
+  def create
+    # RM API creates titles as a side-effect of creating resources, so
+    # we validate against a resource using the combined payload of the
+    # new title and an included resource with a packageId
+    resource_validation =
+      Validation::ResourceCreateParameters.new(combined_resource)
+
+    if resource_validation.valid?
+      @title = titles.create_title(combined_resource)
+      render jsonapi: @title
+    else
+      render jsonapi_errors: resource_validation.errors,
+             status: :unprocessable_entity
+    end
+  end
+
   def show
     render jsonapi: @title, include: params[:include]
   end
@@ -32,5 +48,22 @@ class TitlesController < ApplicationController
 
   def titles
     Title.configure(config)
+  end
+
+  def combined_resource # rubocop:disable Metrics/AbcSize
+    json = JSON.parse request.body.read
+
+    unless json['included']&.first
+      raise ActionController::BadRequest 'Missing resource'
+    end
+
+    resource_params = json['data']['attributes'].merge(
+      json['included'].first['attributes']
+    )
+
+    DeserializableResource.call(
+      'type' => 'resources',
+      'attributes' => resource_params
+    )
   end
 end

--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -29,6 +29,15 @@ class TitlesController < ApplicationController
       render jsonapi_errors: resource_validation.errors,
              status: :unprocessable_entity
     end
+  # combined_resource may raise this exception
+  rescue JSON::ParserError, NoMethodError
+    error = {
+      title: 'Invalid JSON',
+      detail: 'The provided JSON payload could not be parsed'
+    }
+
+    render jsonapi_errors: [error],
+           status: :unprocessable_entity
   end
 
   def show

--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -50,7 +50,7 @@ class TitlesController < ApplicationController
     Title.configure(config)
   end
 
-  def combined_resource # rubocop:disable Metrics/AbcSize
+  def combined_resource
     json = JSON.parse request.body.read
 
     unless json['included']&.first

--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -86,4 +86,19 @@ class Title < RmApiResource
       Resource.new(title_attrs)
     end
   end
+
+  # RM API creates titles as a side-effect of creating resources, so
+  # we actually create a resource here, but then return the resulting
+  # title that was also created
+  def self.create_title(params)
+    package_id = params[:packageId]
+    create_params = params.to_hash.except(:packageId)
+    rm_api_create = { vendor_id: provider_id, package_id: package_id }.merge(create_params)
+    resource_response = Resource.configure(config).create rm_api_create
+    find resource_response[:titleId]
+  end
+
+  def self.provider_id
+    Provider.configure(config).provider_id
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :titles, only: %i[index show] do
+    resources :titles, only: %i[index create show] do
       member do
         get 'resources'
       end

--- a/spec/fixtures/vcr_cassettes/post-custom-title-all-fields.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-all-fields.yml
@@ -1,0 +1,286 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1181us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42150us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 981040/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      X-Amzn-Requestid:
+      - f06a2cdd-4e45-11e8-898b-a9fc4b4a47b9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4wHu5oAMF4hw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2e60888b24fa442131e50f158ca360a6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 1aa70KfLQXY9qcj5axSfcnz-MZ3SHqcilNILs5FYT8WwweU_46fjxg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"Totally New Title Testing All Fields","pubType":"book","publisherName":"test
+        publisher","isPeerReviewed":true,"edition":"test edition","description":"test
+        description","contributorsList":[{"type":"Editor","contributor":"some editor"},{"type":"Illustrator","contributor":"some
+        illustrator"}],"identifiersList":[{"id":"12347","type":1,"subtype":1},{"id":"98547","type":0,"subtype":2}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:13 GMT
+      X-Amzn-Requestid:
+      - f0883bcb-4e45-11e8-b775-e71b7a056870
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4xGbjoAMF5EQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:13 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2d2e1e199c18b4b9392796150bff22d6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xJ2aYn5Z6_3M9DAIcj5uNinRyxHHIfJ7OAOTNWIPkSeI2W25xeR-lg==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239273}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17239273
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1187'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:13 GMT
+      X-Amzn-Requestid:
+      - f0dd1220-4e45-11e8-a24a-ab33fe61241c
+      X-Amzn-Remapped-Content-Length:
+      - '1187'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl43GZ6oAMFRDA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:13 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1e0f6d91fb358639e6808cb6d2638da0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 3ZeZ-bIogDA77qYYmNdPmL6mUNeiFitVqWKPWjPw8KJRSBza4oNMUQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239273,"titleName":"Totally New Title Testing All Fields","publisherName":"test
+        publisher","identifiersList":[{"id":"12347","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"98547","source":"ResourceIdentifier","subtype":2,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17239273,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"test
+        description","edition":"test edition","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"some
+        editor"},{"type":"illustrator","contributor":"some illustrator"}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-existing-name.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-existing-name.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 981us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 41566us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 882693/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Amzn-Requestid:
+      - eeb095d0-4e45-11e8-ad46-81cbd00bb9fe
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4TG3moAMF0vg=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fQiYFmPqeHtti8ry_sSGoNW0_vjJXPySwodtAB9mXAWDhF2djB0Low==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:10 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing","pubType":"book"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '101'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      X-Amzn-Requestid:
+      - eece2fb3-4e45-11e8-8c6f-ef96a5c9bff1
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4VEmtIAMFTeg=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 0ae25fed904e0259c5db061e4b999b59.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kuAxcwgiXORMA2gBhdoQ72c0Qgs2BRjAYy3K87JsswLGofYdKsKDMA==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Custom Title with the
+        provided name already exists"}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-invalid-contributor-type.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-invalid-contributor-type.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 2846us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42099us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 237163/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:14 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Amzn-Requestid:
+      - f15416fe-4e45-11e8-8da4-d39305ee51d0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4_EpaIAMF6Lw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4433cfc63e9b5d5c7330b53b6a102c94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - jGqV2vvzdkqhmThjQHTf3m1NvZ2zijxGoZdTxzDi6rPpYDVXe5sorw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:14 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing Invalid Contributor","pubType":"book","contributorsList":[{"type":"invalid
+        type","contributor":"some editor"},{"type":"Illustrator","contributor":"some
+        illustrator"}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '139'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Amzn-Requestid:
+      - f17422a6-4e45-11e8-92da-bfcc614f7767
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5BGdgIAMFyAw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 e151cdfc40018593a63b6d2b830f43ab.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Te74LtEtghlQvDdCoWS8_xfxffpmqfgHpe4dwIzoqjiK_YCYW7q0Ng==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Parameter contributorsList.contributorType
+        must be one of (author, editor, illustrator)."}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-invalid-packageId.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-invalid-packageId.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1203us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43798us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 893143/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      X-Amzn-Requestid:
+      - f00920b2-4e45-11e8-8cd7-9553e9375f89
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4pFh4oAMFXhg=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 06df2f0e5cefb5e7b8be41ff25b6fd8a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bSULZlL26yNYGLr60Xi63Uagxm1khu_Y-ey5jwxfyo2P3rPfmwMuZw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/9999999/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"My Title Testing Bad Package Id","pubType":"unspecified"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '104'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:12 GMT
+      X-Amzn-Requestid:
+      - f02d98f0-4e45-11e8-8bf8-89bd1f87a910
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4sH9YIAMF1Tw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pE32iUt_25lvVsJ4s3QoK_J0PelUU5RO9xpwnwSdU6XA_s3z4xTxUQ==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Custom Title can not
+        be added to the provided package"}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-invalid-pubtype.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-invalid-pubtype.yml
@@ -1,0 +1,280 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1300us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 42298us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 709981/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      X-Amzn-Requestid:
+      - ef1153a0-4e45-11e8-8e69-c9c275d6ecd3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4ZFuSoAMFXcg=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e7e29d0eded63a37a4752639a0b543bf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - duJILc52DuieQ63-DH9-vUbZyHIOyHY7ZC2L-jstXCkj2X61JZO9Rw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:10 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"My Title Testing Pub Type","pubType":"unspecified"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      X-Amzn-Requestid:
+      - ef2d400b-4e45-11e8-b966-7da81c6689c4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4bEo3IAMF1Cw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:10 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4433cfc63e9b5d5c7330b53b6a102c94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YC15fxJfWfK2i86i2ZnEx79WDRGoYnY4fm1kncbryUdsp5_HLck-rQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239272}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:11 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17239272
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '916'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Amzn-Requestid:
+      - ef678922-4e45-11e8-99c1-ef0342fe62d1
+      X-Amzn-Remapped-Content-Length:
+      - '916'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4fFijoAMF1xg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1a855d5f6b4cbdb5eb9d1df48257840c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - f6sxZ42HJOyXKQG7zbvTctfMysBPUd5IJYBj0Jx7-zmDLD0a_fG_yw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239272,"titleName":"My Title Testing Pub Type","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Unspecified","customerResourcesList":[{"titleId":17239272,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-managed-packageId.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-managed-packageId.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1388us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 43038us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 229363/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:11 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Amzn-Requestid:
+      - efad6bfd-4e45-11e8-a24b-bf6594c27283
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4jG02IAMFeUg=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 827359063b85d918b26fb93316e9cd61.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - oEsTpLX77HUzS18ojQ_FAqjHbesgIKjXOZgY5i898aFfsGso5zZtGA==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:11 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2512592/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"My Title Testing","pubType":"unspecified"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '104'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Amzn-Requestid:
+      - efcab84c-4e45-11e8-a9b3-23f0e73d4072
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4lEGkIAMFV1A=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:11 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 e7e29d0eded63a37a4752639a0b543bf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _G4bBQx7Oxicbh9lqYe3e2Ne2CJYd-sQ4CwCAqAnbE6hrc-_JT8jTA==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Custom Title can not
+        be added to the provided package"}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-name-pubtype.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-name-pubtype.yml
@@ -1,0 +1,280 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 357447us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 67680us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '034929/configurations'
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:08 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:08 GMT
+      X-Amzn-Requestid:
+      - ede4448a-4e45-11e8-9846-331546d93d0d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4FG3soAMFVMw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:08 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 48caa39e1bf7b421aefe9f98b0ab696b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Qn0UTcydbbA7rYkjUHnx8tMpDmZFXpPxbJCBFrgYlHbJd5sRgI6StQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:08 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing","pubType":"book"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Amzn-Requestid:
+      - ee042900-4e45-11e8-b705-15a3f0bb1160
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4HH1xoAMFdnw=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8f60415505ef336ae223e56abdc2ef6c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - WdcBE608Q_BQnKI0Mx07dWiFXF-na9yMTUTBBjpc-RQy5yldjLiSgQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239271}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17239271
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '901'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Amzn-Requestid:
+      - ee3f83f2-4e45-11e8-820a-055865116513
+      X-Amzn-Remapped-Content-Length:
+      - '901'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl4LFGgoAMFfdg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:09 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0ae25fed904e0259c5db061e4b999b59.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CGMDbJddNd82Gka4yzV6wRdJkuiOCiyNPBqHbyDoInyFJ8jTPe3n8g==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239271,"titleName":"New Title Testing","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17239271,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-valid-identifier-subtypes.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-valid-identifier-subtypes.yml
@@ -1,0 +1,281 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1265us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 41959us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 298934/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:15 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Amzn-Requestid:
+      - f242e461-4e45-11e8-ac90-e37206b0f489
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5OG1HoAMFksA=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 8f60415505ef336ae223e56abdc2ef6c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ndWjdKolvwGxy1pCWhDNWxpXYGW7PORMo9ls8UUyaD3PTNcrlOUBpQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:15 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing Valid Identifier SubTypes","pubType":"book","identifiersList":[{"id":"12345","type":0,"subtype":1},{"id":"12345","type":1,"subtype":2}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:16 GMT
+      X-Amzn-Requestid:
+      - f25e8215-4e45-11e8-b80e-3fa980127afd
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5QGcloAMF0hA=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:16 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ec4375358288b9efc2e39724f9fffdc4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 8LJN26CHsAoosErRVEQCwwzVl5pP7MH7UDLOM9j0Brx7Z0VmEGq7rQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239275}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:16 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17239275
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1058'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:16 GMT
+      X-Amzn-Requestid:
+      - f29a5274-4e45-11e8-b210-c1e986381554
+      X-Amzn-Remapped-Content-Length:
+      - '1058'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5UG96oAMFr_g=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:16 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - MrEpZ-Toa2y_TShdoCFATR7-nOieAhN5-XMuVBWkJFk7is4gwsHJ-A==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239275,"titleName":"New Title Testing Valid Identifier
+        SubTypes","publisherName":null,"identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17239275,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-title-valid-identifier-types.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-valid-identifier-types.yml
@@ -1,0 +1,281 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
+        : 202 1250us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
+        : 200 41093us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 034771/configurations
+      X-Okapi-Url:
+      - http://10.39.243.220:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:14 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Amzn-Requestid:
+      - f1bbb2d0-4e45-11e8-a1d9-cf71457275ea
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5GENwoAMFV-w=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4CA8LITOqpVbBvEU8d64GG5eB4ZSjozPwOVDL6eDzU9_JlzDmuhzbw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:15 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing Valid Identifier Types","pubType":"book","identifiersList":[{"id":"12345","type":0,"subtype":1},{"id":"12345","type":1,"subtype":1}]}'
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Amzn-Requestid:
+      - f1d99b6c-4e45-11e8-a4b5-532000ef998f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5IFpMoAMF2BQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:14 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f706d57c41f06c046fabff5d072be255.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-1l1FcPre5rri4qJJ4BJKTEz3_tEm-xo4egM_P0tXSXAXtWW72FKzQ=="
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239274}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:15 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17239274
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.5.5
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1055'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Amzn-Requestid:
+      - f1fe3a49-4e45-11e8-9395-ad686ada724c
+      X-Amzn-Remapped-Content-Length:
+      - '1055'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GRl5KEoYIAMF-zw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 02 May 2018 20:18:15 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 52225573c1a940328665dd7134bf391d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 57tG-TyDDE_eMxaZBHBNlokdD2QZh4loBFwGDlQ9xahSiqxLSqjvgA==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17239274,"titleName":"New Title Testing Valid Identifier
+        Types","publisherName":null,"identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17239274,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 20:18:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_titles_create_spec.rb
+++ b/spec/requests/custom_titles_create_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
       let!(:json) { Map JSON.parse response.body }
 
       it 'returns an error status' do
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(400)
         expect(json.errors.first.title).to eql('Missing resource')
       end
     end

--- a/spec/requests/custom_titles_create_spec.rb
+++ b/spec/requests/custom_titles_create_spec.rb
@@ -1061,5 +1061,23 @@ RSpec.describe 'Custom Titles Create', type: :request do
           .to eq('Online')
       end
     end
+
+    describe 'with an invalid payload' do
+      before do
+        VCR.use_cassette('post-custom-title-invalid-payload') do
+          post '/eholdings/titles', headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid JSON')
+      end
+    end
   end
 end

--- a/spec/requests/custom_titles_create_spec.rb
+++ b/spec/requests/custom_titles_create_spec.rb
@@ -1,0 +1,1065 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Custom Titles Create', type: :request do
+  describe 'creating a custom title' do
+    let(:create_headers) do
+      okapi_headers.merge(
+        'Content-Type': 'application/vnd.api+json'
+      )
+    end
+
+    describe 'with minimum required fields' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing',
+              'publicationType' => 'Book'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-name-pubtype') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has a list of attributes' do
+        expect(attributes).to include(
+          'contributors',
+          'description',
+          'identifiers',
+          'isPeerReviewed',
+          'isTitleCustom',
+          'name',
+          'publicationType',
+          'publisherName',
+          'subjects'
+        )
+      end
+
+      it 'has the new name' do
+        expect(json.data.attributes.name).to eq('New Title Testing')
+      end
+
+      it 'has the new publication type' do
+        expect(json.data.attributes.publicationType).to eq('Book')
+      end
+
+      it 'has the newly generated id' do
+        expect(json.data.id).to eq('17239271')
+      end
+    end
+
+    describe 'with an existing name' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing',
+              'publicationType' => 'Book'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-existing-name') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with bad request' do
+        expect(response).to have_http_status(400)
+        expect(json.errors.first.title).to eql('Custom Title with the provided name already exists')
+      end
+    end
+
+    describe 'with missing name' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'publicationType' => 'Book'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-missing-name') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid titleName')
+      end
+    end
+
+    describe 'with a name that exceeds maximum size' do
+      let(:largeName) { '0' * 401 }
+
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => largeName,
+              'publicationType' => 'Book'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-long-name') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid titleName')
+      end
+    end
+
+    describe 'with missing publication type' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-missing-pubtype') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid pubType')
+      end
+    end
+
+    describe 'with publication type outside list of known values' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing Pub Type',
+              'publicationType' => 'Made Up'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-pubtype') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has unspecified publication type' do
+        expect(json.data.attributes.publicationType).to eq('Unspecified')
+      end
+    end
+
+    describe 'with missing included resource' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing',
+              'publicationType' => 'Book'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-missing-resource') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Missing resource')
+      end
+    end
+
+    describe 'with missing package id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing Bad Package Id',
+              'publicationType' => 'Book'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {}
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-missing-packageId') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid packageId')
+      end
+    end
+
+    describe 'with a managed package id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing',
+              'publicationType' => 'Made Up'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2512592'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-managed-packageId') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(400)
+        expect(json.errors.first.title).to eql('Custom Title can not be added to the provided package')
+      end
+    end
+
+    describe 'with invalid package id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'My Title Testing Bad Package Id',
+              'publicationType' => 'Made Up'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '9999999'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-packageId') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(400)
+        expect(json.errors.first.title).to eql('Custom Title can not be added to the provided package')
+      end
+    end
+
+    describe 'with all fields' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'Totally New Title Testing All Fields',
+              'publicationType' => 'Book',
+              'publisherName' => 'test publisher',
+              'isPeerReviewed' => true,
+              'edition' => 'test edition',
+              'description' => 'test description',
+              "contributors": [
+                {
+                  "type": 'Editor',
+                  "contributor": 'some editor'
+                },
+                {
+                  "type": 'Illustrator',
+                  "contributor": 'some illustrator'
+                }
+              ],
+              "identifiers": [
+                {
+                  "id": '12347',
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '98547',
+                  "type": 'ISSN',
+                  "subtype": 'Online'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-all-fields') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has the new resource name' do
+        expect(json.data.attributes.name).to eq('Totally New Title Testing All Fields')
+      end
+
+      it 'has the new publicationType' do
+        expect(json.data.attributes.publicationType).to eq('Book')
+      end
+
+      it 'has the new publisherName' do
+        expect(json.data.attributes.publisherName).to eq('test publisher')
+      end
+
+      it 'has the new isPeerReviewed' do
+        expect(json.data.attributes.isPeerReviewed).to eq(true)
+      end
+
+      it 'has the new edition' do
+        expect(json.data.attributes.edition).to eq('test edition')
+      end
+
+      it 'has the new description' do
+        expect(json.data.attributes.description).to eq('test description')
+      end
+
+      it 'has the list of contributors' do
+        expect(json.data.attributes.contributors[0].type)
+          .to eq('editor')
+        expect(json.data.attributes.contributors[0].contributor)
+          .to eq('some editor')
+        expect(json.data.attributes.contributors[1].type)
+          .to eq('illustrator')
+        expect(json.data.attributes.contributors[1].contributor)
+          .to eq('some illustrator')
+      end
+
+      it 'has the list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12347')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('98547')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Online')
+      end
+    end
+
+    describe 'with publisher name that exceeds maximum size' do
+      let(:largePublisherName) { '0' * 251 }
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Long Publisher',
+              'publicationType' => 'Book',
+              'publisherName' => largePublisherName
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-long-publishername') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid publisherName')
+      end
+    end
+
+    describe 'with peer reviewed that is not true/false' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Peer Review',
+              'publicationType' => 'Book',
+              'isPeerReviewed' => 'invalid'
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-peer-review') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid isPeerReviewed')
+      end
+    end
+
+    describe 'with edition that exceeds maximum size' do
+      let(:largeEdition) { '0' * 251 }
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Edition',
+              'publicationType' => 'Book',
+              'edition' => largeEdition
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-long-edition') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid edition')
+      end
+    end
+
+    describe 'with description that exceeds maximum size' do
+      let(:largeDescription) { '0' * 1501 }
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Custom Title Testing Long Description',
+              'publicationType' => 'Book',
+              'description' => largeDescription
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-long-description') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+        expect(json.errors.first.title).to eql('Invalid description')
+      end
+    end
+
+    describe 'with invalid contributor type' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Contributor',
+              'publicationType' => 'Book',
+              "contributors": [
+                {
+                  "type": 'invalid type',
+                  "contributor": 'some editor'
+                },
+                {
+                  "type": 'Illustrator',
+                  "contributor": 'some illustrator'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-contributor-type') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(400)
+      end
+
+      it 'returns expected error message' do
+        expect(json.errors.first.title).to eql('Parameter contributorsList.contributorType must be one of (author, editor, illustrator).')
+      end
+    end
+
+    describe 'with invalid identifier id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Identifier Id',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": 12_345, # cannot be an integer, has to be a string
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-identifier-id') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with invalid identifier id length' do
+      let(:longIdentifierId) { '0' * 21 }
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Identifier Id Length',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": longIdentifierId,
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-identifier-id-length') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with missing identifier id' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Missing Identifier Id',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-missing-identifier-id') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierId')
+      end
+    end
+
+    describe 'with invalid identifier type' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Identifier Type',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'Invalid Type',
+                  "subtype": 'Print'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-identifier-type') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierType')
+      end
+    end
+
+    describe 'with valid identifier types' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Valid Identifier Types',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '12345',
+                  "type": 'ISBN',
+                  "subtype": 'Print'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-valid-identifier-types') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has the expected list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Print')
+      end
+    end
+
+    describe 'with invalid identifier subtype' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Identifier Type',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Invalid subtype'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-invalid-identifier-type') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns expected error message title' do
+        expect(json.errors.first.title).to eql('Invalid IdentifierSubType')
+      end
+    end
+
+    describe 'with valid identifier subtypes' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Valid Identifier SubTypes',
+              'publicationType' => 'Book',
+              "identifiers": [
+                {
+                  "id": '12345',
+                  "type": 'ISSN',
+                  "subtype": 'Print'
+                },
+                {
+                  "id": '12345',
+                  "type": 'ISBN',
+                  "subtype": 'Online'
+                }
+              ]
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-valid-identifier-subtypes') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+      let!(:attributes) { json.data.attributes }
+
+      it 'has the expected list of identifiers' do
+        expect(json.data.attributes.identifiers[0].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[0].type)
+          .to eq('ISSN')
+        expect(json.data.attributes.identifiers[0].subtype)
+          .to eq('Print')
+        expect(json.data.attributes.identifiers[1].id)
+          .to eq('12345')
+        expect(json.data.attributes.identifiers[1].type)
+          .to eq('ISBN')
+        expect(json.data.attributes.identifiers[1].subtype)
+          .to eq('Online')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
EBSCO's RM API does not allow the creation of custom titles without creating a resource linking that title to a custom package. To make `mod-kb-ebsco`'s API more predictable, we'd like to establish a `POST /titles` endpoint.

## Approach
To work around RM API's relationship limitation, we can require titles to be created in conjunction with a resource, like:
```
{
  'data' => {
    'type' => 'titles',
    'attributes' => {
      'name' => 'New Title Testing',
      'publicationType' => 'Book'
    }
  },
  'included' => [
    {
      'type' => 'resources',
      'attributes' => {
        'packageId' => '2845504'
      }
    }
  ]
}
```
