### PR TITLE
Add title endpoints to module descriptor

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -35,7 +35,7 @@
           "pathPattern": "/eholdings/packages*"
         },
         {
-          "methods": [ "GET" ],
+          "methods": [ "GET", "POST", "PUT", "DELETE" ],
           "pathPattern": "/eholdings/titles*"
         },
         {


### PR DESCRIPTION
Okapi needs to know about the existence of `POST /titles` and `GET /titles`. I threw `DELETE` in there too, since I could see a need for that down the line.

Adding these to the module descriptor means requests to those endpoints will make it through to `mod-kb-ebsco`, instead of being cut off upstream by Okapi.