### PR TITLE
Remove rubocop from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,6 @@ pipeline {
 
         sh "sudo /bin/bash -l -c '. /usr/share/rvm/scripts/rvm && bundle install'"
 
-        echo "Run Ruby linter - rubocop..."
-        sh "/bin/bash -l -c '. /usr/share/rvm/scripts/rvm && rubocop'"
-
         echo "Run unit tests..."
         sh "/bin/bash -l -c '. /usr/share/rvm/scripts/rvm && rake spec'"
       }
@@ -135,5 +132,3 @@ pipeline {
   }
 
 }
-
-


### PR DESCRIPTION
## Purpose
Jenkins is failing to publish the docker image for merges to master on `mod-kb-ebsco`. It runs into Rubocop violations.

The Rubocop being run by Jenkins is version 0.52.1, even though `Gemfile.lock` specifies 0.55.0.

I don't have a diagnosis for what's going on. Perhaps something `rvm`-related?

## Approach
Temporarily disable Rubocop on Jenkins to prevent the pipeline from being blocked while we figure out the problem. Travis will still run Rubocop (at version 0.55.0).