### PR TITLE
Removed extraneous character 'g' at end of providers_controller.rb

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -64,4 +64,3 @@ class ProvidersController < ApplicationController
       )
   end
 end
-g


### PR DESCRIPTION
## Purpose
Seeing below errors in provider search or provider link due to an extraneous character in the file
## Approach
Removed character and confirmed tests with rubocop

## Screenshots
![correction-for-errors](https://user-images.githubusercontent.com/19415226/39785966-4b990d58-52ec-11e8-8fef-ac1a96ecf854.gif)

