### PR TITLE
UIEH-287 Optimize GET for all custom packages

### DIFF
--- a/spec/fixtures/vcr_cassettes/get-all-custom-packages.yml
+++ b/spec/fixtures/vcr_cassettes/get-all-custom-packages.yml
@@ -1,0 +1,341 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 09 May 2018 02:39:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 357882us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 48286us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 874746/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 09 May 2018 02:39:38 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '170'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 09 May 2018 02:39:38 GMT
+      X-Amzn-Requestid:
+      - 37cf900d-5332-11e8-985c-8330b54e98f6
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GmPYoHqOoAMF53g=
+      X-Amzn-Remapped-Date:
+      - Wed, 09 May 2018 02:39:38 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 720fb1b64ad23858127ee16baf9bbf32.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 8DGHjCIts6HtBO8jyffcPq0Wp-23TZ2uQAaoIIXc-qWq9oQ-W5k7zg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":74,"packagesSelected":74,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 09 May 2018 02:39:38 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages?contenttype=all&count=100&offset=1&orderby=packagename&search&selection=all
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '26978'
+      Connection:
+      - close
+      Date:
+      - Wed, 09 May 2018 02:39:38 GMT
+      X-Amzn-Requestid:
+      - 37ea1db8-5332-11e8-b208-87d3f5106cf4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GmPYqEGooAMFxTQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 09 May 2018 02:39:38 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 cbce93bae14c2990d9c172c1090b26cd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dUxXl1li0PNAV_4CHQ_zcUaqdgPfrtaj2kb-VeUT0IEp12zz3unEKg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":74,"packagesList":[{"packageId":2845504,"packageName":"\"HAHAHA\"","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":6,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":6,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2845510,"packageName":"\"Testing2\"","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846022,"packageName":"\"Testing4\"","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2018-04-02","endCoverage":"2018-04-23"},"packageType":"Custom"},{"packageId":2861742,"packageName":"All
+        Managed Stuff","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2720678,"packageName":"TEST_CUSTOMER_ID-custom-package","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":9,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":9,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2723775,"packageName":"TEST_CUSTOMER_ID-live-custompackage","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":9,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":9,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846164,"packageName":"Boston","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":2,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":2,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2865551,"packageName":"caroles
+        test package","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2861806,"packageName":"DE16909
+        Match Title","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2861802,"packageName":"DE21046
+        Create Custom","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2861804,"packageName":"DE26882
+        Ignore Selected","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848917,"packageName":"different
+        name","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2847324,"packageName":"Foo
+        bar book Vol. 1","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2846239,"packageName":"Foo
+        book Vol. 1","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846243,"packageName":"Foo
+        book Vol. 2.1","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846247,"packageName":"Foo
+        book Vol. 2.3","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846249,"packageName":"Foo
+        book Vol. 2.4","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846251,"packageName":"Foo
+        book Vol. 2.5","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846253,"packageName":"Foo
+        book Vol. 2.6","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2847514,"packageName":"Foo
+        book Vol. 2.8","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846241,"packageName":"Foo
+        book Vol. 2a","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846639,"packageName":"Foo
+        book Vol. 4","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2846722,"packageName":"Foo
+        book Vol. 4.1","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2845506,"packageName":"I
+        got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2789766,"packageName":"Jason
+        Nowlin Custom Package DE23001","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2850659,"packageName":"JeffreyApr23ab","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"OnlineReference","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2850661,"packageName":"JeffreyPkgApr30","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2851884,"packageName":"Jeffrey''s
+        Custom Package","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"Print","customCoverage":{"beginCoverage":"2018-04-11","endCoverage":"2018-04-27"},"packageType":"Custom"},{"packageId":2864055,"packageName":"joes_test","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2018-05-08","endCoverage":"2018-05-31"},"packageType":"Custom"},{"packageId":2864301,"packageName":"joes_test3","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":6,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":6,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2018-05-08","endCoverage":"2018-05-31"},"packageType":"Custom"},{"packageId":2861731,"packageName":"Marvel","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848852,"packageName":"My
+        new custom package","isCustom":true,"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848892,"packageName":"My
+        SD custom package","isCustom":true,"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2849475,"packageName":"Name
+        not used so far","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848967,"packageName":"name
+        not used yet","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2848969,"packageName":"name
+        still not used","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2849013,"packageName":"new
+        name","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2850657,"packageName":"new
+        nameaaaa","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2863806,"packageName":"newest
+        name","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2863801,"packageName":"newest
+        name of them all","isCustom":true,"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2849009,"packageName":"not
+        yet created","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848827,"packageName":"SD
+        test new custom package","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Print","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2850417,"packageName":"SD''s
+        test package","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":21,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":21,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2848228,"packageName":"SD''s
+        test package again","isCustom":true,"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":3,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":3,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2843723,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID again","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844850,"packageName":"SD''s
+        test package with root proxy","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844853,"packageName":"SD''s
+        test package with root proxy again","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844893,"packageName":"SD''s
+        test package with root proxy for Mohan","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844856,"packageName":"SD''s
+        test package with visibility","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844860,"packageName":"SD''s
+        test package with visibility again","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2844899,"packageName":"SD''s
+        test package with visibility for Mohan","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"},"packageType":"Custom"},{"packageId":2864801,"packageName":"smoketest1","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2018-05-01","endCoverage":"2018-05-29"},"packageType":"Custom"},{"packageId":2848898,"packageName":"Sob
+        new package","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2845384,"packageName":"Sobha
+        testing isHidden in POST","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2845445,"packageName":"sobha-test-custom-pacakges","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848902,"packageName":"Sob''s
+        new package","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2861738,"packageName":"Star
+        Wars Testing","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2862785,"packageName":"supercalifragilisticexpialidocious
+        Pkg","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848911,"packageName":"test
+        cp","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2739728,"packageName":"testing
+        ","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":2,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":2,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2849015,"packageName":"testing
+        content type again","isCustom":true,"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2842964,"packageName":"testing
+        title","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE CUSTOMER","titleCount":5,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":5,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846034,"packageName":"Testing10","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846037,"packageName":"Testing11","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846029,"packageName":"Testing8","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2846032,"packageName":"Testing9","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2848963,"packageName":"totally
+        new name","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2863818,"packageName":"VCR
+        Package 1","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2863820,"packageName":"VCR
+        Package 1.2","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"},{"packageId":2863822,"packageName":"VCR
+        Package 1.3","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2863824,"packageName":"VCR
+        Package 1.4","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2863826,"packageName":"VCR
+        Package 1.5","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Custom"},{"packageId":2863828,"packageName":"VCR
+        Package 1.6","isCustom":true,"vendorId":123355,"vendorName":"API DEV CORPORATE
+        CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"packageType":"Custom"}]}'
+    http_version: 
+  recorded_at: Wed, 09 May 2018 02:39:38 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1287,4 +1287,20 @@ RSpec.describe 'Packages', type: :request do
       end
     end
   end
+
+  describe 'filtering by custom' do
+    before do
+      VCR.use_cassette('get-all-custom-packages') do
+        get '/eholdings/packages?filter[custom]=true&count=100', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'gets a list of custom packages' do
+      expect(response).to have_http_status(200)
+      expect(json.data.length).to equal(74)
+      expect(json.data.first.attributes.isCustom).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
Calls to acquire all of a org's custom packages (`GET /eholdings/packages?filter[custom]=true&count=100`) were taking over 50 seconds.

## Approach
The original implementation looped through every page of packages available, and picked out ones where `isCustom` is true.

All custom packages fall under the same provider, and that provider id is available from the tenant config. Instead of looping through the entire world of packages, we can just ask for the packages belonging to that specific provider.

The endpoint now takes about a second.