### PR TITLE
Expect composite package ids when creating titles

### DIFF
--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -91,7 +91,7 @@ class Title < RmApiResource
   # we actually create a resource here, but then return the resulting
   # title that was also created
   def self.create_title(params)
-    package_id = params[:packageId]
+    provider_id, package_id = params[:packageId].split('-')
     create_params = params.to_hash.except(:packageId)
     rm_api_create = { vendor_id: provider_id, package_id: package_id }.merge(create_params)
     resource_response = Resource.configure(config).create rm_api_create

--- a/spec/fixtures/vcr_cassettes/post-custom-title-invalid-packageId.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-invalid-packageId.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 02 May 2018 20:18:12 GMT
+      - Wed, 09 May 2018 03:43:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +35,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1203us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 43798us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 362702us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 44066us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 893143/configurations
+      - 444057/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,68 +107,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 02 May 2018 20:18:12 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 02 May 2018 20:18:12 GMT
-      X-Amzn-Requestid:
-      - f00920b2-4e45-11e8-8cd7-9553e9375f89
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GRl4pFh4oAMFXhg=
-      X-Amzn-Remapped-Date:
-      - Wed, 02 May 2018 20:18:12 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 06df2f0e5cefb5e7b8be41ff25b6fd8a.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - bSULZlL26yNYGLr60Xi63Uagxm1khu_Y-ey5jwxfyo2P3rPfmwMuZw==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":63,"packagesSelected":63,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+  recorded_at: Wed, 09 May 2018 03:43:41 GMT
 - request:
     method: post
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/9999999/titles
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/9999999/packages/9999999/titles
     body:
       encoding: UTF-8
       string: '{"titleName":"My Title Testing Bad Package Id","pubType":"unspecified"}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -181,35 +129,34 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 404
+      message: Not Found
     headers:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '104'
+      - '67'
       Connection:
       - keep-alive
       Date:
-      - Wed, 02 May 2018 20:18:12 GMT
+      - Wed, 09 May 2018 03:43:42 GMT
       X-Amzn-Requestid:
-      - f02d98f0-4e45-11e8-8bf8-89bd1f87a910
+      - 2aba53c4-533b-11e8-855d-052a594ad10c
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GRl4sH9YIAMF1Tw=
+      - GmYxLGdDIAMFaDg=
       X-Amzn-Remapped-Date:
-      - Wed, 02 May 2018 20:18:11 GMT
+      - Wed, 09 May 2018 03:43:42 GMT
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 e9b460d4fbe79e1b34e06840ef460c69.cloudfront.net (CloudFront)
+      - 1.1 aa9a6b87feabe1a30d21428a24c1a7d8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - pE32iUt_25lvVsJ4s3QoK_J0PelUU5RO9xpwnwSdU6XA_s3z4xTxUQ==
+      - q2lZNRSX1Mk5-IkaklDawnKFJuySmOznElooadZ549XoDVAVybaf9g==
     body:
       encoding: UTF-8
-      string: '{"errors":[{"code":1006,"subCode":0,"message":"Custom Title can not
-        be added to the provided package"}]}'
+      string: '{"errors":[{"code":1001,"subCode":0,"message":"Vendor not found"}]}'
     http_version: 
-  recorded_at: Wed, 02 May 2018 20:18:12 GMT
+  recorded_at: Wed, 09 May 2018 03:43:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/custom_titles_create_spec.rb
+++ b/spec/requests/custom_titles_create_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -86,7 +86,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -121,7 +121,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -159,7 +159,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -194,7 +194,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -230,7 +230,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -332,7 +332,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2512592'
+                'packageId' => '123355-2512592'
               }
             }
           ]
@@ -368,7 +368,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '9999999'
+                'packageId' => '9999999-9999999'
               }
             }
           ]
@@ -385,8 +385,8 @@ RSpec.describe 'Custom Titles Create', type: :request do
       let!(:json) { Map JSON.parse response.body }
 
       it 'returns an error status' do
-        expect(response).to have_http_status(400)
-        expect(json.errors.first.title).to eql('Custom Title can not be added to the provided package')
+        expect(response).to have_http_status(404)
+        expect(json.errors.first.title).to eql('Provider not found')
       end
     end
 
@@ -430,7 +430,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -518,7 +518,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -555,7 +555,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -593,7 +593,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -631,7 +631,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -677,7 +677,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -723,7 +723,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -770,7 +770,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -815,7 +815,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -861,7 +861,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -912,7 +912,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -972,7 +972,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]
@@ -1023,7 +1023,7 @@ RSpec.describe 'Custom Titles Create', type: :request do
             {
               'type' => 'resources',
               'attributes' => {
-                'packageId' => '2845504'
+                'packageId' => '123355-2845504'
               }
             }
           ]


### PR DESCRIPTION
## Purpose
Custom titles weren't being created, because `ui-eholdings` only knows about the composite `packageId` of the RM API vendor id + RM API package id.

## Approach
Deconstruct the composite id to just get the RM API package id.

Tests updated to only use the composite ids.