### PR TITLE
Do not POST empty arrays to RM API for custom titles

### DIFF
--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -93,6 +93,13 @@ class Title < RmApiResource
   def self.create_title(params)
     provider_id, package_id = params[:packageId].split('-')
     create_params = params.to_hash.except(:packageId)
+
+    # RM API returns a Malformed request if either contributorsList
+    # or identifiersList are empty arrays; if they are, don't
+    # send them in the payload
+    create_params.delete(:contributorsList) unless params[:contributorsList]
+    create_params.delete(:identifiersList) unless params[:identifiersList]
+
     rm_api_create = { vendor_id: provider_id, package_id: package_id }.merge(create_params)
     resource_response = Resource.configure(config).create rm_api_create
     find resource_response[:titleId]

--- a/spec/fixtures/vcr_cassettes/post-custom-title-empty-contributors-identifiers.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-title-empty-contributors-identifiers.yml
@@ -1,0 +1,228 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 09 May 2018 04:46:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 358611us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 45156us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 683385/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 09 May 2018 04:46:49 GMT
+- request:
+    method: post
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845504/titles
+    body:
+      encoding: UTF-8
+      string: '{"titleName":"New Title Testing Invalid Contributor","pubType":"book"}'
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '20'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 09 May 2018 04:46:50 GMT
+      X-Amzn-Requestid:
+      - fc6f8078-5343-11e8-8a91-bf2602364a05
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GmiBBFgnoAMFa5A=
+      X-Amzn-Remapped-Date:
+      - Wed, 09 May 2018 04:46:50 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 72882d2d20025ce740b1efae5c3e8544.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0tmdrUwqDczYWiffBF9sK-kdyKmHVdnuB4sjOEtlKuc4GODq1WkyRg==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17267343}'
+    http_version: 
+  recorded_at: Wed, 09 May 2018 04:46:50 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles/17267343
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '921'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 09 May 2018 04:46:50 GMT
+      X-Amzn-Requestid:
+      - fcb1e0bd-5343-11e8-a505-3b5a17e82221
+      X-Amzn-Remapped-Content-Length:
+      - '921'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - GmiBGHWPIAMF9RA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Wed, 09 May 2018 04:46:50 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 89cb9fcdbd0314a45e84448b824c18db.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dHdCAJ4lK5g6dZA8LjY_pFuPOSXPjTXMQPNiH2FxIhvKzLOHKvtsYQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":17267343,"titleName":"New Title Testing Invalid Contributor","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17267343,"packageId":2845504,"packageName":"\"HAHAHA\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Wed, 09 May 2018 04:46:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/custom_titles_create_spec.rb
+++ b/spec/requests/custom_titles_create_spec.rb
@@ -702,6 +702,43 @@ RSpec.describe 'Custom Titles Create', type: :request do
       end
     end
 
+    describe 'with empty contributors and identifiers' do
+      let(:params) do
+        {
+          'data' => {
+            'type' => 'titles',
+            'attributes' => {
+              'name' => 'New Title Testing Invalid Contributor',
+              'publicationType' => 'Book',
+              "contributors": [],
+              "identifiers": []
+            }
+          },
+          'included' => [
+            {
+              'type' => 'resources',
+              'attributes' => {
+                'packageId' => '123355-2845504'
+              }
+            }
+          ]
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-title-empty-contributors-identifiers') do
+          post '/eholdings/titles',
+               params: params, as: :json, headers: create_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'responds with OK status' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
     describe 'with invalid identifier id' do
       let(:params) do
         {


### PR DESCRIPTION
## Purpose
If you `POST` to RM API to create a custom title, and `contributorsList` or `identifiersList` are empty arrays, it returns a 500 with error `Malformed request`.

So it was impossible to create custom titles in the front end without contributors or identifiers.

## Approach
Eliminate `contributorsList` or `identifiersList` from the request params if `POST`ing and they're empty.
