### PR TITLE
UIEH-135: Mask RM API encryption key when it is read from configuration endpoint

### DIFF
--- a/app/serializable/serializable_configuration.rb
+++ b/app/serializable/serializable_configuration.rb
@@ -3,5 +3,11 @@
 class SerializableConfiguration < SerializableJSONAPIResource
   type 'configurations'
 
-  attributes :api_key, :customer_id
+  attribute :customer_id
+
+  # The api key is masked in the payload returned from
+  # configuration so it cannot be retrieved by unauthorized users
+  attribute :api_key do
+    '*' * 40
+  end
 end

--- a/spec/requests/configurations_spec.rb
+++ b/spec/requests/configurations_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe 'Configurations', type: :request do
     ]
   end
 
+  let(:masked_api_key) do
+    '*' * 40
+  end
+
   describe 'setting the configuration when it has never been set before' do
     before do
       VCR.use_cassette('put-configuration') do
@@ -52,7 +56,7 @@ RSpec.describe 'Configurations', type: :request do
 
       it 'contains valid attributes' do
         expect(json.data.attributes.customerId).to eql(customer_id)
-        expect(json.data.attributes.apiKey).to eql(api_key)
+        expect(json.data.attributes.apiKey).to eql(masked_api_key)
       end
     end
   end


### PR DESCRIPTION
[UIEH-135 - RM API Encryption Key - do not return key in GET response](https://issues.folio.org/browse/UIEH-135)

## Purpose
eHoldings application does not display the RM API encryption key in the UI. As was implemented in [UIEH-105](https://issues.folio.org/browse/UIEH-105). This follow on ticket updates mod-kb-ebsco GET endpoint to prevent the return of credentials. As it exists now, credentials can be obtained by observing network traffic or viewing text of the settings page. 

## Approach
As suggested in earlier ticket, return a masked string (********) 40 characters for RM API from configuration GET request

#### TODOS and Open Questions
- [ ] Longer term need to consider storage of key in database - should it be encrypted there?


## Screenshots
GET response from mod-kb-ebsco - 
![mask-api-key](https://user-images.githubusercontent.com/19415226/39827555-41d577da-5386-11e8-974c-8190e7721cdf.gif)
Settings page from which credentials can be observed.
![settings-api-key](https://user-images.githubusercontent.com/19415226/39827605-6fc8b256-5386-11e8-8502-6661a48df714.gif)
