### PR TITLE
Modify ModuleDescriptor.json

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -16,11 +16,11 @@
         },
         {
           "methods": [ "GET", "PUT", "DELETE" ],
-          "pathPattern": "/eholdings/custom-labels/*"
+          "pathPattern": "/eholdings/custom-labels*"
         },
         {
           "methods": [ "GET", "PUT" ],
-          "pathPattern": "/eholdings/root-proxies/*"
+          "pathPattern": "/eholdings/root-proxies*"
         },
         {
           "methods": [ "GET" ],


### PR DESCRIPTION
## Purpose
When we are trying to implement the UI for root-proxies, we are getting a 404 Not Found. Checking other module descriptors in other backend modules, noticed that GET on a collection does not have trailing '/' at the end. Other endpoints in mod-kb-ebsco do not have trailing slash either. 

## Approach
Remove the trailing slash at the end for both root-proxies as well as custom-labels endpoints.
