### PR TITLE
UIEH-376 : Proxy support at resource level

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -149,6 +149,7 @@ class ResourcesController < ApplicationController
         :edition,
         :description,
         :url,
+        proxy: %i[id inherited],
         visibilityData: %i[isHidden reason],
         customCoverageList: [
           %i[beginCoverage endCoverage]

--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -11,7 +11,8 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
              :description,
              :url,
              :packageId,
-             :titleId
+             :titleId,
+             :proxy
 
   attribute :name do |value|
     { titleName: value }

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -116,7 +116,8 @@ class Resource < RmApiResource
       publisherName: attributes[:publisherName],
       edition: attributes[:edition],
       description: attributes[:description],
-      url: resource_attributes[:url]
+      url: resource_attributes[:url],
+      proxy: resource_attributes[:proxy]
     )
     refresh!
   end
@@ -195,7 +196,8 @@ class Resource < RmApiResource
         :identifiersList,
         :customEmbargoPeriod,
         :coverageStatement,
-        :url
+        :url,
+        :proxy
       )
     else
       resource.to_hash.with_indifferent_access.slice(
@@ -203,7 +205,8 @@ class Resource < RmApiResource
         :visibilityData,
         :customCoverageList,
         :customEmbargoPeriod,
-        :coverageStatement
+        :coverageStatement,
+        :proxy
       )
     end
   end

--- a/app/serializable/serializable_resource.rb
+++ b/app/serializable/serializable_resource.rb
@@ -158,4 +158,7 @@ class SerializableResource < SerializableJSONAPIResource
   attribute :customCoverages do
     @object.resource.customCoverageList
   end
+  attribute :proxy do
+    @object.resource.proxy
+  end
 end

--- a/spec/fixtures/vcr_cassettes/get-resources-success.yml
+++ b/spec/fixtures/vcr_cassettes/get-resources-success.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 01 Dec 2017 23:39:48 GMT
+      - Wed, 16 May 2018 18:56:22 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
-        : 202'
-      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 44269us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 354491us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42707us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.1.1
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.36.1.1
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,13 +66,13 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 548538/configurations
+      - 991245/configurations
       X-Okapi-Url:
-      - http://10.39.247.213:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
       X-Okapi-Permissions:
       - '["configuration.entries.collection.get"]'
       X-Okapi-User-Id:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "0ccfbcb5-a2eb-4bb8-bee4-b918a8d0aeaa",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-11-22T19:11:39.501+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-11-22T19:11:39.501+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 23:39:48 GMT
+  recorded_at: Wed, 16 May 2018 18:56:22 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -116,7 +116,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,17 +135,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1471'
+      - '1672'
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Dec 2017 23:39:49 GMT
+      - Wed, 16 May 2018 18:56:22 GMT
       X-Amzn-Requestid:
-      - eb91b76d-d6f0-11e7-99ca-7f83b19a3cbf
+      - d39f2f1b-593a-11e8-9ff5-7b340e33edff
       X-Amzn-Remapped-Content-Length:
-      - '1471'
+      - '1672'
       X-Amzn-Remapped-Connection:
       - keep-alive
+      X-Amz-Apigw-Id:
+      - G_jBkH6EoAMF3sw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -157,23 +159,24 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 01 Dec 2017 23:39:49 GMT
+      - Wed, 16 May 2018 18:56:22 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4fb857c1dabd2115624fdcb2050db6b9.cloudfront.net (CloudFront)
+      - 1.1 15b0145f4a440167477203d93c9e877a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KNERwuRwYb6m-WzycZ1pM1R2V04MBCUD0grgLlxeDCW-BjZNwhY1Eg==
+      - 16stwMknCO7vaOooCDy0wQFVzUmeqy7yuojTUGOAtKGRthPkm2cBBw==
     body:
       encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
         / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":false,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
+        Ebook Central","packageType":"Variable","proxy":{"id":"EZProxy","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
+        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"https://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
     http_version: 
-  recorded_at: Fri, 01 Dec 2017 23:39:49 GMT
+  recorded_at: Wed, 16 May 2018 18:56:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-resource-ishidden-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-resource-ishidden-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 20 Dec 2017 20:03:47 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.1.1-SNAPSHOT.7 http://10.39.243.223:8081/configurations/entries..
-        : 202'
-      - 'GET mod-configuration-3.0.1-SNAPSHOT.18 http://10.39.247.37:8081/configurations/entries..
-        : 200 41757us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 357845us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42612us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.2.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.2.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,13 +66,13 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 169071/configurations
+      - 698608/configurations
       X-Okapi-Url:
-      - http://10.39.247.213:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.1.1-SNAPSHOT.7":["perms.users.get"]}'
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
       X-Okapi-Permissions:
       - '["configuration.entries.collection.get"]'
       X-Okapi-User-Id:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "0f7643e0-25b5-487a-816e-17484ec17e1b",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2017-12-12T18:31:12.750+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2017-12-12T18:31:12.750+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:03:47 GMT
+  recorded_at: Wed, 16 May 2018 19:02:22 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -116,7 +116,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,17 +135,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1579'
+      - '1672'
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       X-Amzn-Requestid:
-      - e3f5fd3e-e5c0-11e7-8f42-a3e368ef60ef
+      - a9e882d5-593b-11e8-8680-915eda537cb7
       X-Amzn-Remapped-Content-Length:
-      - '1579'
+      - '1672'
       X-Amzn-Remapped-Connection:
       - keep-alive
+      X-Amz-Apigw-Id:
+      - G_j5vFQcIAMF53g=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -157,34 +159,37 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5ae8b0e76af80aa471660f48d35acb41.cloudfront.net (CloudFront)
+      - 1.1 001e3d2e0977f947f2e93be8539ac1de.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - IqAVkxXXrQe7RgPO9-H7QpGZUiDUmzPo-h5UZDXe6l1L96qIjhDl_A==
+      - wLwAQMeW35f27rFPHCD4cR9dUOB6eOOF3YC8vpLXgM-8ANrXVZybfw==
     body:
       encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
         / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
-        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
+        Ebook Central","packageType":"Variable","proxy":{"id":"EZProxy","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
+        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"https://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
+  recorded_at: Wed, 16 May 2018 19:02:22 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[{"beginCoverage":"2005-01-01","endCoverage":""},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5}}'
+      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[{"beginCoverage":"2005-01-01","endCoverage":""},{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"}],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"coverageStatement":"Only
+        2000s issues available.","titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","pubType":"Book","isPeerReviewed":false,"publisherName":"Elsevier","edition":null,"description":null,"url":null,"proxy":{"id":"EZProxy","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -207,11 +212,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       X-Amzn-Requestid:
-      - e426f873-e5c0-11e7-b47e-19463f23d40e
+      - aa099fee-593b-11e8-bc4a-85d7e69bc67f
       X-Amzn-Remapped-Connection:
       - keep-alive
+      X-Amz-Apigw-Id:
+      - G_j5xFZxIAMF7GQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -223,20 +230,20 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5ae8b0e76af80aa471660f48d35acb41.cloudfront.net (CloudFront)
+      - 1.1 2f7eec78b53c7625bd656dcd08ed1823.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - GBN_5MZEbp6zmQ6XNEn4OyDdQn7vyuZuK8kkG-VLvaSNeopTUv1Wdw==
+      - ZtXOl35yysFIW9IcC2AtcZ1_ophFaolX4wvtjFk1RSBp-pYujKSfHw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
+  recorded_at: Wed, 16 May 2018 19:02:22 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
@@ -245,7 +252,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -264,17 +271,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1596'
+      - '1689'
       Connection:
       - keep-alive
       Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:23 GMT
       X-Amzn-Requestid:
-      - e43ffeb0-e5c0-11e7-9c84-3be4208b146c
+      - aa563958-593b-11e8-9c84-99275ca2c964
       X-Amzn-Remapped-Content-Length:
-      - '1596'
+      - '1689'
       X-Amzn-Remapped-Connection:
       - keep-alive
+      X-Amz-Apigw-Id:
+      - G_j52FnJIAMFxTQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -286,24 +295,25 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 20 Dec 2017 20:03:48 GMT
+      - Wed, 16 May 2018 19:02:22 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9443b13f9c1702357fc79e34ddbc761c.cloudfront.net (CloudFront)
+      - 1.1 ac3474fe463b33f1439c8d949f9a075f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - rN4LzrpanwV452btRF9sc9Zh79lQKXkMM8f7gDMsAccGi7IWwZ7RDw==
+      - BVkRUZsJkRyjO3Cq1kKtq7pKGR05EEIJi4Z0SFDYW_Ax5CW-DjAU4w==
     body:
       encoding: UTF-8
-      string: '{"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
-        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}],"titleId":1440285,"titleName":"Havard''s
-        Nursing Guide to Drugs (Nursing Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":16},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":6},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":8}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
         / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
-        Ebook Central","isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Ebook Central","packageType":"Variable","proxy":{"id":"EZProxy","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
         Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"http://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}'
+        by Customer"},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[{"beginCoverage":"2000-01-01","endCoverage":"2004-02-01"},{"beginCoverage":"2005-01-01","endCoverage":""}],"coverageStatement":"Only
+        2000s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Months","embargoValue":5},"url":"https://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
     http_version: 
-  recorded_at: Wed, 20 Dec 2017 20:03:48 GMT
+  recorded_at: Wed, 16 May 2018 19:02:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -45,11 +45,12 @@ RSpec.describe 'Resources', type: :request do
         'url',
         'vendorId',
         'vendorName',
-        'visibilityData'
+        'visibilityData',
+        'proxy'
       )
     end
 
-    it "has a composite pacakge id of '{vendor_id}-{package_id}'" do
+    it "has a composite package id of '{vendor_id}-{package_id}'" do
       expect(attributes.packageId).to eq('22-1887786')
     end
 
@@ -58,7 +59,7 @@ RSpec.describe 'Resources', type: :request do
     end
 
     it 'has a selected value' do
-      expect(attributes.isSelected).to be false
+      expect(attributes.isSelected).to be true
     end
 
     it 'has a manage coverage' do
@@ -118,7 +119,16 @@ RSpec.describe 'Resources', type: :request do
         expect(attributes.identifiers[2].subtype).to eq('Print')
       end
       it 'identifier has a human readable subtype' do
-        expect(attributes.identifiers[2].type).to eq('ZDBID')
+        expect(attributes.identifiers[2].type).to eq('ISBN')
+      end
+    end
+
+    describe 'with proxy' do
+      it 'contains proxy id' do
+        expect(attributes.proxy.id).to eq('EZProxy')
+      end
+      it 'contains proxy inheritance' do
+        expect(attributes.proxy.inherited).to eq(true)
       end
     end
   end
@@ -387,6 +397,10 @@ RSpec.describe 'Resources', type: :request do
                 'isSelected' => true,
                 'visibilityData' => {
                   'isHidden' => true
+                },
+                'proxy' => {
+                  'id' => 'EZProxy',
+                  'inherited' => false
                 }
               }
             }
@@ -409,6 +423,14 @@ RSpec.describe 'Resources', type: :request do
 
         it 'is no longer visible' do
           expect(visibility.isHidden).to be true
+        end
+
+        it 'updated proxy correctly' do
+          expect(json.data.attributes.proxy.id).to eq('EZProxy')
+        end
+
+        it 'does not change inheritance value, always from RM API' do
+          expect(json.data.attributes.proxy.inherited).to eq(true)
         end
       end
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-376, users should be able to view/update proxy setting at a resource(title-package) level irrespective of whether it is a managed title or a custom title.

## Approach
- Add proxy in serializers and deserializers and in update params of a resource.
- Associated unit tests

## Learning
- What I learnt while implementing this is that RM API, if current proxy setting is inherited, then for updating the setting, we need to pass "inherited" as false; else RM API will throw an error that inherited proxy setting cannot be updated. Where as when we do a GET, the state of inherited need not match. RM API gives the correct state of whether it is inherited or not irrespective of what we pass to it. Added support to get both proxy "id" as well as "inherited" from UI. 

## Screenshots
![root_proxy_resource](https://user-images.githubusercontent.com/33662516/40138960-53e5f102-591c-11e8-88f8-f2bd6ff3db8e.gif)

