### PR TITLE
[UIEH-367] Add skeletal eholdings RAML.

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -1,0 +1,12 @@
+#%RAML 0.8
+title: "mod-kb-ebsco"
+baseUri: https://github.com/folio-org/mod-kb-ebsco
+version: v1
+
+documentation:
+  - title: mod-kb-ebsco (category)
+    content: Implements the eholdings interface using the EBSCO kb as a backend.
+
+
+/eholdings/vendors:
+  displayName: Vendors


### PR DESCRIPTION
## Purpose
As it stands, mod-kb-ebsco docs are not present in the api doc repository here https://dev.folio.org/reference/api/ which is a shame.

## Approach
This adds a skeletal RAML file so that we can deploy our documentation to production. Then, after this is in place, we can add more documentation for each endpoint.

## TODOS
- [x] Merge documentation generation #133 
- [ ] flip on configuration to copy over to the documentation site after merge.

## Learning

- FOLIO uses RAML v0.8 for all of its api documentation endpoints https://raml.org
- RAML uses json schema for body types https://www.jsonschema.net
