### PR TITLE
UIEH-361 Adjust error handling for PackagesRepository

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,13 +42,9 @@ class ApplicationController < ActionController::API
 
   def catch_repository_errors
     yield
-  rescue PackagesRepository::BadRequest => e
-    render jsonapi_errors: [title: e.message], status: :bad_request
-  rescue PackagesRepository::RequestError => e
-    render jsonapi_errors: [title: e.result.message], status: e.result.status
-  rescue PackagesRepository::ValidationError => e
-    status = %w[create update].include?(action_name.to_s) ? :unprocessable_entity : :bad_request
-    render jsonapi_errors: e.validation.errors, status: status
+  rescue RmapiRepository::RequestError => e
+    render jsonapi_errors: [title: e.message],
+           status: e.status
   end
 
   def catch_flexirest_exceptions

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -23,17 +23,38 @@ class PackagesController < ApplicationController
   end
 
   def create
-    @result = packages.create! package_create_params
-    render jsonapi: @result.data
+    package_create_validation = Validation::CustomPackageParameters.new(package_create_params)
+    if package_create_validation.valid?
+      @result = packages.create! package_create_params
+      render jsonapi: @result.data
+    else
+      render jsonapi_errors: package_create_validation.errors,
+             status: :unprocessable_entity
+    end
   end
 
   def update
-    @result = packages.update! params[:id], package_update_params
-    render jsonapi: @result.data
+    package_update_validation = Validation::PackageParameters.new(package_update_params)
+    if package.is_custom
+      package_update_validation = Validation::CustomPackageParameters.new(package_update_params)
+    end
+    if package_update_validation.valid?
+      @result = packages.update! params[:id], package_update_params
+      render jsonapi: @result.data
+    else
+      render jsonapi_errors: package_update_validation.errors,
+             status: :unprocessable_entity
+    end
   end
 
   def destroy
-    packages.destroy! params[:id]
+    package_destroy_validation = Validation::PackageDestroyParameters.new(package)
+    if package_destroy_validation.valid?
+      packages.destroy! params[:id]
+    else
+      render jsonapi_errors: package_destroy_validation.errors,
+             status: :bad_request
+    end
   end
 
   # Relationships

--- a/app/controllers/validation/custom_package_parameters.rb
+++ b/app/controllers/validation/custom_package_parameters.rb
@@ -6,13 +6,19 @@ module Validation
   class CustomPackageParameters
     include ActiveModel::Validations
 
-    attr_accessor :packageName, :contentType
+    attr_accessor :name, :contentType
 
-    validates :packageName, presence: true
+    validates :name, presence: true
     validates :contentType, presence: true
 
+    # TODO: this should turn snake as soon as it
+    # comes out of the deserializable layer.  also
+    # we should probably validate more than presence on these.
+    # content_type is an enum, and name could be arbitrarily
+    # long to the point that RMAPI throws the error instead of us
+
     def initialize(params = {})
-      @packageName = params[:packageName]
+      @name = params[:name]
       @contentType = params[:contentType]
     end
   end

--- a/app/deserializable/deserializable_package.rb
+++ b/app/deserializable/deserializable_package.rb
@@ -5,8 +5,8 @@ class DeserializablePackage < JSONAPI::Deserializable::Resource
              :contentType,
              :customCoverage,
              :isSelected,
-             :name,
-             :visibilityData
+             :visibilityData,
+             :name
 
   attribute :contentType do |value|
     content_types = {

--- a/app/repositories/rmapi_repository.rb
+++ b/app/repositories/rmapi_repository.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class RmapiRepository
+  attr_reader :base_url, :headers
+
+  def initialize(config:)
+    @config = config
+    @base_url = "#{rmapi_url}/rm/rmaccounts/#{config.customer_id}"
+
+    @headers = {
+      'X-Api-Key': config.api_key,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
+  end
+
+  def request(verb, fragment = '', **options)
+    response = HTTP.headers(headers).request(
+      verb,
+      "#{base_url}#{fragment}",
+      options
+    )
+
+    fail RequestError.new(response.body, response.status) unless response.status.success?
+
+    # TODO: return Result instance, nix normalize_response_body and make it to_entity
+    # enforce generic interface
+    [response.status, normalize_response_body(response)]
+  end
+
+  private
+
+  def rmapi_url
+    Rails.application.config.rmapi_base_url
+  end
+
+  class RequestError < StandardError
+    attr_reader :status
+
+    def initialize(message, status)
+      @status = status
+      super(message)
+    end
+  end
+end
+
+# TODO: abstract methods?

--- a/spec/fixtures/vcr_cassettes/delete-non-custom-package.yml
+++ b/spec/fixtures/vcr_cassettes/delete-non-custom-package.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 04:13:39 GMT
+      - Wed, 30 May 2018 12:35:40 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +35,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1313us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41214us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1227us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42734us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 269971/configurations
+      - 676569/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 04:13:39 GMT
+  recorded_at: Wed, 30 May 2018 12:35:40 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/583/packages/4345
@@ -135,28 +135,28 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '433'
+      - '436'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 04:13:39 GMT
+      - Wed, 30 May 2018 12:35:40 GMT
       X-Amzn-Requestid:
-      - 86179e40-4f51-11e8-a346-53440f0e90f2
+      - f685fba0-6405-11e8-b253-9d614a7f2c57
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GV-eDFrpoAMFr_g=
+      - Hs0YgGwYIAMFeqA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 04:13:39 GMT
+      - Wed, 30 May 2018 12:35:40 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 6f4c292df8fb7b5bd5bfa8aff66748aa.cloudfront.net (CloudFront)
+      - 1.1 66114286e54efb82c700272100713f2f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - oDHhwnH5qJJe6bqFKmr0xHxKczq8w5y-VQqjcF45lSBPhiL3tyTeLw==
+      - KsV69_s2QTsH-3dG6I90b1_tMFbBVO1UzL5ftzdU-iE0HFXltEcUsQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":4345,"packageName":"ABC-CLIO eBook Collection","isCustom":false,"vendorId":583,"vendorName":"ABC-CLIO","titleCount":9428,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":9428,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Variable"}'
+      string: '{"packageId":4345,"packageName":"ABC-CLIO eBook Collection","isCustom":false,"vendorId":583,"vendorName":"ABC-CLIO","titleCount":9428,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":9427,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Variable"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 04:13:39 GMT
+  recorded_at: Wed, 30 May 2018 12:35:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-package-invalid-content-type.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-package-invalid-content-type.yml
@@ -157,218 +157,6 @@ http_interactions:
     http_version: 
   recorded_at: Fri, 04 May 2018 05:03:38 GMT
 - request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 04 May 2018 05:04:08 GMT
-      X-Amzn-Requestid:
-      - 932bfdc7-4f58-11e8-bf00-2fad7a065eb6
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GWF3PGaBoAMFzJQ=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 05:04:08 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 3da3508da5df5956549a94ec250a7674.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - X4Dd9ULCJd7yH2CPDU7J5oqCt4TcatP6Mdp1e8TbY1TnLdNI8hGuBQ==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":70,"packagesSelected":70,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:04:08 GMT
-- request:
-    method: get
-    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.13.5
-      Date:
-      - Fri, 04 May 2018 05:05:11 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 355006us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42579us'
-      Host:
-      - okapi.frontside.io
-      X-Real-Ip:
-      - 10.128.0.4
-      X-Forwarded-For:
-      - 10.128.0.4
-      X-Forwarded-Host:
-      - okapi.frontside.io
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      X-Scheme:
-      - https
-      X-Auth-Request-Redirect:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-      X-Okapi-Request-Id:
-      - 184096/configurations
-      X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
-      X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
-      X-Okapi-User-Id:
-      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains;
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
-            "module" : "KB_EBSCO",
-            "configName" : "api_credentials",
-            "code" : "kb.ebsco.credentials",
-            "description" : "EBSCO RM-API Credentials",
-            "enabled" : true,
-            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
-            "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
-              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
-              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
-            }
-          } ],
-          "totalRecords" : 1,
-          "resultInfo" : {
-            "totalRecords" : 1,
-            "facets" : [ ]
-          }
-        }
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:05:11 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 04 May 2018 05:05:13 GMT
-      X-Amzn-Requestid:
-      - ba09ca2b-4f58-11e8-b455-a37016e4f442
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GWGBbFURoAMFujA=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 05:05:12 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 adde0d65c765d838363d053879c9c938.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - kMzX67MNf45wJhdvNScFdl2TintMcxtSUcySJ2dOH13UGNi0JYq8Jg==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":70,"packagesSelected":70,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:05:13 GMT
-- request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/
     body:
@@ -471,4 +259,216 @@ http_interactions:
         DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"Unknown","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
   recorded_at: Fri, 04 May 2018 05:05:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '172'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 30 May 2018 11:43:41 GMT
+      X-Amzn-Requestid:
+      - b341ff67-63fe-11e8-ba42-7dbe2a61915a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HssxHF_-oAMF5Sw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:43:41 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 69871091d5ae923909dc2904245b7354.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - V4j3fUNh7C1oZdLW80-kjb9ZzMkZAk0jBfEO5JRvw19Lir0g5xeTwA==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":112,"packagesSelected":112,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:41 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 30 May 2018 11:43:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 837us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 41838us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 873559/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:46 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '172'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 30 May 2018 11:43:46 GMT
+      X-Amzn-Requestid:
+      - b655f6b7-63fe-11e8-9943-a511f2a63a4f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hssx6Gm4oAMFelw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:43:46 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 fcd9aaae3f7bd20d13dd07c7cf616378.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bX-Clx3WvyNX7rSMHLcuWVxq8ikhXJBu3GXQJxWJt5_SwKJsx-siQQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":112,"packagesSelected":112,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-package-taken-name.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-package-taken-name.yml
@@ -1,166 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.13.5
-      Date:
-      - Fri, 04 May 2018 05:05:54 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 358412us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42160us'
-      Host:
-      - okapi.frontside.io
-      X-Real-Ip:
-      - 10.36.4.1
-      X-Forwarded-For:
-      - 10.36.4.1
-      X-Forwarded-Host:
-      - okapi.frontside.io
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      X-Scheme:
-      - https
-      X-Auth-Request-Redirect:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-      X-Okapi-Request-Id:
-      - 539905/configurations
-      X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
-      X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
-      X-Okapi-User-Id:
-      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains;
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
-            "module" : "KB_EBSCO",
-            "configName" : "api_credentials",
-            "code" : "kb.ebsco.credentials",
-            "description" : "EBSCO RM-API Credentials",
-            "enabled" : true,
-            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
-            "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
-              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
-              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
-            }
-          } ],
-          "totalRecords" : 1,
-          "resultInfo" : {
-            "totalRecords" : 1,
-            "facets" : [ ]
-          }
-        }
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:05:54 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 04 May 2018 05:05:57 GMT
-      X-Amzn-Requestid:
-      - d420418a-4f58-11e8-aa61-9de1c6bb24a7
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GWGIRGR4IAMFw4A=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 05:05:57 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 663b9ec2cd0b34391786d62f92365deb.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - uUfOWlxkiSN4p89wP2A54gRcCdGqQtQquPQZj74dFwqFhrnGnQyO4Q==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":71,"packagesSelected":71,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:05:57 GMT
-- request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/
     body:
@@ -212,4 +52,164 @@ http_interactions:
         the provided name already exists"}]}'
     http_version: 
   recorded_at: Fri, 04 May 2018 05:05:57 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 30 May 2018 11:43:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1385us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42672us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 585956/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:36 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '172'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 30 May 2018 11:43:36 GMT
+      X-Amzn-Requestid:
+      - b04ed750-63fe-11e8-98ba-d18830dd2dc0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsswVGStoAMFzkA=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:43:36 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 94fb69b274bb5ab206667cb69fcc5932.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - UjtRzpBT3qHh4j4bkVDshmoucRZTFeV0HTdCHnF9oEU4WK8RcABQoA==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":112,"packagesSelected":112,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/post-custom-package.yml
+++ b/spec/fixtures/vcr_cassettes/post-custom-package.yml
@@ -209,218 +209,6 @@ http_interactions:
     http_version: 
   recorded_at: Fri, 04 May 2018 04:57:44 GMT
 - request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 04 May 2018 04:57:44 GMT
-      X-Amzn-Requestid:
-      - aed42deb-4f57-11e8-9b1a-2f30719f98e3
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GWE7YGDUIAMFrTQ=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 04:57:44 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 3da3508da5df5956549a94ec250a7674.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - WunyUvyRbULAnslqarqfwMgBuvMib8ZD3ruD-wcvpw3JuNN9WqsSmw==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":68,"packagesSelected":68,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 04:57:44 GMT
-- request:
-    method: get
-    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.13.5
-      Date:
-      - Fri, 04 May 2018 05:07:39 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 353703us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41850us'
-      Host:
-      - okapi.frontside.io
-      X-Real-Ip:
-      - 10.128.0.4
-      X-Forwarded-For:
-      - 10.128.0.4
-      X-Forwarded-Host:
-      - okapi.frontside.io
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      X-Scheme:
-      - https
-      X-Auth-Request-Redirect:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-      X-Okapi-Request-Id:
-      - 252441/configurations
-      X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
-      X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
-      X-Okapi-User-Id:
-      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains;
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
-            "module" : "KB_EBSCO",
-            "configName" : "api_credentials",
-            "code" : "kb.ebsco.credentials",
-            "description" : "EBSCO RM-API Credentials",
-            "enabled" : true,
-            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
-            "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
-              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
-              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
-            }
-          } ],
-          "totalRecords" : 1,
-          "resultInfo" : {
-            "totalRecords" : 1,
-            "facets" : [ ]
-          }
-        }
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:07:39 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '170'
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 04 May 2018 05:07:41 GMT
-      X-Amzn-Requestid:
-      - 121e01fb-4f59-11e8-ab4b-4554eb2e5cc1
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GWGYhHxIIAMFn2w=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 05:07:41 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 a171e7841621158d2aaef33e456c3688.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - ADzd00kDQweKYjsZ3fR36xelax9cMTTNXsRD5g3jtTWfuDo0l_R5Cw==
-    body:
-      encoding: UTF-8
-      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
-        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":71,"packagesSelected":71,"vendorToken":null}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 05:07:41 GMT
-- request:
     method: post
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/
     body:
@@ -524,4 +312,216 @@ http_interactions:
         DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"EBook","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
   recorded_at: Fri, 04 May 2018 05:07:41 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '172'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 30 May 2018 11:43:28 GMT
+      X-Amzn-Requestid:
+      - ab71924c-63fe-11e8-8226-47a90eac3efc
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HssvDFpWoAMFlSg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:43:28 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CTzPOCD7apJfx3mZDOwH4fVXoD7S7BuOqt491dR6tOwF05Oo0GfRMw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":112,"packagesSelected":112,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:28 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 30 May 2018 11:43:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1139us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42130us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 470627/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:32 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=25&offset=1&orderby=relevance&search=TEST_CUSTOMER_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '172'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 30 May 2018 11:43:32 GMT
+      X-Amzn-Requestid:
+      - adff1b35-63fe-11e8-9a61-856efbe58c87
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HssvuHcFIAMFe6w=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:43:32 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a86da8347e06cd1a49dfa25142e0bbf8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - TC3ZuOIzQbjrhcyv0j1Z6nnKvIyRpAIVyQEO9J0vauSyf_2yaagsMw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":1,"vendors":[{"vendorId":123355,"vendorName":"API DEV
+        CORPORATE CUSTOMER","isCustomer":true,"packagesTotal":112,"packagesSelected":112,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:43:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-package-content-type.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-content-type.yml
@@ -1,173 +1,12 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.13.5
-      Date:
-      - Fri, 04 May 2018 04:04:16 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 354032us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42727us'
-      Host:
-      - okapi.frontside.io
-      X-Real-Ip:
-      - 10.128.0.3
-      X-Forwarded-For:
-      - 10.128.0.3
-      X-Forwarded-Host:
-      - okapi.frontside.io
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      X-Scheme:
-      - https
-      X-Auth-Request-Redirect:
-      - "/configurations/entries?query=module=KB_EBSCO"
-      Accept:
-      - application/json
-      X-Okapi-Tenant:
-      - fs
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-      X-Okapi-Request-Id:
-      - 213898/configurations
-      X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
-      X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
-      X-Okapi-User-Id:
-      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
-      X-Okapi-Token:
-      - TEST_OKAPI_TOKEN
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains;
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
-            "module" : "KB_EBSCO",
-            "configName" : "api_credentials",
-            "code" : "kb.ebsco.credentials",
-            "description" : "EBSCO RM-API Credentials",
-            "enabled" : true,
-            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
-            "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
-              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
-              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
-            }
-          } ],
-          "totalRecords" : 1,
-          "resultInfo" : {
-            "totalRecords" : 1,
-            "facets" : [ ]
-          }
-        }
-    http_version: 
-  recorded_at: Fri, 04 May 2018 04:04:16 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '487'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 04:04:19 GMT
-      X-Amzn-Requestid:
-      - 387b428a-4f50-11e8-838f-8d8d54eb6583
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GV9GmGn9IAMFqNw=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 04:04:19 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 557f58686e107bfa2925cf3d6a17c717.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - rzySZaTLe8NP6BX4zRg3DmilqegUcAF3uJ4LRmymHBlIYCIxocWn3Q==
-    body:
-      encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 04:04:19 GMT
-- request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
     body:
       encoding: UTF-8
-      string: '{"contentType":1,"isSelected":true,"allowEbscoToAddTitles":null,"packageName":"I
-        got a newer package name","isHidden":null}'
+      string: '{"contentType":1,"isSelected":true,"allowEbscoToAddTitles":null,"isHidden":null,"packageName":"I
+        got a newer package name"}'
     headers:
       X-Api-Key:
       - TEST_API_KEY
@@ -193,26 +32,26 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 04:04:26 GMT
+      - Wed, 30 May 2018 11:43:06 GMT
       X-Amzn-Requestid:
-      - 3c451bdd-4f50-11e8-b125-cb57f754b407
+      - 9e174c59-63fe-11e8-8f09-8339ee33bc9e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GV9HlFbOIAMFYuw=
+      - HssrjEpYIAMFdtg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 04:04:26 GMT
+      - Wed, 30 May 2018 11:43:05 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9137d054c423ede4794f3621c7d50adb.cloudfront.net (CloudFront)
+      - 1.1 3b1807627d3f1dc0cdeb157fc313627b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - YQQKNIjxi5NSi1pPCXy3h02ecvT8FRwG-GBLVXYX8HYB5ILPcCqaTA==
+      - QoHEfF7UVH7lSwB3afmRG1RgJR22k-V_ZAw5JzY-O16pmpegdRO40w==
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 04 May 2018 04:04:26 GMT
+  recorded_at: Wed, 30 May 2018 11:43:06 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -244,25 +83,393 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 04:04:26 GMT
+      - Wed, 30 May 2018 12:21:58 GMT
       X-Amzn-Requestid:
-      - 3c87ca28-4f50-11e8-b2a2-e10f288d0789
+      - 0c196e8e-6404-11e8-a967-0189c071981f
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GV9HqETeoAMF7uw=
+      - HsyX8FJwoAMFlvg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 04:04:26 GMT
+      - Wed, 30 May 2018 12:21:58 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 400a1d6d49b59bb68b7dc9d180a3fe2d.cloudfront.net (CloudFront)
+      - 1.1 d58537e312a32f11086af17e2a952efc.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - MXqtUnTIHcEvjt6N9mZ2wHnriPmMC71uEyEb515Mk9GOOHG79ejo9Q==
+      - Po0mKwiZPEluCqU9TFT2B1W8ZVaNXK_WcM0dmj-dxNsbVF8hMsfefQ==
     body:
       encoding: UTF-8
       string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
         DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 04:04:26 GMT
+  recorded_at: Wed, 30 May 2018 12:21:58 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 357248us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42252us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.3.1
+      X-Forwarded-For:
+      - 10.36.3.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 554238/configurations
+      X-Okapi-Url:
+      - http://10.39.242.98:80
+      X-Okapi-Permissions-Required:
+      - configuration.entries.collection.get
+      X-Okapi-Module-Permissions:
+      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Amzn-Requestid:
+      - 0eb304ed-6404-11e8-9082-090e2ecede3f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyYoE4aIAMF1Cw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 777c0716c0ef8010208c3559195306d7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - CjQNWTArJN6iAMy1lH9QNwo78qjIWC5aE9KP5tsQU9EMSuZUtZQTtg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Amzn-Requestid:
+      - 0edb2647-6404-11e8-8d19-abcc042561fb
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyYqG3roAMFc3Q=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b7a66b6616123855c5af2d7cdf2b099f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - UFWwTlFyADhYtwt6Jqb4Zn9dmjY7dnwXCBAkaqLbUmZ9BFeR_Zp8dQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Amzn-Requestid:
+      - 0ef8e7ab-6404-11e8-a566-7fd5edc13baf
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyYsH2cIAMFd4Q=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1bbfa275cce73ba7a423bc907239dedf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - QfHFljUiGtVLEGSAcqVZDbB33THmbhCip2uq81n0dBEd5i8aQ0aEIg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:22:03 GMT
+      X-Amzn-Requestid:
+      - 0f232c3a-6404-11e8-9362-7fa65e29983f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyYvFGeIAMFjsg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1e0c086b1361f8d4ae58a5db76efda36.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - MshLV8zguLBRubK18Pci63qlbq5qtVxwNNym6JSRTNUK25njQlniuA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:03 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:22:03 GMT
+      X-Amzn-Requestid:
+      - 0f3888ff-6404-11e8-994e-132b18db6005
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyYwEFAoAMFnKw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:22:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zkdvf4y4xFrfAEhsZ8zgGYdkIrCQMYucIk7p5lbzj5Z-LmMcpPCthw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:22:03 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:43:00 GMT
+      - Wed, 30 May 2018 13:02:19 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1377us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41244us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 963us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43869us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 154063/configurations
+      - 628229/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:00 GMT
+  recorded_at: Wed, 30 May 2018 13:02:19 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -135,38 +135,246 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '489'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:19 GMT
       X-Amzn-Requestid:
-      - dc853dd6-4f44-11e8-b251-37cf60a997c9
+      - afa48d2f-6409-11e8-8b9a-0ff863793478
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMSF5SoAMF7tQ=
+      - Hs4SXHatIAMFdvA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:19 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 bfa784781409d5c8401392394480e61c.cloudfront.net (CloudFront)
+      - 1.1 66114286e54efb82c700272100713f2f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - NV_M0-CwLXsm4BbL3vNfcGb0zbLduJOj2rdYZIQKK_cJtkWn_WyH0Q==
+      - S3WXAK6mkQMDIfjSrTzU8pfJOvxfJhqVMBpyxqMeFbE4MYRrvS1rFQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:01 GMT
+  recorded_at: Wed, 30 May 2018 13:02:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '489'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Amzn-Requestid:
+      - afbef300-6409-11e8-b32e-4717013ebf24
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4SYG3MIAMFpcg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:02:19 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9fbe771abcabdb4e14e7709f1f3c6e94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ALvmpku04xz_0piS-CEQ54P1GL78LINfwA5GE4-jG3e8h-BEhqF2pg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:02:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '489'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Amzn-Requestid:
+      - afde88d7-6409-11e8-8829-8933f219a121
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4SaGVsoAMFY0A=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ebfea1c8ef298b6d415684e80825a277.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - IyJ4mGMq6L6nbIR8KyY6EYyjZhBcKsvArDeFvNbPPn8iWVZy0-mtfQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:02:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '489'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Amzn-Requestid:
+      - b001051c-6409-11e8-938e-3dc7a0a826cf
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4SdH6MoAMF3Cw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 30aeb6ef25a393db74fabfc78bbd79e3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dL9brzFPrmh_4bh-dwn8dmXzM_--McSUNyIMvq5Vwef7HJpXGrHl7A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:02:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '489'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Amzn-Requestid:
+      - b0257c32-6409-11e8-9c55-0f044c925243
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4SfGneIAMF5Iw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:02:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b78bfeca7339074512b7289497872df2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - UcEaMCbZs8NCPoi8zz7QlTBJG_klXu57phjp3oSrf2qw6JvKk5SnDg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:02:20 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":null,"packageName":null,"isHidden":null}'
+      string: '{"contentType":1,"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":null,"isHidden":null,"packageName":"name
+        of the ages forever and ever"}'
     headers:
       X-Api-Key:
       - TEST_API_KEY
@@ -182,37 +390,36 @@ http_interactions:
       - http.rb/3.3.0
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 204
+      message: No Content
     headers:
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json
       Content-Length:
-      - '84'
+      - '0'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:21 GMT
       X-Amzn-Requestid:
-      - dc9f06de-4f44-11e8-838f-8d8d54eb6583
+      - b03fe2b4-6409-11e8-9db8-bd31a36bbebb
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMUECEIAMFqNw=
+      - Hs4ShEVxoAMF0gg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:20 GMT
       X-Cache:
-      - Error from cloudfront
+      - Miss from cloudfront
       Via:
-      - 1.1 7ea42c16b0af66858eb9302f2f610cd6.cloudfront.net (CloudFront)
+      - 1.1 215207bc7fb93e55e70ed5107d9c8949.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - LoXHrzdG0J7NP64F9qkAM3jwt2WcJ2F6J3cdeNdr4RyZVk_25ptaHA==
+      - J3H4AOrkFLiy2KafwdLrbOJI8mGnFLn-D7y7R2I1HqIisPl4OsvL_w==
     body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1001,"subCode":0,"message":"Attribute PackageName
-        is missing."}]}'
+      encoding: ASCII-8BIT
+      string: ''
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:01 GMT
+  recorded_at: Wed, 30 May 2018 13:02:21 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -240,30 +447,29 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '489'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:21 GMT
       X-Amzn-Requestid:
-      - dcb3ee32-4f44-11e8-9a7b-0fafb9e11f82
+      - b0614d60-6409-11e8-ad56-df98c5cb1e4c
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMVH-sIAMF7jQ=
+      - Hs4SjH4gIAMFdnw=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:01 GMT
+      - Wed, 30 May 2018 13:02:20 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9865fbd5c61131fde861cc79a5ba4ead.cloudfront.net (CloudFront)
+      - 1.1 d4cdd862c8bc0148f37b685614031cf5.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 0WfxQDMSauNl9QnVot4NvPfHVV_beGxVJ9z1ytAZqQXd564mz6x6iw==
+      - UT5tG9o_LFD4XlRDyBfS3N253dJQPIjDimdrOWoxdl_w0Hd_EuYWxw==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:01 GMT
+  recorded_at: Wed, 30 May 2018 13:02:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-package-name.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-name.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:59 GMT
+      - Wed, 30 May 2018 12:24:20 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 2225us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41385us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 358176us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43400us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 497221/configurations
+      - 735331/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:59 GMT
+  recorded_at: Wed, 30 May 2018 12:24:20 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -135,38 +135,246 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '462'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:59 GMT
+      - Wed, 30 May 2018 12:24:20 GMT
       X-Amzn-Requestid:
-      - db75c939-4f44-11e8-b7f7-516186a342a6
+      - 611801f7-6404-11e8-8e7a-ebd588bcb55b
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMBHMnIAMF62w=
+      - HsyuOGhIIAMFqJg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:58 GMT
+      - Wed, 30 May 2018 12:24:20 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 64fc1ccc427044d03aa5724d4825ec8f.cloudfront.net (CloudFront)
+      - 1.1 bc6981f82440e44448ee5dd3577bf4f4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 0uB84eXbWN2t9hKqPHqH1DMqCYWrPrUhw-TaEMfHRICZxBSeUJ9Uzg==
+      - idMG-DdqplUIZ-OjwqJX1da9_RTQ1TRGxqQrhcqdW9my64mws0STPQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:59 GMT
+  recorded_at: Wed, 30 May 2018 12:24:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:20 GMT
+      X-Amzn-Requestid:
+      - 613a56b1-6404-11e8-9c09-f7637f28c573
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyuQFsZoAMFbeg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d58537e312a32f11086af17e2a952efc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pWiKnL9xKdDGGDkIKHAWDoS4raQDVG7rV6MK57mENW7zVCjr15V31g==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:20 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:21 GMT
+      X-Amzn-Requestid:
+      - 61550a48-6404-11e8-b7ec-d31d3eb2ddb0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyuSFNKoAMF0hA=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NQhcWbRLtU5WY2_qIdHv5OxQ1JiidCHJzqLkBhmVCUN9-9myNWN4Cg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:21 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:21 GMT
+      X-Amzn-Requestid:
+      - 616f227c-6404-11e8-b234-c7c1c446cfc7
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyuUGGwIAMF_lw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 fcd9aaae3f7bd20d13dd07c7cf616378.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2Vm1xMa4p8U6yEzcO9aOf-cHCGOwjkxiqbWXy_0HnKjyZYO6u4qXag==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:21 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '462'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:21 GMT
+      X-Amzn-Requestid:
+      - 6189397a-6404-11e8-b9e1-c78cf8ec47f3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyuVETiIAMFlDg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:20 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 3JTsg8b0F9EGEsIwHU6quC8paclvunGFt2KFsSbEpiUQ0cCpLn5H4A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"I got a newer package name","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:21 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
     body:
       encoding: UTF-8
-      string: '{"allowEbscoToAddTitles":null,"packageName":"I got a new package name","isHidden":null}'
+      string: '{"contentType":1,"isSelected":true,"allowEbscoToAddTitles":null,"isHidden":null,"packageName":"name
+        of the ages forever and ever"}'
     headers:
       X-Api-Key:
       - TEST_API_KEY
@@ -182,37 +390,36 @@ http_interactions:
       - http.rb/3.3.0
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 204
+      message: No Content
     headers:
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json
       Content-Length:
-      - '83'
+      - '0'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:59 GMT
+      - Wed, 30 May 2018 12:24:21 GMT
       X-Amzn-Requestid:
-      - db89519f-4f44-11e8-93e4-73f3090fe1a7
+      - 61b3f3e7-6404-11e8-94ec-7163d09e0c2c
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMCHB4IAMFgzw=
+      - HsyuYECIoAMFYQQ=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:58 GMT
+      - Wed, 30 May 2018 12:24:21 GMT
       X-Cache:
-      - Error from cloudfront
+      - Miss from cloudfront
       Via:
-      - 1.1 4b69ba320c9cbd3f6090f3170cdcc531.cloudfront.net (CloudFront)
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - pPpw5e7RiB8fuIz_Wi2IgWDg_o4WZMB9MD6PFJovXrTb8G9eAjTpjQ==
+      - Km1FOpw3UEybMiSZ8L2OHnEdLMJy8W15imtfN6kXr9rzPGVZFaUZUw==
     body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1005,"subCode":0,"message":"Attribute IsSelected
-        is missing."}]}'
+      encoding: ASCII-8BIT
+      string: ''
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:59 GMT
+  recorded_at: Wed, 30 May 2018 12:24:21 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -240,30 +447,29 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '469'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:59 GMT
+      - Wed, 30 May 2018 12:24:22 GMT
       X-Amzn-Requestid:
-      - dbac1b5b-4f44-11e8-b0ff-530293b42801
+      - 61d64857-6404-11e8-9b21-eb8909013f8a
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxMEGKYoAMF19w=
+      - HsyuaE1XIAMFV-w=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:59 GMT
+      - Wed, 30 May 2018 12:24:21 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 6ddeb72bd0522678e37bacf079348a81.cloudfront.net (CloudFront)
+      - 1.1 215207bc7fb93e55e70ed5107d9c8949.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 3yCe37A0NNxMepDmEkLssh5zs3ZuQl_tEqBi6lXaUvKd8OrCc1KQxw==
+      - 7lKKla7vegtELo483gvB1c2-pfA4Wu0T58B_eL12oKcs5REAlx0lzA==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:59 GMT
+  recorded_at: Wed, 30 May 2018 12:24:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-package-visibility.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-visibility.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:43:11 GMT
+      - Wed, 30 May 2018 13:05:13 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1229us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41468us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 895us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42995us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.3.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.3.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - '098061/configurations'
+      - 437189/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:11 GMT
+  recorded_at: Wed, 30 May 2018 13:05:13 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -135,38 +135,251 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '486'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:11 GMT
+      - Wed, 30 May 2018 13:05:13 GMT
       X-Amzn-Requestid:
-      - e2f09ce0-4f44-11e8-8d62-a73384407920
+      - 1704a1ca-640a-11e8-b443-ffa194f9bef6
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxN-Hg2oAMFyZw=
+      - Hs4tdHWbIAMFgEg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:11 GMT
+      - Wed, 30 May 2018 13:05:12 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ac34121093afdc7c5e89263bece028e1.cloudfront.net (CloudFront)
+      - 1.1 94fb69b274bb5ab206667cb69fcc5932.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - DxMjxVirE45TW8aKMWhKttFjpKH10p4HZUNCaSZe9J_T8e9_i8DEOA==
+      - UHYPPDx_gdETg8Oqv7YYqHF7h5uBhCrQwFlDGK1ro2qYbTU2ej3HLA==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
         DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:11 GMT
+  recorded_at: Wed, 30 May 2018 13:05:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:05:13 GMT
+      X-Amzn-Requestid:
+      - 1728cb5e-640a-11e8-9699-2356e8e680b2
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4tfHtgoAMFjrA=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:05:12 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 71963481e8787829babadbbb735376ef.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dPN5HqsusgsgHQhWLGjX45i1r_KVwA4imhVDunbyfkrwEceJ3SN8FA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:05:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:05:13 GMT
+      X-Amzn-Requestid:
+      - 1748afc0-640a-11e8-a247-67ccbfaa5c16
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4thHlIIAMF7tQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:05:13 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a86da8347e06cd1a49dfa25142e0bbf8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PNcfUxmp13MP6mFHXRThcRpkjIWGC8C_P4UmkOYs_FFIriilQ3pJLg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:05:13 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:05:14 GMT
+      X-Amzn-Requestid:
+      - 1768457d-640a-11e8-9b3c-e9e6fe63a233
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4tjEJwoAMFtYw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:05:13 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ebfea1c8ef298b6d415684e80825a277.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zfzNPPkTZlVIw0vXS34WtZ3q77MW1EDf1zRSUvk44shVhGj3wxV0nQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:05:14 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 13:05:14 GMT
+      X-Amzn-Requestid:
+      - 178283ea-640a-11e8-8cf6-2b2668a3dda4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hs4tlEgVIAMFxLw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 13:05:13 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 215207bc7fb93e55e70ed5107d9c8949.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - s1HRqZcEpNfPq0Gr7r98b0Ya2lw_ojA3UfkP97vsxytusnk43aDQVA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 13:05:14 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"allowEbscoToAddTitles":null,"packageName":null,"isHidden":true}'
+      string: '{"contentType":1,"isSelected":true,"allowEbscoToAddTitles":null,"isHidden":true,"packageName":"name
+        of the ages forever and ever"}'
     headers:
       X-Api-Key:
       - TEST_API_KEY
@@ -182,37 +395,36 @@ http_interactions:
       - http.rb/3.3.0
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 204
+      message: No Content
     headers:
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json
       Content-Length:
-      - '84'
+      - '0'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:12 GMT
+      - Wed, 30 May 2018 13:05:14 GMT
       X-Amzn-Requestid:
-      - e3153b4e-4f44-11e8-9724-8bf2b243d420
+      - 179d5ea4-640a-11e8-a02c-45bf7cecdd08
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxOAFtqoAMF-fA=
+      - Hs4tnF4GoAMFoDw=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:11 GMT
+      - Wed, 30 May 2018 13:05:13 GMT
       X-Cache:
-      - Error from cloudfront
+      - Miss from cloudfront
       Via:
-      - 1.1 a1bc06b7f7932216e8d406a348288eac.cloudfront.net (CloudFront)
+      - 1.1 3b1807627d3f1dc0cdeb157fc313627b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - AxjJ8Kvs4TZRiZQoSPJc0sURlW4aCal1JM1mkGnmWox6Z4aS86jZ2Q==
+      - Ma-tL7r4t4F7GehNPIEFGiiUffenAqkL_2oW8hwIB1yZFOwJMHGeaw==
     body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1001,"subCode":0,"message":"Attribute PackageName
-        is missing."}]}'
+      encoding: ASCII-8BIT
+      string: ''
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:12 GMT
+  recorded_at: Wed, 30 May 2018 13:05:14 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
@@ -240,30 +452,30 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '487'
+      - '486'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:43:12 GMT
+      - Wed, 30 May 2018 13:05:14 GMT
       X-Amzn-Requestid:
-      - e33175d5-4f44-11e8-94d0-51541d963490
+      - 17c3d287-640a-11e8-a370-0d9fbc602204
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxOCFYToAMFq1w=
+      - Hs4tpH-VoAMF8dg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:43:12 GMT
+      - Wed, 30 May 2018 13:05:13 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9865fbd5c61131fde861cc79a5ba4ead.cloudfront.net (CloudFront)
+      - 1.1 d4cdd862c8bc0148f37b685614031cf5.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - lZv7bnBA9Gv0gn7ziiKwKRk2aH51IQLhyfBD05QEqXhMPpXK5wF52Q==
+      - hPiOjS7VNjTcdU4eT7lbkV7sOKgMUESbjaGj9M3RpLEhQ538X5LVRA==
     body:
       encoding: UTF-8
-      string: '{"packageId":2845506,"packageName":"I got a new package name","isCustom":true,"vendorId":123355,"vendorName":"API
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
         DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"EJournal","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:43:12 GMT
+  recorded_at: Wed, 30 May 2018 13:05:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-package-managed-content-type.yml
+++ b/spec/fixtures/vcr_cassettes/put-package-managed-content-type.yml
@@ -1,6 +1,58 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: UTF-8
+      string: '{"allowEbscoToAddTitles":null,"isHidden":null}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '83'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:42:46 GMT
+      X-Amzn-Requestid:
+      - 925336de-63fe-11e8-8829-8933f219a121
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HssoeEjVIAMFY0A=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:42:45 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 d671204b8bf6c2b9056c338588204020.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ixDi7k-0WgJfTud2TW9TLpgNmHIqJpCzAk7l3Y6P6SXvV5UHzU-lVg==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1005,"subCode":0,"message":"Attribute IsSelected
+        is missing."}]}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:42:46 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +79,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:57 GMT
+      - Wed, 30 May 2018 12:21:33 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +87,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1289us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41238us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 357439us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43185us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.3.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.3.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +118,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 683518/configurations
+      - 649671/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +138,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +146,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +159,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:57 GMT
+  recorded_at: Wed, 30 May 2018 12:21:33 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
@@ -135,83 +187,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '470'
+      - '474'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:57 GMT
+      - Wed, 30 May 2018 12:21:34 GMT
       X-Amzn-Requestid:
-      - da651c82-4f44-11e8-bb1a-c5588c0e58a8
+      - fdcbc72e-6403-11e8-b253-9d614a7f2c57
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxLvFdhoAMFU4A=
+      - HsyUMGqsIAMFeqA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:57 GMT
+      - Wed, 30 May 2018 12:21:34 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 655ceee114a61672fa30ade2501aa4b4.cloudfront.net (CloudFront)
+      - 1.1 27f5831be5a9ad411fca9c84fe627bdc.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fPrhW_D_i8fX9Gz0WfJCHraNQVt0-0GSDbai_jtVAvvOSEs8ddgPyQ==
+      - SHbmmn-ivwGEi_oHiM4enK425RzsLF90_s-K_VpfjS4D5Dp0rEOV1A==
     body:
       encoding: UTF-8
       string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
-        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:57 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
-    body:
-      encoding: UTF-8
-      string: '{"allowEbscoToAddTitles":null,"packageName":null,"isHidden":null}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '83'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:57 GMT
-      X-Amzn-Requestid:
-      - da8946d5-4f44-11e8-b4b0-b3be4fccf6f8
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxLxHpLIAMFvIQ=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:57 GMT
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 b7c3cbb5c341d39495b423af981f2a5d.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - C1BCEOvb8H4b1z6tAY_YmvTBAOnJ7X1lIxOv1tePy2Kmvc6AGTeW6A==
-    body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1005,"subCode":0,"message":"Attribute IsSelected
-        is missing."}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:57 GMT
+  recorded_at: Wed, 30 May 2018 12:21:34 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
@@ -239,29 +239,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '470'
+      - '474'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:58 GMT
+      - Wed, 30 May 2018 12:21:34 GMT
       X-Amzn-Requestid:
-      - daa9c6d4-4f44-11e8-bfed-1f4545017c61
+      - fde913a0-6403-11e8-ba7a-e362130f7f35
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxLzHCcIAMFjeg=
+      - HsyUOGhnIAMFmwA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:57 GMT
+      - Wed, 30 May 2018 12:21:34 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 89dbe128b639cdc1367dfadc360947d0.cloudfront.net (CloudFront)
+      - 1.1 d4cdd862c8bc0148f37b685614031cf5.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - k03asHn-8X_EeL_kYEIWBrrJfLOhiqgigBk84DzN95jt7p2faJPxgA==
+      - IcKLW0YRfSgi4yHr7u6GzAiOWkKUh6RME2oREiehM475Cb-RT-8Prw==
     body:
       encoding: UTF-8
       string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
-        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:58 GMT
+  recorded_at: Wed, 30 May 2018 12:21:34 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '474'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:21:34 GMT
+      X-Amzn-Requestid:
+      - fe0bde11-6403-11e8-a332-1531d4889209
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyUQE6aoAMFiMg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:21:34 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a86da8347e06cd1a49dfa25142e0bbf8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5tdT4qIPBBZLgOu2zGyd4giDW873Gu_TMeR5eMTZa1a6cgEp5iv-qA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:21:34 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/75/packages/2686
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '474'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:21:34 GMT
+      X-Amzn-Requestid:
+      - fe2c84a3-6403-11e8-bebd-39d10a7f6c6b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyUSF5HIAMFr_g=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:21:34 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6e24e95f882f20707346a032d1fa2949.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - C4eE87zhND7kiTELPwlqPhqYZKELWFeC2tZ2l97z90SZpz-Hv4YKCA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2686,"packageName":"Aerospace & High Technology Database","isCustom":false,"vendorId":75,"vendorName":"Cambridge
+        Scientific Abstracts","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:21:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-add-customcoverage.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:06:54 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1199us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41563us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 353681us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43137us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.3.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.3.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 741420/configurations
+      - 256474/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:25 GMT
+  recorded_at: Wed, 30 May 2018 11:06:54 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,28 +135,79 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '455'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:06:54 GMT
       X-Amzn-Requestid:
-      - c72374f1-4f44-11e8-aac3-cb1199787e8c
+      - 8fd61acc-63f9-11e8-9d17-5b80160087af
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxGsHE3oAMFdJw=
+      - HsnYREqCoAMFW6w=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:24 GMT
+      - Wed, 30 May 2018 11:06:54 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 e90303ba6db45a2785ea8e963e1ef010.cloudfront.net (CloudFront)
+      - 1.1 52be75510d37db554486d5736b47f348.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 03Tnln70BfIxfsTklb74WCiU-QVuPtby9tyulk9_uZ1l1PIsrDAijQ==
+      - 9qKdx9O8YkKXqg34RMr8ccSrot-4nIMXx38kYNDNbNDtTIcbgifUqg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:25 GMT
+  recorded_at: Wed, 30 May 2018 11:06:54 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '455'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:06:54 GMT
+      X-Amzn-Requestid:
+      - 9003bb03-63f9-11e8-9c09-f7637f28c573
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsnYUG5roAMFbeg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:06:54 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 69871091d5ae923909dc2904245b7354.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9vPPH0ReU3e7E0dngrM3mIu_AD8lj2HTkCu-WFlqTvjG0zu-fCF3-A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:06:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-allow-add-titles.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-allow-add-titles.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:08:07 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1540us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 43426us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 355699us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 41544us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.36.3.1
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.36.3.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 157932/configurations
+      - 647909/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:25 GMT
+  recorded_at: Wed, 30 May 2018 11:08:07 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,28 +135,81 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '473'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:08:07 GMT
       X-Amzn-Requestid:
-      - c76fe6e9-4f44-11e8-92d8-172d7899b621
+      - bb7391c8-63f9-11e8-91ea-0d2aa529bd57
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxGxGM5oAMFg9Q=
+      - HsnjtGVoIAMFhVA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:08:07 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 655ceee114a61672fa30ade2501aa4b4.cloudfront.net (CloudFront)
+      - 1.1 caeaab1dec28e8247466740025a521a6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - UIf7czjDqo2RAg0JfSSGhoyXf07l5VI759EtyfJlv6kfTlfP3_5Quw==
+      - zvuA_BFtxINiHYB4COwdNozp-mF2qb75ZeqvP6mnIluAkAs8TtPHwQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:25 GMT
+  recorded_at: Wed, 30 May 2018 11:08:07 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '473'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:08:08 GMT
+      X-Amzn-Requestid:
+      - bb954b17-63f9-11e8-84cf-f1cb7fa813e0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsnjvEMNoAMFZxA=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:08:07 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e000b4829c397da077a65028075a32a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - VBRJF2-8xVNZA60AZ_Lwz2myzI13FpbOV3ZzvzPhuuJMzm9zeSWOvw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:08:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-combined-update.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:26 GMT
+      - Wed, 30 May 2018 11:08:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1467us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41699us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1708us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42642us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 118296/configurations
+      - 295416/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:26 GMT
+  recorded_at: Wed, 30 May 2018 11:08:08 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,28 +135,81 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '473'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:26 GMT
+      - Wed, 30 May 2018 11:08:08 GMT
       X-Amzn-Requestid:
-      - c7d5fba7-4f44-11e8-bfed-1f4545017c61
+      - bbe6edcb-63f9-11e8-8d92-e93ac86b9ceb
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxG3GN_oAMFjeg=
+      - Hsnj1GiCoAMFpsA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:25 GMT
+      - Wed, 30 May 2018 11:08:07 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 64fc1ccc427044d03aa5724d4825ec8f.cloudfront.net (CloudFront)
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - _kZAR4sZY3UnikfRvHaUhNp_UKz7WWfZ57hiMZAiThUDICV1mPQhRQ==
+      - t1iMB5LE74VEZN4YZY4RWhLWcJZ7paMlfW3QoR04HekjnRWqgvtLHQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:26 GMT
+  recorded_at: Wed, 30 May 2018 11:08:08 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '473'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:08:08 GMT
+      X-Amzn-Requestid:
+      - bc0d3a21-63f9-11e8-b6d5-079df7fd98d8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hsnj3GvjIAMF4wg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:08:08 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 30aeb6ef25a393db74fabfc78bbd79e3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - pTxEdKoRMuPBDUhk1MWOds540QtTDiqNc3NUdCd1ZhC8Ub0_xZpdUg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:08:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-ishidden.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:24 GMT
+      - Wed, 30 May 2018 11:05:57 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1258us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41174us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 355063us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42517us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 295636/configurations
+      - 122129/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:24 GMT
+  recorded_at: Wed, 30 May 2018 11:05:57 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,28 +135,79 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '455'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:24 GMT
+      - Wed, 30 May 2018 11:05:57 GMT
       X-Amzn-Requestid:
-      - c6dcf5b9-4f44-11e8-8c29-530af0929a6d
+      - 6de85843-63f9-11e8-b95b-4b134c90b101
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxGnGT8oAMFTqQ=
+      - HsnPYHxRoAMF5bQ=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:24 GMT
+      - Wed, 30 May 2018 11:05:57 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 2ee0fe9a0480e5e9a23a7364903f489e.cloudfront.net (CloudFront)
+      - 1.1 6e24e95f882f20707346a032d1fa2949.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KY7m3FGxflpxWZuWqZRxOrh4QvCHvSMy_WK40R5YCa08dQZCSnVKzQ==
+      - HZbLlG5OHwRUGpHiDmyzIKwapz_5mNvOrS9RXX0yBETMaxvaNI5yug==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:24 GMT
+  recorded_at: Wed, 30 May 2018 11:05:57 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '455'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:05:57 GMT
+      X-Amzn-Requestid:
+      - 6e0b49b3-63f9-11e8-b60e-85302ad54840
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsnPbHL6oAMFw9Q=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:05:57 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a1b9c0f574e30dae7536945f59627868.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Fg1RE-QJCdlnO6Bk3g4U01Du6toYPUkYZ7hRAjvAdud6zXYvX5VMcA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:05:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isnotselected-toggle-isselected.yml
@@ -1,6 +1,109 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":true,"isHidden":false}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:08:11 GMT
+      X-Amzn-Requestid:
+      - bdc6aa6b-63f9-11e8-acbf-43722e86eeb0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsnkUFixoAMFTiQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:08:11 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bdfe34c94134f86b07ebb7714d12d095.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - cH7Dq-OoUs7OBCDaBDhzdxFOOJ_E1Zfkt5_eL9jN5ZDV-FGokcOMAA==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:08:11 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:19:57 GMT
+      X-Amzn-Requestid:
+      - c3e9349e-6403-11e8-95de-f102a83d08b3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyFBHRtIAMFT_A=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:19:56 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c62f6c9a9fdf2356a904a1b156a05fe1.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - am8Fs3g_xxBuUKQFHKp8zDOf4ShWBJkVcaZ9OSgCbbWn_W-nGLB0Bg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:19:57 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +130,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:27 GMT
+      - Wed, 30 May 2018 12:20:01 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +138,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1307us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41678us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 960us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42630us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,9 +169,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 109258/configurations
+      - 235332/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +189,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +197,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +210,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:27 GMT
+  recorded_at: Wed, 30 May 2018 12:20:01 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,81 +238,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:27 GMT
+      - Wed, 30 May 2018 12:20:01 GMT
       X-Amzn-Requestid:
-      - c8abc1c5-4f44-11e8-b640-539f3c936c17
+      - c6baf1e3-6403-11e8-b218-6377737edd18
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxHFFZFIAMFcXg=
+      - HsyFwHK0IAMFn9A=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:26 GMT
+      - Wed, 30 May 2018 12:20:01 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b4b2849aaf2c14969531f9514611da28.cloudfront.net (CloudFront)
+      - 1.1 9b6576d35a1a9eda48ee30caf8cac918.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - nQ7vFZih8zs0BO5scDjPh3-cl0SPZkPQlDgRHq5GdVTWhBuzNkCPCA==
+      - _NYKnDsAi3Zkmt4JrBgsk48p0SJ6RT5giIHZNZozbL02-B0ple-kLg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:27 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":true,"packageName":null,"isHidden":false}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:28 GMT
-      X-Amzn-Requestid:
-      - c8c8235b-4f44-11e8-81aa-d3b69c24c6e5
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxHHFZyoAMFS_w=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:28 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 d644e7f3f959c262b5d8dffe5d3078b8.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - E9IJhG5UfEqh7ZPbNUpbpUJ89I0DxJbrrkR5F1wQn4O2G1u_jeH5_A==
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:28 GMT
+  recorded_at: Wed, 30 May 2018 12:20:01 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -237,28 +290,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:28 GMT
+      - Wed, 30 May 2018 12:20:01 GMT
       X-Amzn-Requestid:
-      - c8e26283-4f44-11e8-b6d5-a31628edc062
+      - c6de58af-6403-11e8-9b55-0922d0d2d888
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxHJHG4IAMF-Bg=
+      - HsyFyEZUIAMFRSA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:28 GMT
+      - Wed, 30 May 2018 12:20:01 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f9fbbda041fd5d6cd566e39ed217c7d1.cloudfront.net (CloudFront)
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - ITuoysyRlRx0JW0wr-LJVV6YrT8ZbcrrKnbT2wP5EIDmZjm1n7DmXQ==
+      - TbLXt93-Kr5WsvBzCHJ4qK68b0G1f2tZ6duYwyblhTVJ19LUm9L9Aw==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:28 GMT
+  recorded_at: Wed, 30 May 2018 12:20:01 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:02 GMT
+      X-Amzn-Requestid:
+      - c6f9d041-6403-11e8-a76b-395622acbac9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyF0G-FIAMF6Yg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:01 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DMbhQVpPqO-_0RO-TFDjzQKW14jPVpVgAYaIuWLu1qEpu7-geMPaeQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:02 GMT
+      X-Amzn-Requestid:
+      - c7151fe5-6403-11e8-a566-7fd5edc13baf
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyF2E9uoAMFd4Q=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:01 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0b202e2428f14940b06527255fa020ea.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6cOFHiVLSvHZTJ6EfIDxXr9SHxxwxnEm6_QAc7J2FA3dEyVVSOWR9w==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-add-customcoverage.yml
@@ -1,6 +1,109 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":null,"isHidden":false}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:46:44 GMT
+      X-Amzn-Requestid:
+      - 200db6ce-63ff-11e8-bba7-d9bd38da770a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HstNoFnYIAMFw9w=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:46:44 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 69871091d5ae923909dc2904245b7354.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kBZmPDZsHuFeMEcQC6XYtp7ae2K_Y9tBsmpL5D3ccVi1e4tWY8Hi9Q==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:46:44 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:42 GMT
+      X-Amzn-Requestid:
+      - ded2b414-6403-11e8-8ec6-fd9237b5ffa6
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyMEHKjIAMFcjQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:41 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 777c0716c0ef8010208c3559195306d7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-Yu5GthWLX3s_z4OVLmffThbO6sqV3tgprKxeRAmGSYrQFDTvc5-LA=="
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:42 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +130,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:36 GMT
+      - Wed, 30 May 2018 12:20:45 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +138,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1463us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41558us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1309us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43105us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.3.1
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.36.3.1
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +169,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 509896/configurations
+      - 446552/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +189,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +197,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +210,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:36 GMT
+  recorded_at: Wed, 30 May 2018 12:20:45 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,81 +238,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '472'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:36 GMT
+      - Wed, 30 May 2018 12:20:46 GMT
       X-Amzn-Requestid:
-      - cde382d3-4f44-11e8-9c25-5773313f0309
+      - e12814ec-6403-11e8-a566-7fd5edc13baf
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxIdFUEIAMF0vg=
+      - HsyMrHckIAMFd4Q=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:36 GMT
+      - Wed, 30 May 2018 12:20:46 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9865fbd5c61131fde861cc79a5ba4ead.cloudfront.net (CloudFront)
+      - 1.1 4a93be6e6adaadeec2a72967f0720081.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - ziOjy7qH-wDcL4ivKDpHc08TXABZaQBAKZwuCMjEH5d9U4gnEgtH6w==
+      - L8RC74JD1FWOSYJWB88GcJlxhzbw8zCeeixV_rj-ZvaoAWm-uW4Wyw==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:36 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":null,"packageName":null,"isHidden":false}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 500
-      message: Internal Server Error
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '72'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:36 GMT
-      X-Amzn-Requestid:
-      - ce03b58e-4f44-11e8-bf00-2fad7a065eb6
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxIfHw4oAMFzJQ=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:36 GMT
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 5d4055ddd4ab6dc339d40953c6e99219.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - cJedpfX9mWKdYABiD-Ri_4mU9Xi9RpleWwOwgRQ6heyoojC4L9hNoQ==
-    body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1000,"subCode":0,"message":"Internal Server Error"}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:36 GMT
+  recorded_at: Wed, 30 May 2018 12:20:46 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -237,28 +290,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '472'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:37 GMT
+      - Wed, 30 May 2018 12:20:46 GMT
       X-Amzn-Requestid:
-      - ce23728e-4f44-11e8-aa92-7f364a773251
+      - e151bd65-6403-11e8-8dda-a1b3bf330472
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxIhEdvoAMF51A=
+      - HsyMuHZAIAMFh9Q=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:36 GMT
+      - Wed, 30 May 2018 12:20:46 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 829eee129e6b5002d6c1a37f04888da1.cloudfront.net (CloudFront)
+      - 1.1 66114286e54efb82c700272100713f2f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - QlQ6e-nmKfjN_8GvomtvnT7zfzXqgC406Hg70Gm26ZP59ixv7rLuug==
+      - FEFaDNvLRm5V5id4QqW_qYIg55-QhfmV3TdxBe664e1hkH--FeClPA==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:37 GMT
+  recorded_at: Wed, 30 May 2018 12:20:46 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:46 GMT
+      X-Amzn-Requestid:
+      - e17c0208-6403-11e8-a967-0189c071981f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyMxFDsoAMFlvg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:46 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c7f2e710eb5e4c599a030513a5a7ed22.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eNqbEzrDAI11OuUJ1zfn9PXNUd_AKDek0g3MOAegreWd1k3rsoNhGA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:46 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:46 GMT
+      X-Amzn-Requestid:
+      - e1983c05-6403-11e8-b616-a13fa8ec5a85
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyMzFRDoAMFVSQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:46 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1bbfa275cce73ba7a423bc907239dedf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-AWGX-PAWYVJzkaDtbg0PHt4BiAaqVeaczYiVJjq9xQApnbY787SWQ=="
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-combined-update.yml
@@ -1,6 +1,109 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":true,"isHidden":true}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:46:49 GMT
+      X-Amzn-Requestid:
+      - 2308a6e4-63ff-11e8-8dd1-8be85f43fa4c
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HstOaGydoAMFSVw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:46:48 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4a93be6e6adaadeec2a72967f0720081.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - cxJja-v99gAQJBd3fMSht9f3QBYpAFcCZucX79RWgOnnlQ7rxVCY4Q==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:46:49 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:21:07 GMT
+      X-Amzn-Requestid:
+      - edb5bc61-6403-11e8-9c6d-7b48b88eff87
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyP-GxAIAMF1ew=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:21:06 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bKQTMbgFDiNT7BqHn252qIu5Qe2SGdtQ8SCk8mCZt1ZxjEadw1DpSA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:21:07 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +130,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:44 GMT
+      - Wed, 30 May 2018 12:21:11 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +138,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 969us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42340us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 862us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42312us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,9 +169,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 789253/configurations
+      - 255728/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +189,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +197,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +210,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:44 GMT
+  recorded_at: Wed, 30 May 2018 12:21:11 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,82 +238,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '488'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:45 GMT
+      - Wed, 30 May 2018 12:21:11 GMT
       X-Amzn-Requestid:
-      - d32e0940-4f44-11e8-8d18-5b07aa2e0dc3
+      - f0582cc2-6403-11e8-9b53-57d240726743
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxJ2GwKIAMFgrA=
+      - HsyQqGNiIAMFmUg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:45 GMT
+      - Wed, 30 May 2018 12:21:11 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 1d43f56d3213a63608863fd0e49585b9.cloudfront.net (CloudFront)
+      - 1.1 69871091d5ae923909dc2904245b7354.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - s1WBtR9hxRyUo2jRbTfDDK2kYDSxhvjb9VC-YyOyvzLC0itMVCmCzQ==
+      - FhPHvcNmqDhhOsgRDtQmpj7bqFE_5AZ0FdHldz7PMaK9qWhmq8NZPA==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:45 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"allowEbscoToAddTitles":true,"packageName":null,"isHidden":true}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 500
-      message: Internal Server Error
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '72'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:46 GMT
-      X-Amzn-Requestid:
-      - d3c14822-4f44-11e8-81e7-03858a289d8a
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxJ_HltoAMF8dg=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:46 GMT
-      X-Cache:
-      - Error from cloudfront
-      Via:
-      - 1.1 7ea42c16b0af66858eb9302f2f610cd6.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - waJ1YrSLtjW2UMJHMaHFpZF1yVZODWJ5rZW5Ay7DtFbeu2oAHovtxA==
-    body:
-      encoding: UTF-8
-      string: '{"errors":[{"code":1000,"subCode":0,"message":"Internal Server Error"}]}'
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:46 GMT
+  recorded_at: Wed, 30 May 2018 12:21:11 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -238,29 +290,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '488'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:47 GMT
+      - Wed, 30 May 2018 12:21:11 GMT
       X-Amzn-Requestid:
-      - d41f4719-4f44-11e8-92b8-5331a93fb7b5
+      - f07a81c9-6403-11e8-bf02-633873ed6c2e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxKFHKxIAMFdkQ=
+      - HsyQtGLaIAMFrTQ=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:46 GMT
+      - Wed, 30 May 2018 12:21:11 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 20710af5b67bb4f49570084055f06277.cloudfront.net (CloudFront)
+      - 1.1 66114286e54efb82c700272100713f2f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - irCFzBXkNkz4FFx8xCcfV-XE3lgMzUfcylRZhOylusVNTDQqMEbdZw==
+      - SmdVozR2MarrQcTC_Gqt_VgI_3f2syBeh73eZrngLwFE5JVBevOUvg==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:47 GMT
+  recorded_at: Wed, 30 May 2018 12:21:11 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:21:11 GMT
+      X-Amzn-Requestid:
+      - f0944c04-6403-11e8-9362-7fa65e29983f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyQuGLcoAMFjsg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:21:11 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bc6981f82440e44448ee5dd3577bf4f4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - whWxEnPUsYR-owpOQI6NyvD4P5vArd-R5SvzkJl_LZ94PS809yblkQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:21:11 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:21:12 GMT
+      X-Amzn-Requestid:
+      - f0ae8a9a-6403-11e8-b99b-df48ed254b40
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyQwFpjoAMFjVg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:21:11 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 27f5831be5a9ad411fca9c84fe627bdc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6ICNNm30wb28aITBmZB45437oZmGrk9R-Y5255Cdr7w6O06GcNV0eA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:21:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-add-titles.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-add-titles.yml
@@ -1,6 +1,109 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":true,"isHidden":true}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:41:32 GMT
+      X-Amzn-Requestid:
+      - 6644ae59-63fe-11e8-9367-b7810295292c
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Hssc7GA4oAMFUlQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:41:31 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e000b4829c397da077a65028075a32a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - vto6cObjqrX_pdZuBDdk4vZm7-u_Rhp29g4TMR4Bki7fiB-nMhPN7g==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:41:32 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:27 GMT
+      X-Amzn-Requestid:
+      - d64ed4a1-6403-11e8-9886-a98a90fa816d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyJ1G7mIAMFYPg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6d15137ec23376f4c8a22e6edb289bd.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eM-zwMCVVpfF_5OI9QqxvqUUgqHlRdz4vLaS8U82gxxSMB_GurYShg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:27 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +130,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:33 GMT
+      - Wed, 30 May 2018 12:20:31 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +138,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1928us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41954us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1403us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 43104us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +169,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 908854/configurations
+      - 900829/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +189,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +197,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +210,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:33 GMT
+  recorded_at: Wed, 30 May 2018 12:20:31 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,82 +238,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '468'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:33 GMT
+      - Wed, 30 May 2018 12:20:31 GMT
       X-Amzn-Requestid:
-      - cc405ab1-4f44-11e8-982f-0fec315451d2
+      - d8b09289-6403-11e8-af31-71342e74e50e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxIBHfZIAMFmWA=
+      - HsyKdHf_IAMFw4A=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:33 GMT
+      - Wed, 30 May 2018 12:20:31 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ef5bb413c8bf256b4fd24bf3e475eda5.cloudfront.net (CloudFront)
+      - 1.1 e155b4148d60f528f875d5b690853c59.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - nK6Dwmb9Vs_m_mKFOUgv-dYrXaasQy1TQ7KEog1qLxDqOZkcp6YKVQ==
+      - OTpJAklMDgwTPsXFMqDjpoJZKIbVbtf5bp6vFgxNLMO8_bjAI56mMQ==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:33 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":true,"packageName":null,"isHidden":true}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:34 GMT
-      X-Amzn-Requestid:
-      - cc5cbc1b-4f44-11e8-a5d2-29457048a18a
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxIDGIeoAMFi3Q=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:34 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 0f0049492e2872b6e133c50b6cc7be4b.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - aerNfSnrV1JwHcDkvbx-0KeAnt0GGdpjqS8AIhhLCY2p16oU1DwTLg==
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:34 GMT
+  recorded_at: Wed, 30 May 2018 12:20:31 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -238,29 +290,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '468'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:34 GMT
+      - Wed, 30 May 2018 12:20:32 GMT
       X-Amzn-Requestid:
-      - cc7f868c-4f44-11e8-8c8b-3f9dfe6ce185
+      - d8d35cf5-6403-11e8-8007-3bd898ea2851
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxIGHLCoAMF6Yg=
+      - HsyKgF6RoAMFozA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:34 GMT
+      - Wed, 30 May 2018 12:20:31 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5d4055ddd4ab6dc339d40953c6e99219.cloudfront.net (CloudFront)
+      - 1.1 bc6981f82440e44448ee5dd3577bf4f4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - es0keyV6Q5_-t7eyo-NukjK1w-cjrW8f0rsDPPxLl3nGNmThvqYqog==
+      - D9HjL09CHKjT0BCFkfw5XIgrlRlhw2kJ-qVBEEaPMs4hP-0K_ZC_GA==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:34 GMT
+  recorded_at: Wed, 30 May 2018 12:20:32 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:32 GMT
+      X-Amzn-Requestid:
+      - d8ecd821-6403-11e8-89fa-a11fc1038b1f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyKhEZHIAMFnNw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:31 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 fcd9aaae3f7bd20d13dd07c7cf616378.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GowXGbDt0MjCi2VWY93V-w-ILZ96lPEVRmLNPJx3Hs7sykC1kiTF9g==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:32 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:32 GMT
+      X-Amzn-Requestid:
+      - d9087676-6403-11e8-9d54-c57a82fe1707
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyKjEvwIAMFyrg=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:31 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4a93be6e6adaadeec2a72967f0720081.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XADgVKGiljSbyLnDfsdLiJ5G5Yqv9ViDL2Cr5WCqPsZ2oDwenCQYnA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-ishidden.yml
@@ -1,6 +1,109 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":null,"isHidden":true}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 11:08:16 GMT
+      X-Amzn-Requestid:
+      - c077e775-63f9-11e8-b253-9d614a7f2c57
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsnlBFnvoAMFeqA=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 11:08:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - W6ehaZk6pKgAuQ6SNGfvxdPUrgMwmsTxC_LS66Fd3lNVZMblBGqaVw==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 May 2018 11:08:16 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:13 GMT
+      X-Amzn-Requestid:
+      - cd99acce-6403-11e8-b175-b749e67fe9e9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyHjFRFoAMFQuw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:12 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9b6576d35a1a9eda48ee30caf8cac918.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hnCzYfTNQKjVcRHixYUDrIg7dUfs53Z_AIX01ks17TYcqjKtOHWSrw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:13 GMT
+- request:
     method: get
     uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
     body:
@@ -27,7 +130,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:30 GMT
+      - Wed, 30 May 2018 12:20:16 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +138,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1308us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41260us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1238us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 42424us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +169,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 828750/configurations
+      - 259277/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +189,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +197,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +210,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:30 GMT
+  recorded_at: Wed, 30 May 2018 12:20:16 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,82 +238,31 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '469'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:30 GMT
+      - Wed, 30 May 2018 12:20:17 GMT
       X-Amzn-Requestid:
-      - ca51aa30-4f44-11e8-a505-3b5a17e82221
+      - cfea2bf9-6403-11e8-9362-7fa65e29983f
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxHhEd9oAMF9RA=
+      - HsyIKHEGoAMFjsg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:30 GMT
+      - Wed, 30 May 2018 12:20:17 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 5d4055ddd4ab6dc339d40953c6e99219.cloudfront.net (CloudFront)
+      - 1.1 c62f6c9a9fdf2356a904a1b156a05fe1.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - RF2K_oPXZdYlvlhX0LDReg04fujxFWLLGoyeqcws5RiUpYtsOxMoaA==
+      - _lzW7yu9br76iWW1ThmSxcw6wLqbDluV4WSMigqp2Z5XSk8rsTm1tA==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:30 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":null,"packageName":null,"isHidden":true}'
-    headers:
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.ebsco.io
-      User-Agent:
-      - http.rb/3.3.0
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - close
-      Date:
-      - Fri, 04 May 2018 02:42:30 GMT
-      X-Amzn-Requestid:
-      - ca7510bf-4f44-11e8-94d0-51541d963490
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - GVxHjETzoAMFq1w=
-      X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:30 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 1d43f56d3213a63608863fd0e49585b9.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - JfQXZzIdBPznCGZniV1PpABjeT3hw0DTEYr485eC8-ShVojsbm1_fw==
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:30 GMT
+  recorded_at: Wed, 30 May 2018 12:20:17 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -238,29 +290,133 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '469'
+      - '492'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:31 GMT
+      - Wed, 30 May 2018 12:20:17 GMT
       X-Amzn-Requestid:
-      - ca912401-4f44-11e8-9391-7167cbc99f3d
+      - d00a374b-6403-11e8-8226-47a90eac3efc
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxHlFfFoAMF36w=
+      - HsyIMFhpoAMFlSg=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:30 GMT
+      - Wed, 30 May 2018 12:20:17 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 64fc1ccc427044d03aa5724d4825ec8f.cloudfront.net (CloudFront)
+      - 1.1 d58537e312a32f11086af17e2a952efc.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - Vn8uZyBe-yFhb4K9MsWBwzbCEGQ7cEi42zR-TgLpWq3sNDTZlh5rwQ==
+      - 1t4aDaTe6KLauGq5EA0TBcQ-acmjL_jkYA0yoBGs6XyWBbZv01Ca1A==
     body:
       encoding: UTF-8
       string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:31 GMT
+  recorded_at: Wed, 30 May 2018 12:20:17 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:17 GMT
+      X-Amzn-Requestid:
+      - d02b53e1-6403-11e8-9426-7bd560d2d64d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyIOHZhIAMF4Nw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:17 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c7f2e710eb5e4c599a030513a5a7ed22.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - iCjHqhunpnEn_04gX3GU0kGj_Y7h3o7VawpNIDWEs9GOoCgs1X2crg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:17 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '492'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:20:17 GMT
+      X-Amzn-Requestid:
+      - d04607aa-6403-11e8-a566-7fd5edc13baf
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsyIQF3tIAMFd4Q=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:20:17 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 777c0716c0ef8010208c3559195306d7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qJUAyiIv0RpE0_AL93uIjruSK5fd3gbQgAlCaC2HW0FHStJfeB1JZQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":157,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:20:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-toggle-isselected.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 04 May 2018 02:42:52 GMT
+      - Wed, 30 May 2018 12:24:15 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1224us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41910us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.253.209:8081/configurations/entries..
+        : 202 1178us'
+      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.244.97:8081/configurations/entries..
+        : 200 46682us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,9 +66,9 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 490718/configurations
+      - 284198/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
+      - http://10.39.242.98:80
       X-Okapi-Permissions-Required:
       - configuration.entries.collection.get
       X-Okapi-Module-Permissions:
@@ -86,7 +86,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "a6d98284-5c46-4698-a6fe-f9d1594aecfc",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +94,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-05-07T20:35:44.622+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-05-07T20:35:44.622+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +107,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:52 GMT
+  recorded_at: Wed, 30 May 2018 12:24:15 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -135,36 +135,189 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '455'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:53 GMT
+      - Wed, 30 May 2018 12:24:15 GMT
       X-Amzn-Requestid:
-      - d8055aff-4f44-11e8-af8b-57b0e48cad51
+      - 5e4559dd-6404-11e8-adfd-f3788e83e857
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxLHG1fIAMFvMQ=
+      - HsytfGxpIAMFhhA=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:53 GMT
+      - Wed, 30 May 2018 12:24:15 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 40771aeb308f1b1a112f21c14f905436.cloudfront.net (CloudFront)
+      - 1.1 e000b4829c397da077a65028075a32a8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - SJmN5Edwxet48Qyw0NQOnflPkkh4zS1bLGOKdLuVWU_yJSPT94lTsw==
+      - 1w5i-1RQ9n9iqb6KYkUGEBIvIzy2jxTcbNrgTrFla6h1NCqiylUGsQ==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:53 GMT
+  recorded_at: Wed, 30 May 2018 12:24:15 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '455'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:16 GMT
+      X-Amzn-Requestid:
+      - 5e6c6993-6404-11e8-97e1-6968b970027f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsythGRBIAMFboQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 94fb69b274bb5ab206667cb69fcc5932.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - aCg_SPUIcBYQll4rEkMT8bdxZr9bFsMrr1BmAGx2mfqjSHLKzHBHbw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:16 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '455'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:16 GMT
+      X-Amzn-Requestid:
+      - 5e8aa034-6404-11e8-9908-b5797665c603
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsytjG9bIAMF4rQ=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bc6981f82440e44448ee5dd3577bf4f4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KPTgmTyx-hSmf7mfQfkpXfD9pLn2h0GYiWeRHRusOBzjGDC_NzOvMA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:16 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '455'
+      Connection:
+      - close
+      Date:
+      - Wed, 30 May 2018 12:24:16 GMT
+      X-Amzn-Requestid:
+      - 5eaa0eb0-6404-11e8-aace-c39f6a0d25b9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - HsytlHAbIAMF_fw=
+      X-Amzn-Remapped-Date:
+      - Wed, 30 May 2018 12:24:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 215207bc7fb93e55e70ed5107d9c8949.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fZa5Lw6lPPNdK6dZRKxQMs8WQwQV9a-eHTUnbxhPhNjjC7F5ZiB7Iw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Wed, 30 May 2018 12:24:16 GMT
 - request:
     method: put
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
     body:
       encoding: UTF-8
-      string: '{"isSelected":false,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":false,"packageName":null,"isHidden":false}'
+      string: '{"isSelected":false,"customCoverage":{"beginCoverage":null,"endCoverage":null},"allowEbscoToAddTitles":false,"isHidden":false}'
     headers:
       X-Api-Key:
       - TEST_API_KEY
@@ -190,26 +343,26 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:53 GMT
+      - Wed, 30 May 2018 12:24:16 GMT
       X-Amzn-Requestid:
-      - d8227fb9-4f44-11e8-9c8e-d7850d80b46e
+      - 5ec362f7-6404-11e8-bba7-d9bd38da770a
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxLJHiYoAMFliA=
+      - HsytnFEeIAMFw9w=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:53 GMT
+      - Wed, 30 May 2018 12:24:15 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 3d183dc06807f77c9361cf878faaed82.cloudfront.net (CloudFront)
+      - 1.1 a1b9c0f574e30dae7536945f59627868.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - UFVzTxcApSTFVYys4gbwdTiUvq8a9_i4Ozl2-wBIVf8B3ncdW99-tQ==
+      - 0DIhhYP7eScUomIVsGNkk0wXFiUhpmCcpYOGo9JZ2CPtRW4C_mD1aQ==
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:53 GMT
+  recorded_at: Wed, 30 May 2018 12:24:16 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
@@ -237,28 +390,28 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '451'
+      - '455'
       Connection:
       - close
       Date:
-      - Fri, 04 May 2018 02:42:54 GMT
+      - Wed, 30 May 2018 12:24:16 GMT
       X-Amzn-Requestid:
-      - d845e5b1-4f44-11e8-a666-4fce454008af
+      - 5edb7e96-6404-11e8-bab2-b3bc18be304f
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GVxLLG08IAMFmjg=
+      - HsytoH1xoAMF9dw=
       X-Amzn-Remapped-Date:
-      - Fri, 04 May 2018 02:42:53 GMT
+      - Wed, 30 May 2018 12:24:15 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 440cbcb26e69761b0c95e97cad505b77.cloudfront.net (CloudFront)
+      - 1.1 edf4d9eb8e5d775f8b1cd6b4e97dd4c6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 1qyP8dmTzeEDcXLsS667cn9TzE6j-b7xAQWdKbDSaVAzAybRNMN0wA==
+      - ih4zys--u9EW_Akdo60dufLbYrePGkUqa0ip2s_0nzDfm9C6VMmsCg==
     body:
       encoding: UTF-8
-      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":157,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"EZProxy","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Complete"}'
     http_version: 
-  recorded_at: Fri, 04 May 2018 02:42:54 GMT
+  recorded_at: Wed, 30 May 2018 12:24:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -952,7 +952,7 @@ RSpec.describe 'Packages', type: :request do
     end
 
     it 'gets a successful response' do
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(400)
     end
   end
 
@@ -969,7 +969,9 @@ RSpec.describe 'Packages', type: :request do
           "data": {
             "type": 'packages',
             "attributes": {
-              "name": 'I got a new package name'
+              "isSelected": true,
+              "name": 'name of the ages forever and ever',
+              "contentType": 'Aggregated Full Text'
             }
           }
         }
@@ -989,7 +991,7 @@ RSpec.describe 'Packages', type: :request do
       let!(:json) { Map JSON.parse response.body }
 
       it 'has the new name' do
-        expect(json.data.attributes.name).to eq('I got a new package name')
+        expect(json.data.attributes.name).to eq('name of the ages forever and ever')
       end
     end
 
@@ -1003,7 +1005,9 @@ RSpec.describe 'Packages', type: :request do
                 "beginCoverage": '2003-01-01',
                 "endCoverage": '2004-01-01'
               },
-              "isSelected": true
+              "isSelected": true,
+              "name": 'name of the ages forever and ever',
+              "contentType": 'Aggregated Full Text'
             }
           }
         }
@@ -1069,6 +1073,8 @@ RSpec.describe 'Packages', type: :request do
             "type": 'packages',
             "attributes": {
               "isSelected": true,
+              "name": 'name of the ages forever and ever',
+              "contentType": 'Aggregated Full Text',
               "visibilityData": {
                 "isHidden": true,
                 "reason": ''


### PR DESCRIPTION
## Purpose

In the push to get this out for the demo we botched validation from a
few angles with respect to the new pattern.  This broke almost (if not
all) edits on the package details page.

## Approach
The following work addresses this, while leaving some of the
underlying issues unaddressed for now.  Here's a summary of what was completed:

- Immediate fix for 361, which consists of a) raising an exception if
  a non 200-level response code is encountered anywhere in a
  repository operation.  This will prevent the false positives.  The
  actual 'contentType' error that was being seen is, for now,
  sidestepped by branching on the package's `custom` status inside the
  repo's `update` method.
  - Implementing point a) involved creating an RmapiResource
  superclass to hold some common functionatliy and then adjusting the
  `rmapi` method to a more generic `request` method that fails
  immediately on any HTTP error code.  This failure bubbles up and is
  caught by our other error handlers.
- Validation was pulled into the controller level, because research
  indicated that was the convention, and because it also makes more
  sense there (the way things are currently).  It's not exactly the
  repository's job to validate what it intends to persist.  It should
  only persist, and should only receive arguments ready for
  persistance imo.
- The serialization concerns about case clashing have been addressed
  as far as I'vde seen
- The tests were adjusted accordingly.

#### TODOS and Open Questions
- [ ] The fact that the tests were green when we last merged this gives me very little confidence in their current efficacy.  This should be of high concern.  The tests in this case impeded my changes rather than empowered them.  
- [ ] For now the data transformation is still inline.  I wanted to get an MVP out so I avoided pulling them out into (at the very least) separate methods for now or (ideally) some kind of data structure that represents communication between rmapi and mod-kb in both directions.  I'd like to circle back on that today if i get time, but if not we'll get to it another time.  
- [ ] There are several other TODOs in the code as well, but this covers the ones that are major enough and mature enough to warrant additional time allocated.

## Learning
- [some stuff about how validation works in laravel](https://laracasts.com/discuss/channels/laravel/repository-pattern-and-validation)
- [general overview of repository pattern](https://martinfowler.com/eaaCatalog/repository.html) which leaves some open questions up to the implementor(s) but otherwise is a nice summary
