### PR TITLE
FOLIO-1260 lint-raml-cop bash3

### DIFF
--- a/scripts/lint-raml-cop.sh
+++ b/scripts/lint-raml-cop.sh
@@ -9,11 +9,6 @@ ramls_dir="ramls"
 # Space-separated list of sub-directory paths that need to be avoided.
 prune_dirs="raml-util"
 
-if [[ ${BASH_VERSION%%.*} -lt 4 ]]; then
-  echo "Requires bash 4+"
-  exit 1
-fi
-
 if ! cmd=$(command -v raml-cop); then
   echo "raml-cop is not available. Do 'npm install -g raml-cop'"
   echo "${help_msg}"
@@ -24,7 +19,7 @@ repo_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd "${repo_home}" || exit
 
 prune_string=$(printf " -path ${ramls_dir}/%s -o" ${prune_dirs})
-mapfile -t raml_files < <(find ${ramls_dir} \( ${prune_string% -o} \) -prune -o -name "*.raml" -print)
+raml_files=($(find ${ramls_dir} \( ${prune_string% -o} \) -prune -o -name "*.raml" -print))
 
 if [[ ${#raml_files[@]} -eq 0 ]]; then
   echo "No RAML files found under '${repo_home}/${ramls_dir}'"

--- a/scripts/lint-raml-cop.sh
+++ b/scripts/lint-raml-cop.sh
@@ -7,7 +7,7 @@ help_msg="Some assistance is at https://dev.folio.org/guides/raml-cop"
 ramls_dir="ramls"
 
 # Space-separated list of sub-directory paths that need to be avoided.
-prune_dirs="raml-util"
+prune_dirs="raml-util types"
 
 if ! cmd=$(command -v raml-cop); then
   echo "raml-cop is not available. Do 'npm install -g raml-cop'"


### PR DESCRIPTION
## Purpose

This updates the ./scripts/lint-raml-cop.sh to be able to use bash3 as well as bash4.
It also avoids the new "ramls/types" directory in some branches.
(Note that this script is temporary until FOLIO-1264.)

@sduvvuri-ebsco  and @keathleydavidj 
It is very useful to run raml-cop while developing. It currently does report errors in your branches.