### PR TITLE
Return pluralized data type

### DIFF
--- a/app/serializable/serializable_proxy_type.rb
+++ b/app/serializable/serializable_proxy_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SerializableProxyType < SerializableJSONAPIResource
-  type 'proxyType'
+  type 'proxyTypes'
 
   # Custom Label attributes
   attributes :id,

--- a/spec/requests/root_proxy_spec.rb
+++ b/spec/requests/root_proxy_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Root Proxies', type: :request do
       expect(response).to have_http_status(200)
     end
     it "is of type 'proxyType'" do
-      expect(json.data.first.type).to eq('proxyType')
+      expect(json.data.first.type).to eq('proxyTypes')
     end
 
     describe 'check attributes of proxyType' do


### PR DESCRIPTION
## Purpose
Return data type that is pluralized as this contains a collection of things and to keep the inflection consistent.

## Approach
 - Change `ProxyType` => `ProxyTypes`
