### PR TITLE
UIEH-422

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,12 +66,11 @@ pipeline {
             env.dockerRepo = 'folioci'
             echo "This is a snapshot build."
           }
+        }
 
         echo "Building Ruby artifact: ${env.name} Version: ${env.version}"
-
         sh "/bin/bash -l -c '. /usr/share/rvm/scripts/rvm && rvm use ${env.RUBY_VERSION}'"
         sh "sudo /bin/bash -l -c '. /usr/share/rvm/scripts/rvm && gem install bundler'"
-
         sh "sudo /bin/bash -l -c '. /usr/share/rvm/scripts/rvm && bundle install'"
 
         echo "Run unit tests..."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
     stage('Publish Docker image') {
       when {
         anyOf {
-          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+$", comparator: "REGEXP"
+          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+\$", comparator: "REGEXP"
         }
       }
       steps {
@@ -110,7 +110,7 @@ pipeline {
     stage('Publish Module Descriptor') {
       when {
         anyOf {
-          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+$", comparator: "REGEXP"
+          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+\$", comparator: "REGEXP"
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
     stage('Publish API docs') { 
       when {
         anyOf {
-          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+$", comparator: "REGEXP"
+          branch 'master'; tag pattern: "^v\\d+\\.\\d+\\.\\d+\$", comparator: "REGEXP"
         }
       }
       steps { 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
         script {
           if (env.snapshot) {
             def foliociLib = new org.folio.foliociCommands()
-            foliociLib.updateModDescriptorId('ModuleDescriptor.json')
+            foliociLib.updateModDescriptor('ModuleDescriptor.json')
           }
         }
         postModuleDescriptor('ModuleDescriptor.json')


### PR DESCRIPTION
Modifications made to 'Jenkinsfile' :

1.  Fix module descriptor modifications Jenkins makes before posting module descriptor to FOLIO Registry, including the 'dockerImage' and 'dockerPull' fields in the launch descriptor.  UIEH-422.  

2. Set  'snapshot' or 'release'  Jenkins build environment (based on git tag).  This adds the ability to set other environments properly during the build such as the proper Docker Hub repository, version numbers, and so forth as well as deploy release artifacts via Jenkins.   

