### PR TITLE
Change id value for root proxy that is returned

### DIFF
--- a/app/repositories/root_proxies_repository.rb
+++ b/app/repositories/root_proxies_repository.rb
@@ -57,6 +57,6 @@ class RootProxiesRepository < RmapiRepository
   end
 
   def to_root_proxy(hash)
-    RootProxy.new(id: 'eholdings/root-proxy', proxy_type_id: hash[:id])
+    RootProxy.new(id: 'root-proxy', proxy_type_id: hash[:id])
   end
 end

--- a/spec/requests/root_proxy_spec.rb
+++ b/spec/requests/root_proxy_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Root Proxies', type: :request do
 
       describe 'check attributes of new root proxy' do
         it 'has id of eholdings/root-proxy' do
-          expect(attributes.id).to eq('eholdings/root-proxy')
+          expect(attributes.id).to eq('root-proxy')
         end
         it 'has id of EZProxy' do
           expect(attributes.proxyTypeId).to eq('EZProxy')


### PR DESCRIPTION
## Purpose
The id that is return from the mod-kb-ebsco is used by the ui-eholdings when attempting to save a model. When models are created in ui-eholdings they include a base `path` if you will to what endpoint in mod-kb-ebsco that can handle the desire request.
When the `save` method is run is looks at the id and uses that that to construct a path to a endpoint within mod-kb that can handle that save request. And will then append the `id` that was returned from mod-kb when GET-ing the model to the aforementioned base path. 

So having an id `eholdings/root-proxy` that is created in mod-kb and returned to ui-eholdings will result in whatever base path that is set within the model in ui-eholdings to have `$basepath/eholdings/root-proxy` when trying to save and this constructed path will not match any in mod-kb.

In ui-eholdings if we do not but a path when creating a model it will default to use the type of the model and we do not want that. We want the base path from this model in ui-eholdings to be `eholdings` so when the path is constructed for the save it will be `eholdings/root-proxy` and that will be a valid endpoint in mod-kb

## Approach
 - Change `eholdings/root-proxy` to `root-proxy`
