### PR TITLE
UIEH-421: Validate resource id for GET, PUT and DELETE

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -79,7 +79,15 @@ class ResourcesController < ApplicationController
   private
 
   def set_resource
-    @resource = resources.find resource_id
+    resource_id_validation =
+      Validation::ResourceID.new(resource_id)
+
+    if resource_id_validation.valid?
+      @resource = resources.find resource_id
+    else
+      render jsonapi_errors: resource_id_validation.errors,
+             status: :bad_request
+    end
   end
 
   def resource_id

--- a/app/controllers/validation/resource_id.rb
+++ b/app/controllers/validation/resource_id.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Validation
+  class ResourceID
+    include ActiveModel::Validations
+
+    attr_accessor :vendor_id, :package_id, :title_id
+
+    validates :vendor_id, presence: true
+    validates :package_id, presence: true
+    validates :title_id, presence: true
+
+    validate :vendor_id_int?
+    validate :package_id_int?
+    validate :title_id_int?
+
+    def vendor_id_int?
+      errors.add(:vendor_id, ':Invalid vendor id') unless
+        vendor_id.to_i != 0
+    end
+
+    def package_id_int?
+      errors.add(:package_id, ':Invalid package id') unless
+        package_id.to_i != 0
+    end
+
+    def title_id_int?
+      errors.add(:title_id, ':Invalid title id') unless
+        title_id.to_i != 0
+    end
+
+    def initialize(params = {})
+      @vendor_id = params[:vendor_id]
+      @package_id = params[:package_id]
+      @title_id = params[:title_id]
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-421, we were not providing expected error responses when user makes a request with invalid resource id. 

## Approach
- Validate resource id to consist of provider_id, package_id and title_id
- Also, validate that provided values can be converted to integers
- Add associated unit tests

#### TODOS and Open Questions
- [ ] We might want to do something similar for packages, providers and titles endpoints as well. Will discuss with Khalilah and add more bugs in backlog. Added UIEH-425, UIEH-426 and UIEH-427 in backlog.

## Screenshots
![resource_id_validation](https://user-images.githubusercontent.com/33662516/41243984-b9d81332-6d71-11e8-9202-ffcbcf491916.gif)

