### PR TITLE
Return a 400 Error response for invalid query parameters

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -20,7 +20,7 @@ class PackagesController < ApplicationController
              class: { Package: SerializablePackageList }
     else
       render jsonapi_errors: package_query_params_validation.errors,
-             status: :unprocessable_entity
+             status: :bad_request
     end
   end
 

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Packages', type: :request do
     let!(:json_f) { Map JSON.parse response.body }
 
     it 'returns a bad request error' do
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(400)
       expect(json_f.errors.first.title).to eql('Invalid selectedFilter')
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe 'Packages', type: :request do
     let!(:json_f) { Map JSON.parse response.body }
 
     it 'returns a bad request error' do
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(400)
       expect(json_f.errors.first.title).to eql('Invalid selectedFilter')
     end
   end
@@ -114,7 +114,7 @@ RSpec.describe 'Packages', type: :request do
     let!(:json_f) { Map JSON.parse response.body }
 
     it 'returns a bad request error' do
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(400)
       expect(json_f.errors.first.title).to eql('Invalid contentTypeFilter')
     end
   end
@@ -129,7 +129,7 @@ RSpec.describe 'Packages', type: :request do
     let!(:json_f) { Map JSON.parse response.body }
 
     it 'returns a bad request error' do
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(400)
       expect(json_f.errors.first.title).to eql('Invalid sortFilter')
     end
   end


### PR DESCRIPTION
## Purpose
If a Client pass values in Query Parameters that are not valid or acceptable value return a 400 Error response with the Error Message.

