### PR TITLE
UIEH-433 Validate Query Parameters for providers endpoint

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -13,15 +13,22 @@ class ProvidersController < ApplicationController
   # provides in a detailed record. When RM API team fixes the issue on their end,
   # we can get rid of the SerializableProviderList class and just use SerializableProvider
   def index
-    @providers = providers.all(
-      q: params[:q],
-      page: params[:page],
-      sort: params[:sort]
-    )
+    provider_query_params_validation = Validation::ProviderQueryParameters.new(params)
 
-    render jsonapi: @providers.vendors.to_a,
-           meta: { totalResults: @providers.totalResults },
-           class: { Provider: SerializableProviderList }
+    if provider_query_params_validation.valid?
+      @providers = providers.all(
+        q: params[:q],
+        page: params[:page],
+        sort: params[:sort]
+      )
+
+      render jsonapi: @providers.vendors.to_a,
+             meta: { totalResults: @providers.totalResults },
+             class: { Provider: SerializableProviderList }
+    else
+      render jsonapi_errors: provider_query_params_validation.errors,
+             status: :bad_request
+    end
   end
 
   def show

--- a/app/controllers/validation/provider_query_parameters.rb
+++ b/app/controllers/validation/provider_query_parameters.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/VariableName
+
+module Validation
+  class ProviderQueryParameters
+    include ActiveModel::Validations
+
+    attr_accessor :sortFilter
+
+    validates :sortFilter, inclusion: { in: %w[name relevance],
+                                        message: 'Invalid Query Parameter for sort' }, allow_nil: true
+
+    def initialize(params = {})
+      @sortFilter = params[:sort]
+    end
+  end
+end
+# rubocop:enable Naming/VariableName

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -381,6 +381,21 @@ RSpec.describe 'Providers', type: :request do
       end
     end
 
+    describe 'with an invalid query param sort' do
+      # VCR not needed here because a request will not be made because the
+      # validation will fail and not make the request to RMAPI
+      before do
+        get '/eholdings/providers/?q=ebsco&sort=doNotEnter', headers: okapi_headers
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'returns a bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Invalid sortFilter')
+      end
+    end
+
     describe 'with valid filter options' do
       before do
         VCR.use_cassette('search-providers-related-packages-valid-filter') do


### PR DESCRIPTION
## Purpose
When making a search request a Client has the ability to send URL Query Parameters along with the request to filter down the search result or data set that is returned. This request and Query Parameters are then translated and sent off to RMAPI who then responds with the results or data that the client requests. As long as the Query Parameters values are acceptable with RMAPI then all is fine. However, when the values that sent under Query Parameters those would pass through and be sent to RMAPI which would sometimes cause RMAPI to error out, or respond with a 200 but actually not accepting the invalid Query Parameters. We are making a spot gap before those invalid Query Parameters are requested to RMAPI.

## Approach
- Validate the Query Parameters and return 400 if clients passes any unaccepted values

## Screenshots
<img width="1240" alt="screen shot 2018-06-27 at 4 45 17 pm" src="https://user-images.githubusercontent.com/1953098/41998862-cb37e200-7a29-11e8-94a0-b0e8fd56670f.png">

