### PR TITLE
UIEH-487: Update RAML for PUT and POST packages endpoint

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -200,8 +200,8 @@ types:
                   contentType:
                     description: Content type of the custom package to be created
                     type: string
-                    enum: ["all", "aggregatedfulltext", "abstractandindex", "ebook", "ejournal", "print", "onlinereference", "unknown"]
-                    example: unknown
+                    enum: ["Aggregated Full Text", "Abstract and Index", "E-Book", "E-Journal", "Print", "Online Reference", "Unknown"]
+                    example: Unknown
                     required: true
                   customCoverage:
                     description: Coverage dates of the custom package to be created
@@ -281,8 +281,8 @@ types:
                         Content type of the custom package to be updated.
                         Note that this attribute can be updated ONLY FOR A CUSTOM PACKAGE.
                       type: string
-                      enum: [all, aggregatedfulltext, abstractandindex, ebook, ejournal, print, onlinereference, unknown]
-                      example: unknown
+                      enum: ["Aggregated Full Text", "Abstract and Index", "E-Book", "E-Journal", "Print", "Online Reference", "Unknown"]
+                      example: Unknown
                       required: true
                     customCoverage:
                       description: |

--- a/ramls/examples/packages/packages_post_request.json
+++ b/ramls/examples/packages/packages_post_request.json
@@ -3,7 +3,7 @@
      "type": "packages",
      "attributes": {
        "name": "yet another custom package",
-       "contentType": "unknown",
+       "contentType": "Unknown",
        "customCoverage": {
          "beginCoverage": "2003-01-01",
          "endCoverage": "2004-01-01"

--- a/ramls/examples/packages/packages_put_request.json
+++ b/ramls/examples/packages/packages_put_request.json
@@ -3,7 +3,7 @@
     "type": "packages",
     "attributes": {
       "name": "test package for documentation",
-      "contentType": "unknown",
+      "contentType": "Unknown",
       "customCoverage": {
         "beginCoverage": "2003-01-01",
         "endCoverage": "2003-12-01"


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-487, we were seeing an issue with `contentType` while creating and updating a package using a REST client. Identify the issue and resolve it.

## Approach
- Figured that it works fine from the UI with experimentation.
- Observed what values are being passed from UI and noticed that they are different than what is mentioned in the documentation for packages endpoint.
- If we use the same as what is being passed through UI, then the `contentType` is reflecting as expected.
- Updated eholdings.raml enum for both PUT and POST requests to `/eholdings/packages` endpoint and associated example files with the correct value from the updated enumeration.
- Ran raml-cop to validate updates to RAML.

## Screenshots
![updated_raml](https://user-images.githubusercontent.com/33662516/42844249-5d73ba34-89e0-11e8-8f35-180221198ad6.gif)
