### PR TITLE
UIEH-493 - Resources documentation missing attributes on PUT request

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -106,6 +106,40 @@ types:
           "packageId": "123-456"
         }
       }
+  customIdentifierType:
+    type: string
+    enum: ["ISSN", "ISBN"]
+    example: "ISSN"
+  customIdentifierSubType:
+    type: string
+    enum: ["Print", "Online"]
+    example: "Print"
+  identifier:
+    type: object
+    properties:
+      id: string
+      type: customIdentifierType
+      subtype: customIdentifierSubType
+    example: |
+       {
+          "id": "978-0-7295-3913-5",
+          "type": "ISBN",
+          "subtype": "Print"
+        }
+  contributorType:
+    type: string
+    enum: ["Author", "Editor", "Illustrator"]
+    example: "Author"
+  contributor:
+    type: object
+    properties:
+      type: contributorType
+      contributor: string
+    example: |
+      {
+        "type": "Author",
+        "contributor": "Tiziani, Adriana."
+      }
 
 /eholdings/packages:
   displayName: Packages
@@ -552,20 +586,93 @@ types:
                       type: string
                       example: "https://hello.io"
                       required: false
+                    name:
+                      description: |
+                        Title name for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: string
+                      example: "Sample Title"
+                      required: false
+                    isPeerReviewed:
+                      description: |
+                        Peer review indicator for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: boolean
+                      example: true
+                      required: false
+                    publicationType:
+                      description: |
+                        Publication Type for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: string
+                      enum: ["Audiobook", "Book", "Book Series", "Database", "Journal", "Newsletter", "Newspaper", "Proceedings", "Report", "Streaming Audio", "Streaming Video", "Thesis & Dissertation", "Website", "Unspecified"]
+                      example: "Newspaper"
+                      required: false    
+                    publisherName:
+                      description: |
+                        Publisher Name for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: string
+                      example: "ABC Publishing"
+                      required: false  
+                    edition:
+                      description: |
+                        Edition for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: string
+                      example: "5"
+                      required: false         
+                    description:
+                      description: |
+                        Description for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: string
+                      example: "Sample title description"
+                      required: false 
+                    contributors:
+                      description: |
+                        Contributors for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: array
+                      items: contributor
+                      example: 
+                        - # start item 1
+                          type: Author
+                          contributor: Havard, Margaret
+                        - # start item 2
+                          type: Illustrator
+                          contributor: Tiziani, Adriana
+                      required: false                
+                    identifiers:
+                      description: |
+                        Identifiers for a custom resource.
+                        Note that this attribute can be updated ONLY FOR A CUSTOM RESOURCE.
+                      type: array
+                      items: identifier
+                      example: 
+                        - # start item 1
+                          id: 978-0-7295-3913-5
+                          type: ISBN
+                          subtype: Print
+                        - # start item 2
+                          id: 1996-0794
+                          type: ISSN
+                          subtype: Print
+                      required: false           
                     customCoverages:
                       description: |
                         Coverage dates of the custom or managed resource to be updated.
                         Note that this attribute can be updated BOTH FOR CUSTOM RESOURCES AND MANAGED RESOURCES.
                       type: array
                       items: customCoverage
-                      required: false
                       example:
                         - # start item 1
                           beginCoverage: 2018-06-03
                           endCoverage: 2018-06-04
                         - # start item 2
                           beginCoverage: 2018-06-05
-                          endCoverage: 2018-06-06
+                          endCoverage: 2018-06-06  
+                      required: false
                     isSelected:
                       description: |
                         Selection of the managed or custom resource to be updated.

--- a/ramls/examples/resources/resources_put_request.json
+++ b/ramls/examples/resources/resources_put_request.json
@@ -2,25 +2,47 @@
   "data": {
     "type": "resources",
     "attributes": {
+     "name": "Updated Custom Title Name",
+      "isPeerReviewed": true,
+      "publicationType": "Newspaper",
+      "publisherName": "Updated Publisher",
+      "edition": "5",
+      "description": "Updated Description",
       "url": "https://hello.io",
+      "contributors": [
+        {
+        "type":"Author",
+        "contributor":"smith, john"
+        },
+        {
+        "type":"Illustrator",
+        "contributor":"smith, ralph"
+        }
+      ],
+      "identifiers": [
+        {
+        "id":"11-2222-3333",
+        "type":"ISSN",
+        "subtype":"Online"
+        }      
+      ],
       "isSelected": true,
       "visibilityData": {
-        "isHidden": true
+        "isHidden" : false
       },
-      "customCoverages": [{
-        "beginCoverage": "2018-06-05",
-        "endCoverage": "2018-06-07"
-      }, {
-        "beginCoverage": "2018-06-08",
-        "endCoverage": "2018-06-10"
-      }],
-      "coverageStatement": "hello",
       "customEmbargoPeriod": {
-        "embargoValue": 4,
-        "embargoUnit": "Weeks"
+        "embargoUnit" : "Months",
+        "embargoValue" : 5
       },
-      "proxy": {
-        "id": "<n>"
+      "customCoverages" : [
+      {
+        "beginCoverage" : "2001-01-01",
+        "endCoverage" : "2004-02-01"
+      }
+      ],
+      "coverageStatement": "Updated Coverage Statement",
+      "proxy" : {
+        "id" : "<n>"
       }
     }
   }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIEH-493
While developing API tests for mod-kb-ebsco, we found that some attributes were missing for the documentation for the Resources PUT request. 
Specifically the following attributes should be added (note - these are specific for custom titles only):
"name"
"isPeerReviewed"
"publicationType"
"publisherName"
"edition"
"description"
"contributors"
"identifiers"

In addition, identifiers for custom titles are limited to type = ISSN or ISBN and subtype = Print or Online

https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco/eholdings.html# 
https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco/eholdings.html#eholdings_resources__resourceid__put


## Approach
Added missing properties to Resources PUT request payload.
Added type definitions for identifiers and contributors.


## Learning
The following rm api documentation link provided details of what the custom title payload can include
https://developer.ebsco.com/reference/rmapi#customtitlepayload

## Screenshots
<img width="1669" alt="screen shot 2018-07-18 at 1 30 04 pm" src="https://user-images.githubusercontent.com/19415226/42897694-c898e9f2-8a8e-11e8-820e-572629265e57.png">