### PR TITLE
UIEH-502: Remove 'All' as publication type from serialize/deserialize for resource and titles

### DIFF
--- a/app/deserializable/deserializable_resource.rb
+++ b/app/deserializable/deserializable_resource.rb
@@ -20,7 +20,6 @@ class DeserializableResource < JSONAPI::Deserializable::Resource
 
   attribute :publicationType do |value|
     publication_types = {
-      'All': 'all',
       'Audiobook': 'audiobook',
       'Book': 'book',
       'Book Series': 'bookseries',

--- a/app/serializable/serializable_resource.rb
+++ b/app/serializable/serializable_resource.rb
@@ -77,7 +77,6 @@ class SerializableResource < SerializableJSONAPIResource
   end
   attribute :publicationType do
     publication_types = {
-      all: 'All',
       audiobook: 'Audiobook',
       book: 'Book',
       bookseries: 'Book Series',

--- a/app/serializable/serializable_title_list.rb
+++ b/app/serializable/serializable_title_list.rb
@@ -58,7 +58,6 @@ class SerializableTitleList < SerializableJSONAPIResource
 
   attribute :publication_type do
     publication_types = {
-      all: 'All',
       audiobook: 'Audiobook',
       book: 'Book',
       bookseries: 'Book Series',


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-502

## Purpose
'All' was removed from the publication dropdown as part of eHoldings PR  https://github.com/folio-org/ui-eholdings/pull/468

The option is not available when creating or updating a title/resource. 'All' is only used as a parameter when searching for titles to indicate all publication types should be included. (as is referenced in title.rb)

This PR cleans up and removes 'all'  as an option for publication types from serializers and deserializers for resource and titles.

## Approach
Removed all as option for publication type to be consistent with what is supported in RM API and what is passed from eHoldings UI.
