### PR TITLE
UIEH-265: Remove unsupported endpoints from ModuleDescriptor.json

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -45,22 +45,6 @@
         {
           "methods": [ "GET", "POST", "PUT", "DELETE" ],
           "pathPattern": "/eholdings/resources*"
-        },
-        {
-          "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/ebsco-rmapi/holdings*"
-        },
-        {
-          "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/ebsco-rmapi/packages*"
-        },
-        {
-          "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/ebsco-rmapi/vendors*"
-        },
-        {
-          "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
-          "pathPattern": "/ebsco-rmapi/titles*"
         }
       ]
     }


### PR DESCRIPTION
## Purpose
This PR removes the following unsupported endpoints from `ModuleDescriptor.json`

```
{ "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ], "pathPattern": "/ebsco-rmapi/holdings*" },
{ "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ], "pathPattern": "/ebsco-rmapi/packages*" },
{ "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ], "pathPattern": "/ebsco-rmapi/vendors*" },
{ "methods": [ "GET", "POST", "PUT", "PATCH", "DELETE" ], "pathPattern": "/ebsco-rmapi/titles*" } 
```