### PR TITLE
UIEH-483 - Packages filter[custom] update documentation/validation of true as only value

### DIFF
--- a/app/controllers/validation/package_query_parameters.rb
+++ b/app/controllers/validation/package_query_parameters.rb
@@ -7,7 +7,7 @@ module Validation
     include ActiveModel::Validations
 
     attr_accessor :sortFilter, :selectedFilter,
-                  :contentTypeFilter
+                  :contentTypeFilter, :customFilter
 
     validates :sortFilter, inclusion: { in: %w[name relevance],
                                         message: 'Invalid Query Parameter for sort' }, allow_nil: true
@@ -15,12 +15,14 @@ module Validation
                                             message: 'Invalid Query Parameter for filter[:selected]' }, allow_nil: true
     validates :contentTypeFilter, inclusion: { in: %w[aggregatedfulltext abstractandindex ebook ejournal print onlinereference unknown],
                                                message: 'Invalid Query Parameter for filter[:type]' }, allow_nil: true
-
+    validates :customFilter, inclusion: { in: %w[true],
+                                          message: 'Invalid Query Parameter for filter[:custom]' }, allow_nil: true
     def initialize(params = {})
       filters = params.fetch(:filter, nil)
       @sortFilter = params[:sort]
       @selectedFilter = hash?(filters) ? filters[:selected] : filters
       @contentTypeFilter = hash?(filters) ? filters[:type] : filters
+      @customFilter = hash?(filters) ? filters[:custom] : filters
     end
 
     private

--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -192,7 +192,7 @@ types:
       filter[custom]:
         displayName: Custom Packages List
         type: string
-        enum: ["true", "false"]
+        enum: ["true"]
         description: Filter to get list of custom packages
         example: "true"
         required: false

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1362,4 +1362,19 @@ RSpec.describe 'Packages', type: :request do
       expect(json.data.first.attributes.isCustom).to be true
     end
   end
+
+  describe 'filtering by invalid custom' do
+    before do
+      VCR.use_cassette('get-custom-packages-invalid-filter') do
+        get '/eholdings/packages?filter[custom]=false&count=100', headers: okapi_headers
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'returns an error status' do
+      expect(response).to have_http_status(400)
+      expect(json.errors.first.title).to eql('Invalid customFilter')
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIEH-483

While writing API tests for Packages endpoint, the following was discovered:
Per documentation here: https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco/eholdings.html#eholdings_packages_get; filter[custom] can have 2 values, true or false but passing in either is not making a difference in the response. 

The custom filter is used to populate the dropdown for getting the list of custom packages (when associating a title to a package)  -- we use the filter[custom]=true in this case from eHoldings. The code in mod-kb-ebsco only supports getting custom packages (based on this filter).  There is not a use case to for filter[custom]= false to get a list of packages that are not custom. 

This PR updates documentation and validation for filter[custom] so that it is not ambiguous when trying to use it.

## Approach
- Update the documentation to indicate filter[custom]=true is the only allowed value.
- Update mod-kb-ebsco to validate that the filter passed has value of true. 


## Screenshots
![2018-07-31 13 58 07](https://user-images.githubusercontent.com/19415226/43478355-ae1cdede-94cb-11e8-9e53-7d89defa5109.gif)
![2018-07-31 14 01 25](https://user-images.githubusercontent.com/19415226/43478422-d8c27d10-94cb-11e8-9694-c1decca26598.gif)


