### PR TITLE
UIEH-491: Bug fix for putting a custom/managed resource

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -58,8 +58,9 @@ class ResourcesController < ApplicationController
   end
 
   def update
+    is_title_custom = title_custom?
     resource_validation =
-      Validation::ResourceUpdateParameters.new(update_params)
+      Validation::ResourceUpdateParameters.new(is_title_custom, update_params)
 
     if resource_validation.valid?
       @resource.update update_params
@@ -113,6 +114,10 @@ class ResourcesController < ApplicationController
         :packageId,
         :url
       )
+  end
+
+  def title_custom?
+    @resource.isTitleCustom
   end
 
   def resource_params

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -6,11 +6,9 @@ module Validation
   class ResourceUpdateParameters
     include ActiveModel::Validations
 
-    attr_accessor :isSelected, :isHidden, :customCoverageList, :contributorsList,
+    attr_accessor :isTitleCustom, :isSelected, :isHidden, :customCoverageList, :contributorsList,
                   :identifiersList, :embargoUnit, :embargoValue, :coverageStatement,
-                  :edition
-
-    validates :edition, length: { maximum: 250 }, allow_nil: true
+                  :edition, :titleName, :isPeerReviewed, :pubType, :publisherName, :description, :url
 
     # Deselected resources cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
@@ -26,6 +24,19 @@ module Validation
       validates :coverageStatement, absence: true, unless: :isSelected
     end
 
+    with_options unless: :isTitleCustom do
+      validates :titleName, absence: true, unless: :isTitleCustom
+      validates :isPeerReviewed, absence: true, unless: :isTitleCustom
+      validates :pubType, absence: true, unless: :isTitleCustom
+      validates :publisherName, absence: true, unless: :isTitleCustom
+      validates :edition, absence: true, unless: :isTitleCustom
+      validates :description, absence: true, unless: :isTitleCustom
+      validates :url, absence: true, unless: :isTitleCustom
+      validates :contributorsList, absence: true, unless: :isTitleCustom
+      validates :identifiersList, absence: true, unless: :isTitleCustom
+    end
+
+    validates :edition, length: { maximum: 250 }, allow_nil: true
     validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
 
     def identifiers_list_valid?
@@ -39,7 +50,8 @@ module Validation
       end
     end
 
-    def initialize(params = {})
+    def initialize(is_title_custom, params = {})
+      @isTitleCustom = is_title_custom
       @isSelected = params[:isSelected]
       @isHidden = params.dig(:visibilityData, :isHidden)
       @customCoverageList = params[:customCoverageList]
@@ -49,6 +61,12 @@ module Validation
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]
       @edition = params[:edition]
+      @titleName = params[:titleName]
+      @isPeerReviewed = params[:isPeerReviewed]
+      @pubType = params[:pubType]
+      @publisherName = params[:publisherName]
+      @description = params[:description]
+      @url = params[:url]
     end
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -169,8 +169,10 @@ class Resource < RmApiResource
   end
 
   def merge_fields!(new_values)
-    update_fields.deep_merge(new_values.to_hash).each do |k, v|
-      send("#{k}=".to_sym, v)
+    if isTitleCustom
+      update_fields.deep_merge(new_values.to_hash).each do |k, v|
+        send("#{k}=".to_sym, v)
+      end
     end
 
     resource_update_fields.deep_merge(new_values.to_hash).each do |k, v|

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-coverage-statement.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-coverage-statement.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1474us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 43628us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 311718us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45395us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 567016/configurations
+      - 393686/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:44 GMT
+  recorded_at: Tue, 31 Jul 2018 19:36:45 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2172'
+      - '1035'
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       X-Amzn-Requestid:
-      - 8068cedb-44e2-11e8-ab8a-37994fb234a7
+      - 0f0985fd-94f9-11e8-8952-9983b8abb21a
       X-Amzn-Remapped-Content-Length:
-      - '2172'
+      - '1035'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNsyECQIAMFrmw=
+      - K6IMGH9RIAMF7-Q=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,39 +155,35 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4a9cf7d692d7309a16ebde15ef85ff54.cloudfront.net (CloudFront)
+      - 1.1 2f7eec78b53c7625bd656dcd08ed1823.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - QKEb4L1EwDLLMZ_b83XboA09qvGfP58cO--XygUnyYGCkT0OHWE6OA==
+      - NG4p14mac4P70ihWeY9RN5vNS8ou2zU8REH0TdWscfMN3f04CrV9MQ==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"Issues
-        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:44 GMT
+  recorded_at: Tue, 31 Jul 2018 19:36:45 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
-        have so much coverage.","titleName":"Science","pubType":"Journal","isPeerReviewed":true,"publisherName":"American
-        Association for the Advancement of Science","edition":null,"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","url":"http://www.ebsco.com"}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"We
+        have so much coverage.","titleName":"Update a managed title name 3","pubType":"Newspaper","isPeerReviewed":false,"publisherName":"test
+        publisher","edition":"5","description":"Test Description","url":"https://test","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -214,13 +206,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       X-Amzn-Requestid:
-      - 80a710be-44e2-11e8-9e8e-031a9cd1d096
+      - 0f26f9c4-94f9-11e8-b73c-a10c7a908147
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNs2F0eIAMF4rQ=
+      - K6IMIFwgoAMFddQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -232,29 +224,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 74f392c3bbde3f12fab5155d1847c2cd.cloudfront.net (CloudFront)
+      - 1.1 da6fd4689552fc29462fc5d11b2e27dd.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 8TP1MmR8xBy-S3G3oC8-4bhi3Ay0c7BLG0-PUlc1FLVyCsQRHryOCg==
+      - 8LTC30rnfpdfS7H7i_-D2d1-S5bJVw9-ksGNSaD3E-SH7eAsm8XvcA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:44 GMT
+  recorded_at: Tue, 31 Jul 2018 19:36:45 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -273,19 +265,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2170'
+      - '1060'
       Connection:
       - keep-alive
       Date:
-      - Fri, 20 Apr 2018 21:33:45 GMT
+      - Tue, 31 Jul 2018 19:36:46 GMT
       X-Amzn-Requestid:
-      - 80d52561-44e2-11e8-8a1c-5b15c667b33b
+      - 0f5052e2-94f9-11e8-99f9-6be7c0557aef
       X-Amzn-Remapped-Content-Length:
-      - '2170'
+      - '1060'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FqNs5FW9IAMFiGQ=
+      - K6IMLHydIAMF6DQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -297,24 +289,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 20 Apr 2018 21:33:44 GMT
+      - Tue, 31 Jul 2018 19:36:45 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 2d357730b9d8c4fff788ffa9b0881e8f.cloudfront.net (CloudFront)
+      - 1.1 b5434ae2f27f51f7ce619d0889d77d8d.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - e4Z469ORSU8b6Q2yuLJMADm0p_FbKho4OC9SNQWEZvZamDkQKsumBw==
+      - AMnX39M8XcJDD0XJoRIiRj_kZGovQLi6ICKiBGaXkWvhoCOz8XK6Cg==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 20 Apr 2018 21:33:45 GMT
+  recorded_at: Tue, 31 Jul 2018 19:36:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-contributors.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-contributors.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Mon, 23 Apr 2018 19:46:09 GMT
+      - Tue, 31 Jul 2018 19:57:21 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 361741us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 44395us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 312261us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44806us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 547740/configurations
+      - 358876/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+  recorded_at: Tue, 31 Jul 2018 19:57:21 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2170'
+      - '1063'
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 19:46:09 GMT
+      - Tue, 31 Jul 2018 19:57:21 GMT
       X-Amzn-Requestid:
-      - f83e737a-472e-11e8-89f6-8dbaa70bd4fc
+      - efe9f71a-94fb-11e8-ab24-3304496385a6
       X-Amzn-Remapped-Content-Length:
-      - '2170'
+      - '1063'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - Fz2wNH8PIAMF7uw=
+      - K6LNRGfWIAMFgZg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,40 +155,37 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 19:46:09 GMT
+      - Tue, 31 Jul 2018 19:57:21 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 00869352a9ca097c8b9084cf3a6e32d8.cloudfront.net (CloudFront)
+      - 1.1 45fb37f23f8c197bc04619b2c1f97347.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 2n10B9_23rjbf7JsSXKf6ZJv6BG38GbOkCjK1Zskjo_6myUR_u95Cw==
+      - 1m1A-SmsZRuPk34Bqh-nxNmyzhYhM_LxkJ3_Hvs4AkWN5i7WfcTHsQ==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Only
+        1990s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+  recorded_at: Tue, 31 Jul 2018 19:57:21 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"some
-        type","contributor":"Lang Z"},{"type":"Illustrator","contributor":"last first"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
-        have so much coverage.","titleName":"Science","pubType":"Journal","isPeerReviewed":true,"publisherName":"American
-        Association for the Advancement of Science","edition":null,"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","url":"http://www.ebsco.com"}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":[{"type":"some
+        type","contributor":"Lang Z"},{"type":"Illustrator","contributor":"last first"}],"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"Only
+        1990s issues available.","titleName":"Update a managed title name 3","pubType":"Newspaper","isPeerReviewed":false,"publisherName":"test
+        publisher","edition":"5","description":"Test Description","url":"https://test","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -215,15 +208,15 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 19:46:09 GMT
+      - Tue, 31 Jul 2018 19:57:22 GMT
       X-Amzn-Requestid:
-      - f85d1eee-472e-11e8-bce0-f52a1487f1c3
+      - f02b1ee0-94fb-11e8-9fa1-2f7fc8076186
       X-Amzn-Remapped-Content-Length:
       - '77'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - Fz2wPGcCIAMFgRA=
+      - K6LNVEviIAMFYNw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -235,18 +228,18 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 19:46:09 GMT
+      - Tue, 31 Jul 2018 19:57:21 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 6b55f12026efe25ff5fb4b22b811b2c6.cloudfront.net (CloudFront)
+      - 1.1 2d920921fd72ecf9e944294f2e48d5d1.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - eGgvLy1zLjKqXHXpgSl7zmTHzwZhSH5l-ZoHC-4x7kMJmGm2EwDsPg==
+      - k4glTbiLYVvySJE9CQmTXM55uiIs1dWX1IFQntDmFLMfisb3Agkrqw==
     body:
       encoding: UTF-8
       string: '{"Errors":[{"Code":1006,"Message":"Attribute Type is invalid.","SubCode":0}]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:46:09 GMT
+  recorded_at: Tue, 31 Jul 2018 19:57:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id-length.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id-length.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:12 GMT
+      - Tue, 31 Jul 2018 19:38:59 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +35,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 978us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42294us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 1503us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 42680us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 269207/configurations
+      - 349433/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:12 GMT
+  recorded_at: Tue, 31 Jul 2018 19:38:59 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1060'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:13 GMT
+      - Tue, 31 Jul 2018 19:38:59 GMT
       X-Amzn-Requestid:
-      - 950ffe6d-4a5c-11e8-8c83-8df4f358acf3
+      - 5ee87452-94f9-11e8-89dc-01d6ae190d73
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1060'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL41E4XoAMFjUA=
+      - K6IhCGzWoAMFf3g=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,24 +155,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:13 GMT
+      - Tue, 31 Jul 2018 19:38:59 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b092cc2c048e7d189923dd32e59550c7.cloudfront.net (CloudFront)
+      - 1.1 ac3474fe463b33f1439c8d949f9a075f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - CjhhGZWM61a5vuCnZcreaa3H1Qmd8CQBxnJ7QV5vWZGO4v_pG_jRFA==
+      - QHAe3Q_HhttbsgbcHmoSMjfSc4Zp-QZvwkzf5UFrILPgHFdVImwfig==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:13 GMT
+  recorded_at: Tue, 31 Jul 2018 19:38:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-id.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:09 GMT
+      - Tue, 31 Jul 2018 19:38:58 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +35,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 355817us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 54249us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 310925us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45568us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 831187/configurations
+      - 860210/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:09 GMT
+  recorded_at: Tue, 31 Jul 2018 19:38:58 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1060'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:11 GMT
+      - Tue, 31 Jul 2018 19:38:59 GMT
       X-Amzn-Requestid:
-      - 938cba36-4a5c-11e8-81df-63ff41ea76b1
+      - 5ea354ab-94f9-11e8-a3c1-0d9888238386
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1060'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL4bFV6oAMF7GQ=
+      - K6Ig-GTNoAMFYNA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,24 +155,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:10 GMT
+      - Tue, 31 Jul 2018 19:38:59 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a576c90d056b9a2e1f473050b2981523.cloudfront.net (CloudFront)
+      - 1.1 55157b979573d984aaf7e9e716d67a4a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 2JVpjDNWcZkWC_lZZaSlMun8e5oOHf8IGnXKWxYvMLnFocLDvlXGEw==
+      - QytQAHaOc-AB0waGJtWV7Ygwkt3f_AMGO2jYgkxTqgOtPDKouqQg6A==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:12 GMT
+  recorded_at: Tue, 31 Jul 2018 19:38:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-type.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-invalid-identifier-type.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:15 GMT
+      - Tue, 31 Jul 2018 19:42:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,10 +35,10 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1435us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 41953us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 304892us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44412us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 362881/configurations
+      - 849071/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:15 GMT
+  recorded_at: Tue, 31 Jul 2018 19:42:00 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1060'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:17 GMT
+      - Tue, 31 Jul 2018 19:42:00 GMT
       X-Amzn-Requestid:
-      - 9742e3c1-4a5c-11e8-b3b3-0d0933261956
+      - caf03f93-94f9-11e8-9aaa-efba7a8e0681
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1060'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL5ZFaYoAMF46w=
+      - K6I9XHVfIAMFy8w=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,24 +155,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:17 GMT
+      - Tue, 31 Jul 2018 19:42:00 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 2ecaa1674cb37ba76f1ab4f97b45f4c2.cloudfront.net (CloudFront)
+      - 1.1 8fffcdedc691b0191a3ea5a8f72d87d8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - o8GPUHBh9mGeuo0nNdaJ59XOGUcgyAsy9dLlMjTJx1aBquEh7UIBxA==
+      - Fhnov6TeIp9uipRXPZV-1zzZkQuW1w1HcZfZUFWeawU-uTOyGJgEew==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:17 GMT
+  recorded_at: Tue, 31 Jul 2018 19:42:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-missing-identifier-id.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-missing-identifier-id.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:13 GMT
+      - Tue, 31 Jul 2018 19:39:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1107us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42008us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 308495us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45275us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 992872/configurations
+      - '049281/configurations'
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:13 GMT
+  recorded_at: Tue, 31 Jul 2018 19:39:55 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1060'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:15 GMT
+      - Tue, 31 Jul 2018 19:39:56 GMT
       X-Amzn-Requestid:
-      - 9643007a-4a5c-11e8-a5f4-bfe41b4c997d
+      - 8090a290-94f9-11e8-9329-3fcd944d90b7
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1060'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL5JF_doAMFo8w=
+      - K6Ip3F_CoAMFTQw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,24 +155,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:15 GMT
+      - Tue, 31 Jul 2018 19:39:55 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 e8211ae0170c9ccd38bcd06c168293e9.cloudfront.net (CloudFront)
+      - 1.1 ded72cd2ec35ccfc935b5442dfad81c9.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - KXL6VSFvbxOY9qwxA5IY4iO3YGTmd7lddVoDRDrTuFlsUvoI1Jf-5g==
+      - YICPJnEr7KfHEJd1uBJEhQ5wBhPu61RJ6hcI5hSu4r6e_QxBnVqclA==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update a managed title name 3","publisherName":"test
+        publisher","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Newspaper","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":41000819,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"We
+        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://test","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Test
+        Description","edition":"5","isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:15 GMT
+  recorded_at: Tue, 31 Jul 2018 19:39:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-name.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-name.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Thu, 12 Apr 2018 23:50:53 GMT
+      - Mon, 30 Jul 2018 20:46:25 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 356102us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42447us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 1831us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45607us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.36.4.1
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.36.4.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - '045958/configurations'
+      - 710094/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:50:53 GMT
+  recorded_at: Mon, 30 Jul 2018 20:46:25 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2171'
+      - '1285'
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:50:53 GMT
+      - Mon, 30 Jul 2018 20:46:25 GMT
       X-Amzn-Requestid:
-      - 564fd787-3eac-11e8-9527-c1e0ae3f0d0c
+      - a0249a76-9439-11e8-a04a-ff9f280c93da
       X-Amzn-Remapped-Content-Length:
-      - '2171'
+      - '1285'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKSqGPFoAMFpcg=
+      - K2_dPFrJoAMFVDw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,36 +155,34 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:50:53 GMT
+      - Mon, 30 Jul 2018 20:46:25 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 26323e33c40f7d3c5faf3b27606bb0b1.cloudfront.net (CloudFront)
+      - 1.1 3182c21f2ee69ff40cfaf404637c649f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - XCHR8dIkfUy3kMtMtUY8j3_GB5Fep0sGpZ_l-iNjhy4pOfFosklq9Q==
+      - EwsSqEkPBfi95BEgZw0PfhJ2AJBR09zgy6yOeAiN_tTzfKttYlBb8Q==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38132917,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
-        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"sd-test-4","publisherName":"SD Publishing","identifiersList":[{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":2,"type":0}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"SD1"},{"type":"author","contributor":"SD2"},{"type":"illustrator","contributor":"SD3"}]}'
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:50:53 GMT
+  recorded_at: Mon, 30 Jul 2018 20:46:25 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"coverageStatement":"Issues
-        on or after 6/1/1992","titleName":"I have a great new title name","pubType":"Journal"}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"","titleName":"I
+        have a great new title name","pubType":"Book","isPeerReviewed":true,"publisherName":"SD
+        Publishing","edition":"4","description":"This is a book","url":"http://hello.hello","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -211,13 +205,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:50:54 GMT
+      - Mon, 30 Jul 2018 20:46:26 GMT
       X-Amzn-Requestid:
-      - 569c22c6-3eac-11e8-b55f-a9923b8ccf8e
+      - a03c4032-9439-11e8-b740-03f28e575b56
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKSvFhXoAMF23A=
+      - K2_dRHgpIAMF0Sw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -229,29 +223,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:50:54 GMT
+      - Mon, 30 Jul 2018 20:46:25 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 04548871feef153485c789be4f01c614.cloudfront.net (CloudFront)
+      - 1.1 a170a9e8f9393700a8de4715a0943846.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - A_dlAzwAgO5acChlkehVhRemVAi-akQuqGAvlrp3ip4sTBAKARb1JA==
+      - FAOtjIrNnY3helGVOT36K296_RdmxO-B_Jm3UzXKdjTzFPH367v0kA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:50:55 GMT
+  recorded_at: Mon, 30 Jul 2018 20:46:26 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -270,19 +264,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2146'
+      - '1032'
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:50:56 GMT
+      - Mon, 30 Jul 2018 20:46:26 GMT
       X-Amzn-Requestid:
-      - 57bed06d-3eac-11e8-a809-6535de2ed560
+      - a07aa93f-9439-11e8-88f5-43686881b6ba
       X-Amzn-Remapped-Content-Length:
-      - '2146'
+      - '1032'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKTCGNroAMFR1g=
+      - K2_dVHJuIAMFqZg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -294,24 +288,22 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:50:56 GMT
+      - Mon, 30 Jul 2018 20:46:25 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4ee5063dc9b3d6f9bda9588d4fd84fe7.cloudfront.net (CloudFront)
+      - 1.1 e848f30e8d63b5f324e9295182b986ef.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - htLZ-RCbi2pSmdRxLtNrbnflXJ-IZ6VYsHymqdefdrXFXECzegv1cA==
+      - GTz10B-x05KsSZvKUX9F0YSXMjQLXPkdeNFGFsqoJPXLptxxkTEvWA==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
-        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:50:56 GMT
+  recorded_at: Mon, 30 Jul 2018 20:46:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-pubtype.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-pubtype.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Thu, 12 Apr 2018 23:52:32 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 357708us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 44425us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 376230us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 68035us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.3.1
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.36.3.1
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 731494/configurations
+      - 146145/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:52:32 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:36 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2146'
+      - '1032'
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:52:33 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Amzn-Requestid:
-      - 91625dc6-3eac-11e8-9117-99097ba1fc40
+      - 11c0ebff-943a-11e8-9541-7516c9dfee76
       X-Amzn-Remapped-Content-Length:
-      - '2146'
+      - '1032'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKiJGZhIAMFUrw=
+      - K2_7BHzTIAMFuEg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,36 +155,35 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:52:33 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 00a1d8f37a58e42d70fb6d319f45045f.cloudfront.net (CloudFront)
+      - 1.1 53639ba6f1000a6a161851e05908fd9b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 4ryc0LNpcq_tgzZJFM3M6TmZSTrx8IvSIKms8yMgsnzSSEzBv_4XwA==
+      - tja7q3w9J95XgAMViCN6f14BtEEUjbwFluz7ODiW_JS4etaRpTmEiQ==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
-        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:52:34 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:36 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"coverageStatement":"Issues
-        on or after 6/1/1992","titleName":"Science","pubType":"bookseries"}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"","titleName":"I
+        have a great new title name","pubType":"bookseries","isPeerReviewed":true,"publisherName":"SD
+        Publishing","edition":"4","description":"This is a book","url":"http://hello.hello","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -211,13 +206,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:52:34 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Amzn-Requestid:
-      - 92192b42-3eac-11e8-bba7-5dc53c66443a
+      - 11d70c73-943a-11e8-af01-53fe348ac72b
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKiVHUJIAMFUOA=
+      - K2_7DFztoAMFXeA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -229,29 +224,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:52:33 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 07c2fea6c74337bcf89c265be034efcf.cloudfront.net (CloudFront)
+      - 1.1 707d06343c7b07a529839efb71fdb71b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - GjhiUDXyzBfyMus5JfvQ3Bb9o3DEE0PMMF6BRWAPwvsVTLTGd4w8XA==
+      - CVMqC--poq0Dxn4H9BWH_bs1MBNz7LONIsOiLbzl4A6JpRyszLibPg==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:52:34 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:36 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -270,19 +265,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2146'
+      - '1038'
       Connection:
       - keep-alive
       Date:
-      - Thu, 12 Apr 2018 23:52:34 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Amzn-Requestid:
-      - 92565b0b-3eac-11e8-9c28-050e8ee42bfa
+      - 1211a432-943a-11e8-a180-8568faf22abb
       X-Amzn-Remapped-Content-Length:
-      - '2146'
+      - '1038'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FQKiZEG0oAMFZFA=
+      - K2_7GGsvIAMFpCg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -294,24 +289,22 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Thu, 12 Apr 2018 23:52:33 GMT
+      - Mon, 30 Jul 2018 20:49:36 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 17470a7b5423b241c1cc9b628ff10667.cloudfront.net (CloudFront)
+      - 1.1 8fffcdedc691b0191a3ea5a8f72d87d8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - dXwB-qpCFJETj1ckd1e4TBIv72q78towaRYZNiMOWhx2OSTouiOYeg==
+      - xrAUiEbN3VHQS2S5eDgapRoqWmIB9nxmyUVa36_V8aW8eNDCPvPDEQ==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"Issues
-        on or after 6/1/1992","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Days","embargoValue":1},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"BookSeries","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 23:52:34 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-contributors.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-contributors.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Mon, 23 Apr 2018 19:40:49 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 354562us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42711us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 1690us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43159us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-For:
-      - 10.128.0.4
+      - 10.128.0.5
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 129938/configurations
+      - 314585/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:40:49 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:37 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2170'
+      - '1038'
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       X-Amzn-Requestid:
-      - 39ecadb6-472e-11e8-bc48-43bbacffacb6
+      - 1299e672-943a-11e8-83c1-6d2e1427e7d7
       X-Amzn-Remapped-Content-Length:
-      - '2170'
+      - '1038'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - Fz1-UEnJoAMFbFg=
+      - K2_7PE9eIAMFjkg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,40 +155,36 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c06c27c7288c4be29d3b21ad2efad59f.cloudfront.net (CloudFront)
+      - 1.1 15b0145f4a440167477203d93c9e877a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - Hwf9W9bFyYDN3fxN62M1ylAtSAhLrotXYn7PaIErDsjD1QwhBE69mA==
+      - 99uYwVuBOQNxhElNb0LKBneAY3w5fUuIWq_yTsJ9f2wVegnmUdtrKA==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"BookSeries","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:37 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":[{"type":"Editor","contributor":"Lang
-        Z"},{"type":"Illustrator","contributor":"last first"}],"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
-        have so much coverage.","titleName":"Science","pubType":"Journal","isPeerReviewed":true,"publisherName":"American
-        Association for the Advancement of Science","edition":null,"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","url":"http://www.ebsco.com"}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":[{"type":"Editor","contributor":"Lang
+        Z"},{"type":"Illustrator","contributor":"last first"}],"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"","titleName":"I
+        have a great new title name","pubType":"BookSeries","isPeerReviewed":true,"publisherName":"SD
+        Publishing","edition":"4","description":"This is a book","url":"http://hello.hello","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -215,13 +207,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       X-Amzn-Requestid:
-      - 3a10142d-472e-11e8-997b-151e71eb83eb
+      - 12b16667-943a-11e8-acdd-599a0d3a142e
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - Fz1-XF8xIAMFRDA=
+      - K2_7RGBUIAMFRZA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -233,29 +225,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 28b1b9930ccdd3e560b3f8d56677a679.cloudfront.net (CloudFront)
+      - 1.1 da6fd4689552fc29462fc5d11b2e27dd.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xKmSMlkKiMXOCrVVgq0FDGDqPnibaO1xouBux0XIy3MEqDEIAvFUWQ==
+      - 8m_AfkC8yHdeW1SfGNLblsL3Sh1PCvaOdlwP0Ga_KHiUdTla10Xuiw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:38 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -274,19 +266,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2170'
+      - '1128'
       Connection:
       - keep-alive
       Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       X-Amzn-Requestid:
-      - 3a4b48ed-472e-11e8-a454-79291a64e2df
+      - 12e854b6-943a-11e8-badc-c34fa7c9e29c
       X-Amzn-Remapped-Content-Length:
-      - '2170'
+      - '1128'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - Fz1-aFdZoAMFh9Q=
+      - K2_7VGFboAMFYRg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -298,24 +290,23 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Mon, 23 Apr 2018 19:40:50 GMT
+      - Mon, 30 Jul 2018 20:49:37 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 89cb9fcdbd0314a45e84448b824c18db.cloudfront.net (CloudFront)
+      - 1.1 53639ba6f1000a6a161851e05908fd9b.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - uZGl8UOR_51GIexWZ0XG1adqOHM_FFbkbE-bIjjnQL90FA2UC9j3cw==
+      - I1nfvhI8_OsyVIeFu2uFt5Pj9WqpbAr0BPtWcuNGNyVf_VLm_6BqTw==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":38202027,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":"http://www.ebsco.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"BookSeries","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"Lang
+        Z"},{"type":"illustrator","contributor":"last first"}]}'
     http_version: 
-  recorded_at: Mon, 23 Apr 2018 19:40:50 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:38 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-subtypes.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-subtypes.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:22 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 358353us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42386us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 2311us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43484us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.3.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.3.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 874728/configurations
+      - 870121/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:22 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:39 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1184'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:23 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Amzn-Requestid:
-      - 9b5ab5e8-4a5c-11e8-b6bd-8f64ab6d982c
+      - 13eccd16-943a-11e8-b513-3398e5ed0b4b
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1184'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL6eF4SIAMF4UA=
+      - K2_7mH-9oAMFtnA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,40 +155,35 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:23 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 003d7c1b393a4f2391f49338ba13b47b.cloudfront.net (CloudFront)
+      - 1.1 a170a9e8f9393700a8de4715a0943846.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - XQ_yy4jc1gBt6us6sfNsly0JkGFS_NtzOMjXHA8y8nwV2vZyoGKV7Q==
+      - 6mULEeyZ7Vvix5YPPmBPlFzHayYmiwngfMxZnwVwym-v2v3av7rxMw==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update Custom Title Testing Valid
+        Identifier Types","publisherName":"SD Publishing","identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:24 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:39 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":null,"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
-        have so much coverage.","titleName":"New Custom Title Testing Valid Identifier
-        SubTypes","pubType":"book","isPeerReviewed":true,"publisherName":"American
-        Association for the Advancement of Science","edition":null,"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","url":null}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":null,"identifiersList":[{"id":"12345","subtype":1,"type":0},{"id":"12345","subtype":2,"type":1}],"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"","titleName":"New
+        Custom Title Testing Valid Identifier SubTypes","pubType":"book","isPeerReviewed":true,"publisherName":"SD
+        Publishing","edition":"4","description":"This is a book","url":"http://hello.hello","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -215,13 +206,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:25 GMT
+      - Mon, 30 Jul 2018 20:49:40 GMT
       X-Amzn-Requestid:
-      - 9c2c36b7-4a5c-11e8-8920-b73fa89882a8
+      - 140361d8-943a-11e8-83c1-6d2e1427e7d7
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL6sGpCIAMF8pg=
+      - K2_7nFGzoAMFjkg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -233,29 +224,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:25 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c17d987ff5ce8137613fd33ef9ba83cb.cloudfront.net (CloudFront)
+      - 1.1 8b80cfad007948900303ef793b88e687.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - sewaVdeltORzMOjFPRLtHaG46-_YfEPCjQTnDpSXjSUAOogbg460Qg==
+      - Ddjc-HDIOMh_6i5_fJxknw2Nst4Bim3RV38n3BxonpQd065PZ6zewA==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:25 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:40 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -274,19 +265,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1184'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:26 GMT
+      - Mon, 30 Jul 2018 20:49:40 GMT
       X-Amzn-Requestid:
-      - 9d0383bb-4a5c-11e8-9219-432559289b6a
+      - 1427da0a-943a-11e8-82c9-8f9250edbb96
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1184'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL66F-DoAMFmxQ=
+      - K2_7pF3eIAMFrrw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -298,24 +289,22 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:26 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 26d8fa99acc1b4ab3c750b71faab71a1.cloudfront.net (CloudFront)
+      - 1.1 b5434ae2f27f51f7ce619d0889d77d8d.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - p_1-PQnewu8J0Dqk7jJLL4p3mpqCiXmG8sdhCb5GtT9gLZZVkMNJsg==
+      - ucH7Zqa0tukBsGO9drXyHVah_dMU5BKAdHtQzDNws5vD053B7gmC6g==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"New Custom Title Testing Valid Identifier
+        SubTypes","publisherName":"SD Publishing","identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:27 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-types.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-resource-valid-identifier-types.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Fri, 27 Apr 2018 20:50:17 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 1186us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 42570us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 1879us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43167us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-For:
-      - 10.128.0.5
+      - 10.128.0.4
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 871433/configurations
+      - 625762/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,16 +103,16 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:17 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:38 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1128'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:18 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       X-Amzn-Requestid:
-      - 98388e58-4a5c-11e8-8b23-e9ddb6806052
+      - 13506570-943a-11e8-a4ac-bf30e53bebba
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1128'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL5qFq5oAMFjeg=
+      - K2_7bH1eoAMFdDA=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,40 +155,36 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:18 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 c6b63d687e90622c9c3a2477b537ca25.cloudfront.net (CloudFront)
+      - 1.1 a7dda29620c2fec27c03f7bf6c406fc0.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - YFx4GxNUnDwPodNZ0X6qUE7MElCHUQjvP2xlOVa78eeNOk48hX6uHw==
+      - sSY86zXx69dWDS5Zk2O-9zVVYZ4MI0jqEnHs0xwEFAltkQGJce9ieA==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"I have a great new title name","publisherName":"SD
+        Publishing","identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"BookSeries","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[{"type":"editor","contributor":"Lang
+        Z"},{"type":"illustrator","contributor":"last first"}]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:18 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:38 GMT
 - request:
     method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"contributorsList":null,"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"coverageStatement":"We
-        have so much coverage.","titleName":"Update Custom Title Testing Valid Identifier
-        Types","pubType":"book","isPeerReviewed":true,"publisherName":"American Association
-        for the Advancement of Science","edition":null,"description":"Contains peer-reviewed
-        articles, original research reports, a news section, editorials, letters,
-        and book reviews on timely science-related topics.","url":null}'
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"contributorsList":null,"identifiersList":[{"id":"12345","subtype":1,"type":0},{"id":"12345","subtype":1,"type":1}],"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"","titleName":"Update
+        Custom Title Testing Valid Identifier Types","pubType":"book","isPeerReviewed":true,"publisherName":"SD
+        Publishing","edition":"4","description":"This is a book","url":"http://hello.hello","proxy":{"id":"\u003cn\u003e","inherited":false}}'
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -215,13 +207,13 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:20 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Amzn-Requestid:
-      - 990776dd-4a5c-11e8-a2b5-55a8ebb0ed33
+      - 13688129-943a-11e8-8168-fdbcd35d2757
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL53EPHoAMFucg=
+      - K2_7dGWGIAMFidw=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -233,29 +225,29 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:20 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 415c421af891d7c3f4ade60aba542014.cloudfront.net (CloudFront)
+      - 1.1 2d357730b9d8c4fff788ffa9b0881e8f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fjxqQa-2mGpqFHQZB3c5VWzo6iOke0kToGIfMN8s8nJQRCf4OP5E8w==
+      - r0z1FTws2-doiQQkrLOrFSVVt1lw12SY-ByvpR8xkBFcKts5UGMATw==
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:20 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:39 GMT
 - request:
     method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845510/titles/62477
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2843714/titles/17059805
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -274,19 +266,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '2145'
+      - '1184'
       Connection:
       - keep-alive
       Date:
-      - Fri, 27 Apr 2018 20:50:21 GMT
+      - Mon, 30 Jul 2018 20:49:39 GMT
       X-Amzn-Requestid:
-      - 99de76ca-4a5c-11e8-8f7d-eb7995e4ce44
+      - 13a34052-943a-11e8-b194-ad0a6043e7a7
       X-Amzn-Remapped-Content-Length:
-      - '2145'
+      - '1184'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - GBL6FEdFoAMFV4Q=
+      - K2_7hFW0IAMFlWQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -298,24 +290,22 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Fri, 27 Apr 2018 20:50:21 GMT
+      - Mon, 30 Jul 2018 20:49:38 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 bd90da9254f31df3f30a30f180fba558.cloudfront.net (CloudFront)
+      - 1.1 001e3d2e0977f947f2e93be8539ac1de.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 6eJL5VIMzn7aGLPGE8i3LMDMvy98fIn9bGY2uZ34fm3W_EY6Og29lQ==
+      - oPlQHt5I9LIfXv0E37ytYskJo13zZV5eCNCncWZ-wegQymtK47tD2g==
     body:
       encoding: UTF-8
-      string: '{"titleId":62477,"titleName":"Science","publisherName":"American Association
-        for the Advancement of Science","identifiersList":[{"id":"0036-8075","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"01644869","source":"ResourceIdentifier","subtype":0,"type":2},{"id":"036991008","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"101727","source":"ResourceIdentifier","subtype":0,"type":4},{"id":"1095-9203","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"1496749","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"62477","source":"AtoZ","subtype":0,"type":9},{"id":"803597004","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597343","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803597355","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"803916717","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804167179","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"804240125","source":"ResourceIdentifier","subtype":0,"type":3},{"id":"SCI","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Science
-        (General)"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":62477,"packageId":2845510,"packageName":"\"Testing2\"","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
-        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2004-01-01"}],"coverageStatement":"We
-        have so much coverage.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":"Weeks","embargoValue":6},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Contains
-        peer-reviewed articles, original research reports, a news section, editorials,
-        letters, and book reviews on timely science-related topics.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+      string: '{"titleId":17059805,"titleName":"Update Custom Title Testing Valid
+        Identifier Types","publisherName":"SD Publishing","identifiersList":[{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"12345","source":"ResourceIdentifier","subtype":1,"type":1}],"subjectsList":[],"isTitleCustom":true,"pubType":"Book","customerResourcesList":[{"titleId":17059805,"packageId":2843714,"packageName":"SD''s
+        test package in TEST_CUSTOMER_ID","packageType":"Custom","proxy":{"id":"<n>","inherited":true},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":40526977,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-12"}],"coverageStatement":"","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://hello.hello","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"This
+        is a book","edition":"4","isPeerReviewed":true,"contributorsList":[]}'
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 20:50:21 GMT
+  recorded_at: Mon, 30 Jul 2018 20:49:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Wed, 18 Apr 2018 04:03:13 GMT
+      - Tue, 31 Jul 2018 20:02:46 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,16 +35,16 @@ http_interactions:
       Connection:
       - keep-alive
       X-Okapi-Trace:
-      - 'GET mod-authtoken-1.4.1-SNAPSHOT.20 http://10.39.249.72:8081/configurations/entries..
-        : 202 403708us'
-      - 'GET mod-configuration-4.0.3-SNAPSHOT.29 http://10.39.252.104:8081/configurations/entries..
-        : 200 43430us'
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 306854us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44130us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.36.4.1
+      - 10.128.0.3
       X-Forwarded-For:
-      - 10.36.4.1
+      - 10.128.0.3
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,15 +66,11 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 569831/configurations
+      - 963202/configurations
       X-Okapi-Url:
-      - http://10.39.243.220:80
-      X-Okapi-Permissions-Required:
-      - configuration.entries.collection.get
-      X-Okapi-Module-Permissions:
-      - '{"mod-authtoken-1.4.1-SNAPSHOT.20":["perms.users.get"]}'
+      - http://10.39.254.87:80
       X-Okapi-Permissions:
-      - '["configuration.entries.collection.get"]'
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
       X-Okapi-User-Id:
       - 1ad737b0-d847-11e6-bf26-cec0c932ce01
       X-Okapi-Token:
@@ -86,7 +82,7 @@ http_interactions:
       string: |-
         {
           "configs" : [ {
-            "id" : "9f193b46-4cc5-4c99-b09f-374fe5415673",
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
             "module" : "KB_EBSCO",
             "configName" : "api_credentials",
             "code" : "kb.ebsco.credentials",
@@ -94,9 +90,9 @@ http_interactions:
             "enabled" : true,
             "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
             "metadata" : {
-              "createdDate" : "2018-03-28T14:49:56.794+0000",
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
               "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-              "updatedDate" : "2018-03-28T14:49:56.794+0000",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
               "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
             }
           } ],
@@ -107,7 +103,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
+  recorded_at: Tue, 31 Jul 2018 20:02:46 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
@@ -116,7 +112,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.5.5
+      - Flexirest/1.6.7
       Connection:
       - Keep-Alive
       Accept:
@@ -135,19 +131,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1227'
+      - '1217'
       Connection:
       - keep-alive
       Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
+      - Tue, 31 Jul 2018 20:02:46 GMT
       X-Amzn-Requestid:
-      - 6ac72bd3-42bd-11e8-8ad1-2907b8b65f37
+      - b16a1902-94fc-11e8-bd7c-c7996ee1b7ed
       X-Amzn-Remapped-Content-Length:
-      - '1227'
+      - '1217'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - FhN8WExdIAMFg-Q=
+      - K6L__EYCIAMF4eQ=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -159,156 +155,21 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
+      - Tue, 31 Jul 2018 20:02:46 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 9e9659bd2cd38b362d54042306676bd4.cloudfront.net (CloudFront)
+      - 1.1 93e404430d11dacb3232bae72aaaee90.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - wlRPDVNeQdc7uIbTlGGrE1X-ftq9Hf4Ad0eudGLCfEtAV_c7NiFtgw==
+      - sK_cY1nFWoBx6rG2kg8lKEI704fqbSYCU90xBWPmx3315bbeWtBIrw==
     body:
       encoding: UTF-8
       string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
         the World","publisherName":"ABS Energy Research","identifiersList":[{"id":"15KM","source":"MFS","subtype":0,"type":8},{"id":"417981","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Electrical
         Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
-        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
-- request:
-    method: put
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
-    body:
-      encoding: UTF-8
-      string: '{"isSelected":true,"isHidden":true,"customCoverageList":[],"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":null,"titleName":"ESI:
-        Electrical Supply Industries of the World","pubType":"BookSeries","isPeerReviewed":false,"publisherName":"ABS
-        Energy Research","edition":null,"description":null,"url":null}'
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '0'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
-      X-Amzn-Requestid:
-      - 6ae16aae-42bd-11e8-8d94-0d0619c2741b
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - FhN8YFQmoAMF72A=
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 881f5449ef82fbe0a0cb15b728b80579.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - wErngAHnPatDAsxETKRSh6Fn2WvTfIwGFe37N2vIYTksxaNMwG2UBQ==
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
-- request:
-    method: get
-    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Flexirest/1.5.5
-      Connection:
-      - Keep-Alive
-      Accept:
-      - application/json
-      X-Api-Key:
-      - TEST_API_KEY
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '1227'
-      Connection:
-      - keep-alive
-      Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
-      X-Amzn-Requestid:
-      - 6b25033a-42bd-11e8-9994-d76265ad28c0
-      X-Amzn-Remapped-Content-Length:
-      - '1227'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Amz-Apigw-Id:
-      - FhN8cEOGIAMFqAg=
-      X-Amzn-Remapped-Server:
-      - Microsoft-IIS/8.5
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      X-Powered-By:
-      - ASP.NET
-      Pragma:
-      - no-cache
-      X-Amzn-Remapped-Date:
-      - Wed, 18 Apr 2018 04:03:14 GMT
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 1a912d612b879ef62d1eb2f875df3326.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - ysmis19QW43VNrGAxDXfEqmEx3hIaEno-PFzBbAXpWbCiGxu3DWHYg==
-    body:
-      encoding: UTF-8
-      string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
-        the World","publisherName":"ABS Energy Research","identifiersList":[{"id":"15KM","source":"MFS","subtype":0,"type":8},{"id":"417981","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Electrical
-        Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
-        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
-        by EP"},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
-    http_version: 
-  recorded_at: Wed, 18 Apr 2018 04:03:14 GMT
+  recorded_at: Tue, 31 Jul 2018 20:02:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/custom_resources_spec.rb
+++ b/spec/requests/custom_resources_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-name') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -54,7 +54,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-pubtype') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -195,7 +195,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-coverage-statement') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -236,7 +236,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-valid-contributors') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -283,7 +283,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-invalid-contributors') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -316,7 +316,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-invalid-identifier-id') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -356,7 +356,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-invalid-identifier-id-length') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -394,7 +394,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-missing-identifier-id') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -433,7 +433,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-invalid-identifier-type') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -477,7 +477,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-valid-identifier-types') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -530,7 +530,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-invalid-identifier-type') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end
@@ -574,7 +574,7 @@ RSpec.describe 'Custom Resources', type: :request do
 
       before do
         VCR.use_cassette('put-custom-resource-valid-identifier-subtypes') do
-          put '/eholdings/resources/123355-2845510-62477',
+          put '/eholdings/resources/123355-2843714-17059805',
               params: params, as: :json, headers: update_headers
         end
       end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe 'Resources', type: :request do
         end
       end
 
-      describe 'trying to update fields only available to custom resources' do
+      describe 'trying to update fields only available to custom resources on a managed title' do
         let(:params) do
           {
             "data": {
@@ -676,8 +676,24 @@ RSpec.describe 'Resources', type: :request do
           end
         end
 
+        let!(:json) { Map JSON.parse response.body }
+
         it 'responds with OK status' do
-          expect(response).to have_http_status(200)
+          expect(response).to have_http_status(422)
+          expect(json.errors[0].title).to eq 'Invalid titleName'
+          expect(json.errors[0].detail).to eq 'Titlename must be blank'
+          expect(json.errors[1].title).to eq 'Invalid isPeerReviewed'
+          expect(json.errors[1].detail).to eq 'Ispeerreviewed must be blank'
+          expect(json.errors[2].title).to eq 'Invalid pubType'
+          expect(json.errors[2].detail).to eq 'Pubtype must be blank'
+          expect(json.errors[3].title).to eq 'Invalid publisherName'
+          expect(json.errors[3].detail).to eq 'Publishername must be blank'
+          expect(json.errors[4].title).to eq 'Invalid edition'
+          expect(json.errors[4].detail).to eq 'Edition must be blank'
+          expect(json.errors[5].title).to eq 'Invalid description'
+          expect(json.errors[5].detail).to eq 'Description must be blank'
+          expect(json.errors[6].title).to eq 'Invalid url'
+          expect(json.errors[6].detail).to eq 'Url must be blank'
         end
       end
     end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-491, there is an issue in mod-kb updating managed titles, where we provide fields that can be updated only for custom resources and the response is a 200 showing the updated values as passed in the request. However, when we make a GET request on the same `titleId`, we get the correct response. So, the response after PUT request was totally misleading. Fix that in this PR.

## Approach
- Identify based on https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco/eholdings.html#eholdings_resources__resourceid__put what fields can be updated only for custom vs. managed resources.
- Add validations in resource updates to ensure that fields that are not expected are indeed not present in the request body.
- Modify the update method in the resource model to update certain fields in RM API only if they are valid for the custom resource, else skip that step and only deal with updates to managed resource fields.
- Modify associated unit tests accordingly.

## Screenshots
![put_resources](https://user-images.githubusercontent.com/33662516/43487058-6d9f9e10-94e3-11e8-853c-194b7a92c2d7.gif)