### PR TITLE
UIEH-470: Validate filters within packages associated with a provider

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -50,15 +50,21 @@ class ProvidersController < ApplicationController
 
   # Relationships
   def packages
-    @packages = @provider.find_packages(
-      q: params[:q],
-      page: params[:page],
-      filter: params[:filter],
-      sort: params[:sort]
-    )
+    query_params_validation = Validation::ProviderPackagesQueryParameters.new(params)
 
-    render jsonapi: @packages.data,
-           meta: @packages.meta
+    if query_params_validation.valid?
+      @packages = @provider.find_packages(
+        q: params[:q],
+        page: params[:page],
+        filter: params[:filter],
+        sort: params[:sort]
+      )
+      render jsonapi: @packages.data,
+             meta: @packages.meta
+    else
+      render jsonapi_errors: query_params_validation.errors,
+             status: :bad_request
+    end
   end
 
   private

--- a/app/controllers/validation/provider_packages_query_parameters.rb
+++ b/app/controllers/validation/provider_packages_query_parameters.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/VariableName
+
+module Validation
+  class ProviderPackagesQueryParameters
+    include ActiveModel::Validations
+
+    attr_accessor :sortFilter, :selectedFilter,
+                  :contentTypeFilter
+
+    validates :sortFilter, inclusion: { in: %w[name relevance],
+                                        message: 'Invalid Query Parameter for sort' }, allow_nil: true
+    validates :selectedFilter, inclusion: { in: %w[true false ebsco all],
+                                            message: 'Invalid Query Parameter for filter[selected]' }, allow_nil: true
+    validates :contentTypeFilter, inclusion: { in: %w[aggregatedfulltext abstractandindex ebook ejournal print onlinereference unknown all],
+                                               message: 'Invalid Query Parameter for filter[type]' }, allow_nil: true
+
+    def initialize(params = {})
+      filters = params.fetch(:filter, nil)
+      @sortFilter = params[:sort]
+      @selectedFilter = hash?(filters) ? filters[:selected] : filters
+      @contentTypeFilter = hash?(filters) ? filters[:type] : filters
+    end
+
+    private
+
+    def hash?(filters)
+      if filters.respond_to?(:dig)
+        true
+      else
+        false
+      end
+    end
+  end
+end
+# rubocop:enable Naming/VariableName

--- a/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-filter-selected-query-param.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-filter-selected-query-param.yml
@@ -1,0 +1,158 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 01 Aug 2018 19:34:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 304730us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44323us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.2.1
+      X-Forwarded-For:
+      - 10.36.2.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '080618/configurations'
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:34:01 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 01 Aug 2018 19:34:02 GMT
+      X-Amzn-Requestid:
+      - d814364a-95c1-11e8-b7cb-e96cbde3e312
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - K9aulEYMoAMFp8g=
+      X-Amzn-Remapped-Date:
+      - Wed, 01 Aug 2018 19:34:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ec8f42874d3bbbc031b221c7b294c98a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0Os_-uAZFfdxxnoOssOCRr39Fb_4jP4k44kjgv943GpYBd-zYExDvQ==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":false,"packagesSelected":48,"packagesTotal":624,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":false},"vendorToken":null}'
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:34:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-filter-type-query-param.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-filter-type-query-param.yml
@@ -1,0 +1,158 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 01 Aug 2018 19:34:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 1453us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43046us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 720142/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:34:02 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 01 Aug 2018 19:34:02 GMT
+      X-Amzn-Requestid:
+      - d86ba4b0-95c1-11e8-9024-6dcd9652b969
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - K9auqEKXIAMF6og=
+      X-Amzn-Remapped-Date:
+      - Wed, 01 Aug 2018 19:34:02 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a3b69ec39162cbd39675c093fc4e8539.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tLlIJH9ZUTO13YcKTlmdT1lu96LG-8ppJDaQ7u13W8dKrr7zX2z6Wg==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":false,"packagesSelected":48,"packagesTotal":624,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":false},"vendorToken":null}'
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:34:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-sort-query-param.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-related-packages-invalid-sort-query-param.yml
@@ -1,0 +1,158 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 01 Aug 2018 19:31:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 308816us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 42893us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '073085/configurations'
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:31:52 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 01 Aug 2018 19:31:53 GMT
+      X-Amzn-Requestid:
+      - 8b264d80-95c1-11e8-88b0-1989b3be22dd
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - K9aaaFDIIAMF6_w=
+      X-Amzn-Remapped-Date:
+      - Wed, 01 Aug 2018 19:31:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 28d76bff3dfebb2e99b9976fb0b2b6bf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mysRGYTBpYV-oiukeHl8G2K29YS-y0jgtIG7v51xjlM0BFA9_dOX1g==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":false,"packagesSelected":48,"packagesTotal":624,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":false},"vendorToken":null}'
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:31:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -375,9 +375,9 @@ RSpec.describe 'Providers', type: :request do
       let!(:json_query_invalid_filter) { Map JSON.parse response.body }
 
       it 'returns a request error' do
-        error = json_query_invalid_filter.errors.first.title
         expect(response).to have_http_status(400)
-        expect(error).to eq('Invalid filter parameter')
+        expect(json_query_invalid_filter.errors.first.title).to eq('Invalid selectedFilter')
+        expect(json_query_invalid_filter.errors.first.detail).to eq('Selectedfilter Invalid Query Parameter for filter[selected]')
       end
     end
 
@@ -452,6 +452,60 @@ RSpec.describe 'Providers', type: :request do
           p.attributes.name.downcase
         end
         expect(json_query_with_name_sort.data).to eq(sorted_array)
+      end
+    end
+
+    describe 'with an invalid query param sort within packages query' do
+      before do
+        VCR.use_cassette(
+          'search-providers-related-packages-invalid-sort-query-param'
+        ) do
+          get '/eholdings/providers/19/packages?q=ebsco&sort=invalid', headers: okapi_headers
+        end
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'returns a bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Invalid sortFilter')
+        expect(json_f.errors.first.detail).to eql('Sortfilter Invalid Query Parameter for sort')
+      end
+    end
+
+    describe 'with an invalid query param for filter selected within packages query' do
+      before do
+        VCR.use_cassette(
+          'search-providers-related-packages-invalid-filter-selected-query-param'
+        ) do
+          get '/eholdings/providers/19/packages?q=ebsco&filter[selected]=invalid', headers: okapi_headers
+        end
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'returns a bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Invalid selectedFilter')
+        expect(json_f.errors.first.detail).to eql('Selectedfilter Invalid Query Parameter for filter[selected]')
+      end
+    end
+
+    describe 'with an invalid query param for filter type within packages query' do
+      before do
+        VCR.use_cassette(
+          'search-providers-related-packages-invalid-filter-type-query-param'
+        ) do
+          get '/eholdings/providers/19/packages?q=ebsco&filter[type]=invalid', headers: okapi_headers
+        end
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'returns a bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Invalid contentTypeFilter')
+        expect(json_f.errors.first.detail).to eql('Contenttypefilter Invalid Query Parameter for filter[type]')
       end
     end
   end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-470, we were allowing invalid values for filters in query params for list of packages associated with a given provider. This PR fixes that issue.

## Approach
- Looking at docs here: https://s3.amazonaws.com/foliodocs/api/mod-kb-ebsco/eholdings.html#eholdings_providers__provider_id__packages_get and validating what filters are allowed in UIEH for search within packages for a given provider, understand what values are allowed for various filters.
- Validate them in the ProvidersController
- Write associated unit tests

## Screenshots
![validate_filter_params](https://user-images.githubusercontent.com/33662516/43544625-90d1a6f8-95a1-11e8-8ff4-a6da49d3f49f.gif)