### PR TITLE
UIEH-427 Ensure both provider and package ids are in url

### DIFF
--- a/app/repositories/packages_repository.rb
+++ b/app/repositories/packages_repository.rb
@@ -3,6 +3,9 @@
 class PackagesRepository < RmapiRepository
   def find!(id)
     vendor_id, package_id = id.split('-')
+
+    fail RequestError.new('Package and provider id are required', 400) unless vendor_id && package_id
+
     status, body = request(:get, "/vendors/#{vendor_id}/packages/#{package_id}")
     Result.new(data: to_package(body), status: status, included: body[:included])
   end
@@ -62,6 +65,9 @@ class PackagesRepository < RmapiRepository
 
   def destroy!(id)
     vendor_id, package_id = id.split('-')
+
+    fail RequestError.new('Package and provider id are required', 400) unless vendor_id && package_id
+
     status, _no_content = request(:put, "/vendors/#{vendor_id}/packages/#{package_id}", json: { isSelected: false })
 
     Result.new(data: {}, status: status)

--- a/spec/fixtures/vcr_cassettes/delete-package-missing-package-id-in-url.yml
+++ b/spec/fixtures/vcr_cassettes/delete-package-missing-package-id-in-url.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 01 Aug 2018 19:08:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 404618us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44228us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 453367/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 19:08:35 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/get-package-missing-package-id-in-url.yml
+++ b/spec/fixtures/vcr_cassettes/get-package-missing-package-id-in-url.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Wed, 01 Aug 2018 18:53:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 308834us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43874us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 795954/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 01 Aug 2018 18:53:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -257,6 +257,21 @@ RSpec.describe 'Packages', type: :request do
     it 'returns a valid visibility reason' do
       expect(json.data.attributes.visibilityData.reason).to eq 'Set by system'
     end
+
+    describe 'getting a package with invalid package id' do
+      before do
+        VCR.use_cassette('get-package-missing-package-id-in-url') do
+          get '/eholdings/packages/19', headers: okapi_headers
+        end
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'returns a bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Package and provider id are required')
+      end
+    end
   end
 
   describe 'getting a specific package with allow add titles' do
@@ -1185,6 +1200,22 @@ RSpec.describe 'Packages', type: :request do
 
       it 'gets a bad request response' do
         expect(response).to have_http_status(400)
+      end
+    end
+
+    describe 'trying to delete package with missing package id' do
+      before do
+        VCR.use_cassette('delete-package-missing-package-id-in-url') do
+          delete '/eholdings/packages/123355',
+                 headers: okapi_headers
+        end
+      end
+
+      let!(:json_f) { Map JSON.parse response.body }
+
+      it 'get a error response' do
+        expect(response).to have_http_status(400)
+        expect(json_f.errors.first.title).to eql('Package and provider id are required')
       end
     end
   end


### PR DESCRIPTION
## Purpose
In order to `GET`, `DELETE`, `UPDATE` a package, both the provider_id and package_id have to be present in the URL. 

## Approach
 - Esure that two ids are passed in the URL and return an Error if not

#### Open Questions
- [ ] There was discussion around testing that the URL provider and package id's are only numeric and not alphanumeric. Example `/eholdings/packages/123-123` vs `/eholdings/packages/123-123ABC`. In regards for testing for alphanumeric non-presence. I could not find an overwhelming reason to test for that based on what currently happens. If you pass an id that RMAPI does not find whether it is numeric or alphanumeric it will return 404 not found which seems acceptable. 

## Screenshots
<img width="1238" alt="screen shot 2018-08-01 at 3 12 51 pm" src="https://user-images.githubusercontent.com/1953098/43545418-cfbf3036-95a3-11e8-9fd9-3e4f58551ea2.png">

