### PR TITLE
UIEH-466: Honor count param in providers and titles

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -19,7 +19,8 @@ class ProvidersController < ApplicationController
       @providers = providers.all(
         q: params[:q],
         page: params[:page],
-        sort: params[:sort]
+        sort: params[:sort],
+        count: params[:count]
       )
 
       render jsonapi: @providers.vendors.to_a,

--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -17,7 +17,8 @@ class TitlesController < ApplicationController
         q: params[:q],
         page: params[:page],
         filter: params[:filter],
-        sort: params[:sort]
+        sort: params[:sort],
+        count: params[:count]
       )
 
       render jsonapi: @titles.titles.to_a,

--- a/spec/fixtures/vcr_cassettes/search-providers-specify-count-out-of-range.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-specify-count-out-of-range.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 02 Aug 2018 17:04:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 316929us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44551us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 187314/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 17:04:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=200&offset=1&orderby=relevance&search=e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '93'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 02 Aug 2018 17:04:10 GMT
+      X-Amzn-Requestid:
+      - 13215989-9676-11e8-8b8d-d10472b683d3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LAXtqGmnIAMFwlA=
+      X-Amzn-Remapped-Date:
+      - Thu, 02 Aug 2018 17:04:10 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 8c1b1d3bc72fa37d10089ae804d74c7e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XWdj6eH_0qi4o56tWRd_-s6WxcCOiorDcc6I3dOzIQZFtJSeCqJM-g==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1005,"subCode":0,"message":"Parameter Count is outside
+        the range 1-100"}]}'
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 17:04:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-specify-count.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-specify-count.yml
@@ -1,0 +1,160 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 02 Aug 2018 16:48:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 322320us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44425us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 420292/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 16:48:06 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=2&offset=1&orderby=relevance&search=e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '313'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 02 Aug 2018 16:48:07 GMT
+      X-Amzn-Requestid:
+      - d4aaaad1-9673-11e8-9961-ffc51d07426d
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LAVXEHhBIAMFdpw=
+      X-Amzn-Remapped-Date:
+      - Thu, 02 Aug 2018 16:48:07 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 571228f0590cddc7e73aed23e051dd65.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hT_-3sc-bJ3XQUZCvV1958F178tod22AdUnzwU7zyHWOytqGvmOYcQ==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":112,"vendors":[{"vendorId":565,"vendorName":"E & E
+        Publishing, LLC","isCustomer":false,"packagesTotal":1,"packagesSelected":1,"vendorToken":null},{"vendorId":689,"vendorName":"E.
+        Schweizerbartsche Verlagsbuchhandlung","isCustomer":false,"packagesTotal":1,"packagesSelected":1,"vendorToken":null}]}'
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 16:48:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-titles-specify-count-out-of-range.yml
+++ b/spec/fixtures/vcr_cassettes/search-titles-specify-count-out-of-range.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 02 Aug 2018 17:04:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 2964us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44643us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 995148/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 17:04:16 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles?advancedsearch=true&count=150&offset=1&orderby=relevance&resourcetype=all&search=e&searchfield=titlename&selection=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '100'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 02 Aug 2018 17:04:16 GMT
+      X-Amzn-Requestid:
+      - 16636538-9676-11e8-8173-c910e3452111
+      X-Amzn-Remapped-Connection:
+      - close
+      X-Amz-Apigw-Id:
+      - LAXugF1moAMFiWw=
+      X-Amzn-Trace-Id:
+      - Root=1-5b633990-b92c299a081c59bccf9fde9c;Sampled=1
+      X-Application-Context:
+      - resourcemanagement.knowledgebase.rmapiedge:live:8092
+      X-Amzn-Remapped-Date:
+      - Thu, 02 Aug 2018 17:04:16 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 c89cbbc4e4ec6f9b44fad110d349819a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0Pg7hT66wXeCdD4NsLV5US99h1yI2aUzKy8GUfo48ZHO9yDoP6biNw==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"1006","message":"Parameter ''count'' is outside
+        the range 1-100.","subCode":"0"}]}'
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 17:04:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-titles-specify-count.yml
+++ b/spec/fixtures/vcr_cassettes/search-titles-specify-count.yml
@@ -1,0 +1,172 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 02 Aug 2018 16:49:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 313615us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44057us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 433767/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 16:49:33 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/titles?advancedsearch=true&count=5&offset=1&orderby=relevance&resourcetype=all&search=ebsco&searchfield=titlename&selection=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4407'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 02 Aug 2018 16:49:33 GMT
+      X-Amzn-Requestid:
+      - '08423796-9674-11e8-8a1b-ff6d7b308a67'
+      X-Amzn-Remapped-Connection:
+      - close
+      X-Amz-Apigw-Id:
+      - LAVklGQYoAMFpYA=
+      X-Amzn-Trace-Id:
+      - Root=1-5b63361d-3f37b95cbb30735175a752f1;Sampled=1
+      X-Application-Context:
+      - resourcemanagement.knowledgebase.rmapiedge:live:8092
+      X-Amzn-Remapped-Date:
+      - Thu, 02 Aug 2018 16:49:33 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 90d62e521ee2c5442b186a2cbca3fc9d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SlQdEeOxeMXA-D-YLCpH18GIy33NHx3BSdHfgXMx4z1AHa9UbFgdRg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":59,"titles":[{"titleId":1353080,"titleName":"EBSCO
+        Citations","publisherName":"Unspecified","identifiersList":[],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","contributorsList":[],"customerResourcesList":[{"titleId":1353080,"packageId":6027,"packageName":"EBSCO
+        Citations","packageType":"Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4474341,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":null},"managedCoverageList":[],"customCoverageList":null,"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":481131,"titleName":"GeoRef
+        (EBSCO)","publisherName":"Unspecified","identifiersList":[],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","contributorsList":[],"customerResourcesList":[{"titleId":481131,"packageId":2616,"packageName":"GeoRef
+        (EBSCO)","packageType":"Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1743052,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":null},"managedCoverageList":[],"customCoverageList":null,"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/login.aspx?authtype=cookie,ip,uid&profile=ehost&defaultdb=geh","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":480960,"titleName":"Inspec
+        (EBSCO)","publisherName":"Unspecified","identifiersList":[],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","contributorsList":[],"customerResourcesList":[{"titleId":480960,"packageId":2602,"packageName":"Inspec
+        (EBSCO)","packageType":"Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1742518,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":null},"managedCoverageList":[],"customCoverageList":null,"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/login.aspx?authtype=cookie,ip,uid&profile=ehost&defaultdb=inh","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":790251,"titleName":"FRANCIS
+        (EBSCO)","publisherName":"Unspecified","identifiersList":[],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","contributorsList":[],"customerResourcesList":[{"titleId":790251,"packageId":4737,"packageName":"FRANCIS
+        (EBSCO)","packageType":"Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":3059535,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":null},"managedCoverageList":[],"customCoverageList":null,"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/login.aspx?profile=ehost&defaultdb=fcs","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]},{"titleId":482126,"titleName":"AgeLine
+        (EBSCO)","publisherName":"Unspecified","identifiersList":[],"subjectsList":[],"isTitleCustom":false,"pubType":"Database","contributorsList":[],"customerResourcesList":[{"titleId":482126,"packageId":2699,"packageName":"AgeLine
+        (EBSCO)","packageType":"Complete","isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1747710,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":null},"managedCoverageList":[],"customCoverageList":null,"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/login.aspx?authtype=cookie,ip,uid&profile=ehost&defaultdb=gnh","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}]}]}'
+    http_version: 
+  recorded_at: Thu, 02 Aug 2018 16:49:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -46,6 +46,42 @@ RSpec.describe 'Providers', type: :request do
       end
     end
 
+    describe 'with count within range' do
+      before do
+        VCR.use_cassette('search-providers-specify-count') do
+          get '/eholdings/providers/?q=e&count=2', headers: okapi_headers
+        end
+      end
+
+      let!(:json2) { Map JSON.parse response.body }
+
+      it 'gets two providers results' do
+        expect(response).to have_http_status(200)
+        expect(json2.data.length).to equal(2)
+        expect(json.data.first.type).to eq('providers')
+        expect(json2.meta.totalResults).to equal(112)
+      end
+
+      it 'contains relationships data' do
+        expect(json2.data.first.relationships). to include('packages')
+      end
+    end
+
+    describe 'with count out of range' do
+      before do
+        VCR.use_cassette('search-providers-specify-count-out-of-range') do
+          get '/eholdings/providers/?q=e&count=200', headers: okapi_headers
+        end
+      end
+
+      let!(:json2) { Map JSON.parse response.body }
+
+      it 'gives expected error response' do
+        expect(response).to have_http_status(400)
+        expect(json2.errors.first.title).to eq('Parameter Count is outside the range 1-100')
+      end
+    end
+
     describe 'with alphabetical sorting' do
       before do
         VCR.use_cassette('search-providers-sort-name') do

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -41,6 +41,37 @@ RSpec.describe 'Titles', type: :request do
       end
     end
 
+    describe 'with count within range' do
+      before do
+        VCR.use_cassette('search-titles-specify-count') do
+          get '/eholdings/titles/?q=ebsco&count=5', headers: okapi_headers
+        end
+      end
+
+      let!(:json2) { Map JSON.parse response.body }
+
+      it 'gets five results of titles' do
+        expect(response).to have_http_status(200)
+        expect(json2.data.length).to equal(5)
+        expect(json2.meta.totalResults).to equal(59)
+      end
+    end
+
+    describe 'with count out of range' do
+      before do
+        VCR.use_cassette('search-titles-specify-count-out-of-range') do
+          get '/eholdings/titles/?q=e&count=150', headers: okapi_headers
+        end
+      end
+
+      let!(:json2) { Map JSON.parse response.body }
+
+      it 'gives expected error response' do
+        expect(response).to have_http_status(400)
+        expect(json2.errors.first.title).to eq('Parameter \'count\' is outside the range 1-100.')
+      end
+    end
+
     describe 'filtering by publication type' do
       before do
         VCR.use_cassette('search-titles-filter-book') do


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-466, we uncovered a bug in mod-kb-ebsco that providers and titles are not honoring the count parameter being passed in query params. Fix that in this PR.

## Approach
- Looking through code, understood that the param is in fact not being picked up in controllers as a result of which, it is not being sent to model and to RM API.
- Add that logic in there and associated unit tests.

## Screenshots
![count_param](https://user-images.githubusercontent.com/33662516/43599582-1763c958-9656-11e8-9189-167af3ab911a.gif)