### PR TITLE
Part of UIEH-466: Honor count in packages associated with a provider

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -58,7 +58,8 @@ class ProvidersController < ApplicationController
         q: params[:q],
         page: params[:page],
         filter: params[:filter],
-        sort: params[:sort]
+        sort: params[:sort],
+        count: params[:count]
       )
       render jsonapi: @packages.data,
              meta: @packages.meta

--- a/app/repositories/packages_repository.rb
+++ b/app/repositories/packages_repository.rb
@@ -75,6 +75,7 @@ class PackagesRepository < RmapiRepository
 
   def where!(params)
     vendor_id = params.fetch(:vendor_id, nil)
+    params[:count] = params[:count] ||= 25
 
     # TODO: controller?
     if params[:filter]

--- a/spec/fixtures/vcr_cassettes/search-providers-related-packages-count-out-of-range.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-related-packages-count-out-of-range.yml
@@ -1,0 +1,210 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 03 Aug 2018 13:26:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 308857us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43752us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '010843/configurations'
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:26:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 03 Aug 2018 13:26:53 GMT
+      X-Amzn-Requestid:
+      - e2cc7d72-9720-11e8-92ce-69a8697530f0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LDK0mHG0oAMF-Fg=
+      X-Amzn-Remapped-Date:
+      - Fri, 03 Aug 2018 13:26:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e6827ea64787e6a5cb9e6bf48a334563.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gIZbDcG-Leuvj_AIExqz1EaxEGlV-N0Akv1EF0oMYKnfjuMLyA8yqQ==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":false,"packagesSelected":47,"packagesTotal":624,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":false},"vendorToken":null}'
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:26:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=150&offset=1&orderby=relevance&search=abstract&selection=all
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '94'
+      Connection:
+      - close
+      Date:
+      - Fri, 03 Aug 2018 13:26:53 GMT
+      X-Amzn-Requestid:
+      - e2e70aa6-9720-11e8-a3c1-0d9888238386
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LDK0oHkPIAMFYNA=
+      X-Amzn-Remapped-Date:
+      - Fri, 03 Aug 2018 13:26:53 GMT
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 8bcdfe5c699ee9a81d92de5e160d9563.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2zdJd4ycjumbytTSlpiNGd-fA1Ukwv9TF60MBfPNvsDUfWojkR9euA==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":1006,"subCode":0,"message":"Parameter Count is outside
+        the range 1-100."}]}'
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:26:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-providers-related-packages-count-within-range.yml
+++ b/spec/fixtures/vcr_cassettes/search-providers-related-packages-count-within-range.yml
@@ -1,0 +1,215 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 03 Aug 2018 13:25:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 347064us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45122us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 602706/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:25:37 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 03 Aug 2018 13:25:39 GMT
+      X-Amzn-Requestid:
+      - b6b394b1-9720-11e8-a18f-cbbd86f58dda
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LDKpCGx1oAMFahg=
+      X-Amzn-Remapped-Date:
+      - Fri, 03 Aug 2018 13:25:39 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ab46eac18df172bdef93928eb1f67811.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wG7eSLDWphEHi4zsuzT_KDa9GO7HAfkkpjLj9CptO52hyjInLlyKjQ==
+    body:
+      encoding: UTF-8
+      string: '{"isCustomer":false,"packagesSelected":47,"packagesTotal":624,"vendorId":19,"vendorName":"EBSCO","proxy":{"id":"<n>","inherited":false},"vendorToken":null}'
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:25:39 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages?contenttype=all&count=5&offset=1&orderby=relevance&search=abstract&selection=all
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1848'
+      Connection:
+      - close
+      Date:
+      - Fri, 03 Aug 2018 13:25:40 GMT
+      X-Amzn-Requestid:
+      - b6e0bf9f-9720-11e8-aaec-e59f19379678
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LDKpFHKDIAMFYnA=
+      X-Amzn-Remapped-Date:
+      - Fri, 03 Aug 2018 13:25:40 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d8053cbdcb8a8e0d3f25f05723b00cff.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - kVo7Zqb7nHFF2Ket0u2b3weT8cqbZ5p-Pxw_Jm42dRq7XL2XyCkvBg==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":46,"packagesList":[{"packageId":2516,"packageName":"Abstracts
+        in Social Gerontology","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":1,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5420,"packageName":"Applied
+        Science & Technology Abstracts (H.W. Wilson)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":5459,"packageName":"Art
+        Abstracts (H.W. Wilson)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2706,"packageName":"Biological
+        Abstracts (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"},{"packageId":2707,"packageName":"Biological
+        Abstracts 1969 - Present (EBSCO)","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":1,"isSelected":false,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AbstractAndIndex","customCoverage":{"beginCoverage":"","endCoverage":""},"packageType":"Complete"}]}'
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 13:25:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -398,6 +398,42 @@ RSpec.describe 'Providers', type: :request do
       end
     end
 
+    describe 'with a search query and count within range' do
+      before do
+        VCR.use_cassette('search-providers-related-packages-count-within-range') do
+          get '/eholdings/providers/19/packages?q=abstract&count=5',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_with_query) { Map JSON.parse response.body }
+
+      it 'gets five packages that matches count' do
+        json = json_with_query
+        expect(response).to have_http_status(200)
+        expect(json.data.length).to equal(5)
+        expect(json.meta.totalResults).to equal(46)
+      end
+    end
+
+    describe 'with a search query and count out of range' do
+      before do
+        VCR.use_cassette('search-providers-related-packages-count-out-of-range') do
+          get '/eholdings/providers/19/packages?q=abstract&count=150',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json_with_query) { Map JSON.parse response.body }
+
+      it 'gets the expected error message' do
+        json = json_with_query
+        expect(response).to have_http_status(400)
+        expect(json.errors.length).to equal(1)
+        expect(json.errors.first.title).to eq('Parameter Count is outside the range 1-100.')
+      end
+    end
+
     describe 'with a invalid filter' do
       before do
         VCR.use_cassette(


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-466, count was not being honored in mod-kb providers and titles endpoints. While that has been fixed in https://github.com/folio-org/mod-kb-ebsco/pull/186; we missed out one use case of honoring count while searching for packages associated with a provider. This PR addresses that.

## Approach
- Send count param from controller to provider model where we find packages associated.
- If count does not have a value, then default it to 25 records.
- Add associated positive and negative unit tests.

## Screenshots
![count_again](https://user-images.githubusercontent.com/33662516/43646793-db326e7c-9703-11e8-9bc6-a054d7999e30.gif)