### PR TITLE
Part of UIEH-427: Validate packageId

### DIFF
--- a/app/controllers/validation/resource_id.rb
+++ b/app/controllers/validation/resource_id.rb
@@ -16,17 +16,17 @@ module Validation
 
     def vendor_id_int?
       errors.add(:vendor_id, ':Invalid vendor id') unless
-        vendor_id.to_i != 0
+        vendor_id&.match?(/\A-?\d+\Z/)
     end
 
     def package_id_int?
       errors.add(:package_id, ':Invalid package id') unless
-        package_id.to_i != 0
+        package_id&.match?(/\A-?\d+\Z/)
     end
 
     def title_id_int?
       errors.add(:title_id, ':Invalid title id') unless
-        title_id.to_i != 0
+        title_id&.match?(/\A-?\d+\Z/)
     end
 
     def initialize(params = {})

--- a/app/repositories/packages_repository.rb
+++ b/app/repositories/packages_repository.rb
@@ -5,6 +5,7 @@ class PackagesRepository < RmapiRepository
     vendor_id, package_id = id.split('-')
 
     fail RequestError.new('Package and provider id are required', 400) unless vendor_id && package_id
+    fail RequestError.new('Package or provider id are invalid', 400) unless vendor_id.match?(/\A-?\d+\Z/) && package_id.match?(/\A-?\d+\Z/)
 
     status, body = request(:get, "/vendors/#{vendor_id}/packages/#{package_id}")
     Result.new(data: to_package(body), status: status, included: body[:included])

--- a/spec/fixtures/vcr_cassettes/search-packages-package-id-another-invalid.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-package-id-another-invalid.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 03 Aug 2018 19:56:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 312282us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45460us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.2.1
+      X-Forwarded-For:
+      - 10.36.2.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 259339/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 19:56:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search-packages-package-id-invalid.yml
+++ b/spec/fixtures/vcr_cassettes/search-packages-package-id-invalid.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 03 Aug 2018 17:58:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 312959us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43759us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 843442/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 03 Aug 2018 17:58:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -89,6 +89,36 @@ RSpec.describe 'Packages', type: :request do
     end
   end
 
+  describe 'with an invalid package id' do
+    before do
+      VCR.use_cassette('search-packages-package-id-invalid') do
+        get '/eholdings/packages/abc-abc', headers: okapi_headers
+      end
+    end
+
+    let!(:json_f) { Map JSON.parse response.body }
+
+    it 'returns a bad request error' do
+      expect(response).to have_http_status(400)
+      expect(json_f.errors.first.title).to eql('Package or provider id are invalid')
+    end
+  end
+
+  describe 'with another invalid package id' do
+    before do
+      VCR.use_cassette('search-packages-package-id-another-invalid') do
+        get '/eholdings/packages/123abc-abc123', headers: okapi_headers
+      end
+    end
+
+    let!(:json_f) { Map JSON.parse response.body }
+
+    it 'returns a bad request error' do
+      expect(response).to have_http_status(400)
+      expect(json_f.errors.first.title).to eql('Package or provider id are invalid')
+    end
+  end
+
   describe 'with an invalid query param filter[selected]' do
     before do
       VCR.use_cassette('search-packages-invalid-query-param-selected') do

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -259,6 +259,40 @@ RSpec.describe 'Resources', type: :request do
         expect(json.errors.first.detail).to eq 'Package :Invalid package id'
       end
     end
+
+    describe 'getting a specific resource with invalid vendor id' do
+      before do
+        VCR.use_cassette('get-resource-with-invalid-vendor-id') do
+          get '/eholdings/resources/a22-18834-345',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns a 400 bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json.errors.first.title).to eq 'Invalid vendor_id'
+        expect(json.errors.first.detail).to eq 'Vendor :Invalid vendor id'
+      end
+    end
+
+    describe 'getting a specific resource with invalid title id' do
+      before do
+        VCR.use_cassette('get-resource-with-invalid-title-id') do
+          get '/eholdings/resources/22-18834-345abc',
+              headers: okapi_headers
+        end
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns a 400 bad request error' do
+        expect(response).to have_http_status(400)
+        expect(json.errors.first.title).to eq 'Invalid title_id'
+        expect(json.errors.first.detail).to eq 'Title :Invalid title id'
+      end
+    end
   end
 
   describe 'updating a resource' do


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-427, we are supposed to add validation for packageId in GET package with packageId requests. Part of the work has been addressed in https://github.com/folio-org/mod-kb-ebsco/pull/185. There was a corner case identified in the error response being returned not abiding by JSON API schema. This PR addresses that.

## Approach
- Add validation for provider and package ids to contain only digits and not alphabets
- Port that change over to validating resource ids
- Add associated unit tests

## Screenshots
![packageid](https://user-images.githubusercontent.com/33662516/43662560-50667ffa-9734-11e8-9438-b5041aeb40b1.gif)