### PR TITLE
UIEH-375: Add package proxy support

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -102,6 +102,7 @@ class PackagesController < ApplicationController
         :contentType,
         :isSelected,
         :allowKbToAddTitles,
+        proxy: %i[id inherited],
         visibilityData: [:isHidden],
         customCoverage: %i[beginCoverage endCoverage]
       )

--- a/app/deserializable/deserializable_package.rb
+++ b/app/deserializable/deserializable_package.rb
@@ -6,6 +6,7 @@ class DeserializablePackage < JSONAPI::Deserializable::Resource
              :customCoverage,
              :isSelected,
              :visibilityData,
+             :proxy,
              :name
 
   attribute :contentType do |value|

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -12,6 +12,7 @@ class Package
   attribute :is_custom
   attribute :is_selected
   attribute :name
+  attribute :proxy, default: -> { Proxy.new }
   attribute :package_id
   attribute :package_type
   attribute :provider_id
@@ -34,6 +35,13 @@ class Package
 
     attribute :begin_coverage
     attribute :end_coverage
+  end
+
+  class Proxy
+    include ActiveAttr::Model
+
+    attribute :id
+    attribute :inherited
   end
 
   def id

--- a/app/serializable/serializable_package_list.rb
+++ b/app/serializable/serializable_package_list.rb
@@ -12,6 +12,7 @@ class SerializablePackageList < SerializableJSONAPIResource
              :is_custom,
              :is_selected,
              :name,
+             :proxy,
              :package_id,
              :package_type,
              :provider_id,

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-update-proxy.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-update-proxy.yml
@@ -1,0 +1,413 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 311378us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45588us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.2.1
+      X-Forwarded-For:
+      - 10.36.2.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 239933/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '451'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Amzn-Requestid:
+      - b498fd38-9cbc-11e8-981a-f7efce95ff11
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY0EJyIAMFx3Q=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b112099a211ab81d3a50756cb5a11036.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xhFKRmwFm8fenW00gjih-ATGfToFME9zlj5pioWLwcO62GT5xF8cyA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '451'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Amzn-Requestid:
+      - b4b20372-9cbc-11e8-ad73-816cd0c69aa1
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY2HG6IAMF5XA=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 da802bbf9cd214d2b21a042ada07106b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dyVOukdc--mPimquaBlY7JB-3r2ANYHlm9U3xgcmTbqzY68zhLmubg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '451'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Amzn-Requestid:
+      - b4cc1b7d-9cbc-11e8-9fb1-df14784b2482
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY3FZnoAMFaSQ=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9e0d30e9e48ffdef404c36841b7cb7e5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fJSRQm7T77tIR5P9HyUzCXmPfuADG9L3LPYEIdEqKumB2ZJXf9Nvfw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:53 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '451'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Amzn-Requestid:
+      - b4e74531-9cbc-11e8-84e6-bd6462272a22
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY5EcwIAMFjsg=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4ee5063dc9b3d6f9bda9588d4fd84fe7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _Nxd82A6MutrwVVca88nN5IaXjebKLZebv61Sta19KXzRNBmIZCl5g==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:53 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"proxy":{"id":"TestingFolio"},"allowEbscoToAddTitles":true,"isHidden":false}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:54 GMT
+      X-Amzn-Requestid:
+      - b5026d73-9cbc-11e8-8fb8-53c21f296604
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY7ErFoAMFx5w=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 eac6de8b8ffcf4d5a480e00422a7a4f8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - us_dgCiL2YwbAmiUviTk4ziPrR5Ni6twC8luzRnyioOfz45JC7cOTw==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:54 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Fri, 10 Aug 2018 16:44:54 GMT
+      X-Amzn-Requestid:
+      - b52e5f78-9cbc-11e8-b2d1-df9ff47dd855
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LasY-EDooAMFutA=
+      X-Amzn-Remapped-Date:
+      - Fri, 10 Aug 2018 16:44:53 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5b1f6dfc9ebdbec2869a5bfa561dded0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - cAO4wN-Axz3t4edAlad2wyvTOGzebB-rKMGhGwBUBbjeagvD2GrQHw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Fri, 10 Aug 2018 16:44:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe 'Packages', type: :request do
       expect(json.data.id).to eq('19-6581')
       expect(json.data.attributes).to include(
         'name',
+        'proxy',
         'contentType',
         'titleCount',
         'selectedCount',
@@ -286,6 +287,11 @@ RSpec.describe 'Packages', type: :request do
 
     it 'returns a valid visibility reason' do
       expect(json.data.attributes.visibilityData.reason).to eq 'Set by system'
+    end
+
+    it 'returns proxy' do
+      expect(json.data.attributes.proxy.id).to eq('EZProxy')
+      expect(json.data.attributes.proxy.inherited).to eq(true)
     end
 
     describe 'getting a package with invalid package id' do
@@ -875,7 +881,8 @@ RSpec.describe 'Packages', type: :request do
                 "visibilityData": {
                   "isHidden": true,
                   "reason": ''
-                }
+                },
+                "proxy": '<n>'
               }
             }
           }
@@ -911,6 +918,11 @@ RSpec.describe 'Packages', type: :request do
         it 'is populated with custom coverage' do
           expect(coverage.beginCoverage).to eq '2003-01-01'
           expect(coverage.endCoverage).to eq '2004-01-01'
+        end
+
+        it 'has proxy value with inherited false' do
+          expect(json.data.attributes.proxy.id).to eq('<n>')
+          expect(json.data.attributes.proxy.inherited).to eq(false)
         end
       end
 

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -866,6 +866,52 @@ RSpec.describe 'Packages', type: :request do
         end
       end
 
+      describe 'updating proxy' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'packages',
+              "attributes": {
+                "isSelected": true,
+                "allowKbToAddTitles": true,
+                "proxy": {
+                  "id": 'TestingFolio'
+                },
+                "visibilityData": {
+                  "isHidden": false
+                },
+                "customCoverage": {
+                  "beginCoverage": '2003-01-01',
+                  "endCoverage": '2003-12-12'
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-packages-isselected-update-proxy') do
+            put '/eholdings/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with an ok status' do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'is selected' do
+          expect(json.data.attributes.isSelected).to be true
+        end
+
+        it 'has proxy value with inherited false' do
+          expect(json.data.attributes.proxy.id).to eq('TestingFolio')
+          expect(json.data.attributes.proxy.inherited).to be false
+        end
+      end
+
       describe 'combined update' do
         let(:params) do
           {
@@ -881,8 +927,7 @@ RSpec.describe 'Packages', type: :request do
                 "visibilityData": {
                   "isHidden": true,
                   "reason": ''
-                },
-                "proxy": '<n>'
+                }
               }
             }
           }
@@ -918,11 +963,6 @@ RSpec.describe 'Packages', type: :request do
         it 'is populated with custom coverage' do
           expect(coverage.beginCoverage).to eq '2003-01-01'
           expect(coverage.endCoverage).to eq '2004-01-01'
-        end
-
-        it 'has proxy value with inherited false' do
-          expect(json.data.attributes.proxy.id).to eq('<n>')
-          expect(json.data.attributes.proxy.inherited).to eq(false)
         end
       end
 


### PR DESCRIPTION
## Purpose
To resolve [UIEH-375](https://issues.folio.org/browse/UIEH-375), users should be able to view the current proxy setting as well as change the selected proxy at the package level. This PR takes care of the back end implementation.

## Approach
- [x] Write unit tests
- [x] Add support for (de)serializing the proxy field on the GET and PUT calls for a package.

## Screenshots
TODO
