### PR TITLE
UIEH-485: Handle invalid content type header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  before_action :verify_content_type_header
   before_action :verify_okapi_headers
   before_action :set_response_headers
   around_action :catch_exceptions
@@ -29,6 +30,10 @@ class ApplicationController < ActionController::API
 
   def okapi_token
     request.headers['HTTP_X_OKAPI_TOKEN']
+  end
+
+  def content_type
+    request.headers['Content-Type']
   end
 
   private
@@ -91,6 +96,11 @@ class ApplicationController < ActionController::API
 
   def map_provider(string)
     string.gsub(/Vendor/, 'Provider').gsub(/vendor/, 'provider')
+  end
+
+  def verify_content_type_header
+    render plain: 'Missing/Invalid header Content-Type', status: :bad_request if
+      (request.request_method == 'PUT' || request.request_method == 'POST') && (!content_type || !content_type.casecmp('application/vnd.api+json').zero?)
   end
 
   def verify_okapi_headers

--- a/spec/requests/configurations_spec.rb
+++ b/spec/requests/configurations_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe 'Configurations', type: :request do
     )
   end
 
+  let(:headers_invalid_content_type) do
+    okapi_headers.merge(
+      'Content-Type': 'application/json'
+    )
+  end
+
+  let(:headers_empty_content_type) do
+    okapi_headers.merge(
+      'Content-Type': ''
+    )
+  end
+
   let(:resource) do
     [
       '/eholdings/configuration',
@@ -23,6 +35,40 @@ RSpec.describe 'Configurations', type: :request do
         }
       }.to_json,
       headers: headers
+    ]
+  end
+
+  let(:resource_with_invalid_content_type_header) do
+    [
+      '/eholdings/configuration',
+      params: {
+        data: {
+          type: 'configurations',
+          id: 'default',
+          attributes: {
+            customerId: customer_id,
+            apiKey: api_key
+          }
+        }
+      }.to_json,
+      headers: headers_invalid_content_type
+    ]
+  end
+
+  let(:resource_with_empty_content_type_header) do
+    [
+      '/eholdings/configuration',
+      params: {
+        data: {
+          type: 'configurations',
+          id: 'default',
+          attributes: {
+            customerId: customer_id,
+            apiKey: api_key
+          }
+        }
+      }.to_json,
+      headers: headers_empty_content_type
     ]
   end
 
@@ -58,6 +104,32 @@ RSpec.describe 'Configurations', type: :request do
         expect(json.data.attributes.customerId).to eql(customer_id)
         expect(json.data.attributes.apiKey).to eql(masked_api_key)
       end
+    end
+  end
+
+  describe 'setting the configuration with invalid content type' do
+    before do
+      VCR.use_cassette('put-configuration-invalid-content-type') do
+        put(*resource_with_invalid_content_type_header)
+      end
+    end
+
+    it 'expects the response to have 400' do
+      expect(response).to have_http_status(400)
+      expect(response.body).to eq('Missing/Invalid header Content-Type')
+    end
+  end
+
+  describe 'setting the configuration with empty content type' do
+    before do
+      VCR.use_cassette('put-configuration-empty-content-type') do
+        put(*resource_with_empty_content_type_header)
+      end
+    end
+
+    it 'expects the response to have 400' do
+      expect(response).to have_http_status(400)
+      expect(response.body).to eq('Missing/Invalid header Content-Type')
     end
   end
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-485, we are supposed to handle invalid Content-Type headers passed in request without giving a 500 with a stack trace. This PR addresses that issue.

## Approach
- Get the type of request and if it is a PUT or POST, ensure that the expected Content-Type is passed in headers, else give a bad request with appropriate error message.
- Add associated unit test.

#### TODOS and Open Questions
- [x] Application Controller itself does not have any file containing unit tests. So, I added the test to Configurations although it does not belong there. This can happen across requests in any part of code. Wondering if I should move this test to its own file and add tests for rest of the application controller code or is it an overkill? 🤔 

## Screenshots
![content_type_header](https://user-images.githubusercontent.com/33662516/43925401-27c117f2-9bf5-11e8-9128-49eee98e9656.gif)

