### PR TITLE
UIEH-489: Validate custom coverage in PUT/POST requests of resources/packages

### DIFF
--- a/app/controllers/validation/custom_package_parameters.rb
+++ b/app/controllers/validation/custom_package_parameters.rb
@@ -6,10 +6,32 @@ module Validation
   class CustomPackageParameters
     include ActiveModel::Validations
 
-    attr_accessor :name, :contentType
+    attr_accessor :name, :contentType, :beginCoverage, :endCoverage
 
     validates :name, presence: true
     validates :contentType, presence: true
+    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.nil? }
+    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.nil? }
+
+    def begin_coverage_valid_date_format?
+      errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(beginCoverage)
+    end
+
+    def end_coverage_valid_date_format?
+      errors.add(:endCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(endCoverage)
+    end
+
+    def valid_date?(coverage)
+      yyyy, mm, dd = coverage.split('-')
+      begin
+        @valid_date = Date.new(yyyy.to_i, mm.to_i, dd.to_i)
+        return true
+      rescue ArgumentError
+        return false
+      end
+    end
 
     # TODO: this should turn snake as soon as it
     # comes out of the deserializable layer.  also
@@ -20,6 +42,8 @@ module Validation
     def initialize(params = {})
       @name = params[:name]
       @contentType = params[:contentType]
+      @beginCoverage = params.dig(:customCoverage, :beginCoverage)
+      @endCoverage = params.dig(:customCoverage, :endCoverage)
     end
   end
 end

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -20,6 +20,29 @@ module Validation
       validates :endCoverage, absence: true, unless: :isSelected
     end
 
+    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.nil? }
+    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.nil? }
+
+    def begin_coverage_valid_date_format?
+      errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(beginCoverage)
+    end
+
+    def end_coverage_valid_date_format?
+      errors.add(:endCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(endCoverage)
+    end
+
+    def valid_date?(coverage)
+      yyyy, mm, dd = coverage.split('-')
+      begin
+        @valid_date = Date.new(yyyy.to_i, mm.to_i, dd.to_i)
+        return true
+      rescue ArgumentError
+        return false
+      end
+    end
+
     def initialize(params = {})
       @isSelected = params[:isSelected]
       @allowEbscoToAddTitles = params[:allowEbscoToAddTitles]

--- a/app/controllers/validation/resource_create_parameters.rb
+++ b/app/controllers/validation/resource_create_parameters.rb
@@ -22,6 +22,7 @@ module Validation
     validate :url_has_valid_format?, unless: -> { url.nil? }
     validates :coverageStatement, length: { maximum: 250 }, allow_nil: true
     validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
+    validate :custom_coverage_list_valid?, unless: -> { customCoverageList.blank? }
 
     def url_has_valid_format?
       errors.add(:url, ':url has invalid format') unless
@@ -36,6 +37,35 @@ module Validation
           identifier['type']&.between?(0, 7)
         errors.add(:IdentifierSubType, ':Invalid Identifier subtype') unless
           identifier['subtype']&.between?(1, 2)
+      end
+    end
+
+    def custom_coverage_list_valid?
+      customCoverageList.each do |custom_coverage|
+        begin_coverage = custom_coverage['beginCoverage']
+        end_coverage = custom_coverage['endCoverage']
+        begin_coverage_valid_date_format?(begin_coverage) unless begin_coverage.nil?
+        end_coverage_valid_date_format?(end_coverage) unless end_coverage.nil?
+      end
+    end
+
+    def begin_coverage_valid_date_format?(begin_coverage)
+      errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(begin_coverage)
+    end
+
+    def end_coverage_valid_date_format?(end_coverage)
+      errors.add(:endCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(end_coverage)
+    end
+
+    def valid_date?(coverage)
+      yyyy, mm, dd = coverage.split('-')
+      begin
+        @valid_date = Date.new(yyyy.to_i, mm.to_i, dd.to_i)
+        return true
+      rescue ArgumentError
+        return false
       end
     end
 

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -39,6 +39,7 @@ module Validation
     validates :edition, length: { maximum: 250 }, allow_nil: true
     validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
     validate :url_has_valid_format?, unless: -> { url.nil? }
+    validate :custom_coverage_list_valid?, unless: -> { customCoverageList.blank? }
 
     def identifiers_list_valid?
       identifiersList.each do |identifier|
@@ -54,6 +55,35 @@ module Validation
     def url_has_valid_format?
       errors.add(:url, 'has invalid format') unless
         url.downcase.start_with?('https://', 'http://')
+    end
+
+    def custom_coverage_list_valid?
+      customCoverageList.each do |custom_coverage|
+        begin_coverage = custom_coverage['beginCoverage']
+        end_coverage = custom_coverage['endCoverage']
+        begin_coverage_valid_date_format?(begin_coverage) unless begin_coverage.nil?
+        end_coverage_valid_date_format?(end_coverage) unless end_coverage.nil?
+      end
+    end
+
+    def begin_coverage_valid_date_format?(begin_coverage)
+      errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(begin_coverage)
+    end
+
+    def end_coverage_valid_date_format?(end_coverage)
+      errors.add(:endCoverage, 'has invalid format. Should be YYYY-MM-DD') unless
+        valid_date?(end_coverage)
+    end
+
+    def valid_date?(coverage)
+      yyyy, mm, dd = coverage.split('-')
+      begin
+        @valid_date = Date.new(yyyy.to_i, mm.to_i, dd.to_i)
+        return true
+      rescue ArgumentError
+        return false
+      end
     end
 
     def initialize(is_title_custom, params = {})

--- a/app/middleware/catch_invalid_json_errors.rb
+++ b/app/middleware/catch_invalid_json_errors.rb
@@ -1,0 +1,21 @@
+class CatchInvalidJsonErrors
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    begin
+      @app.call(env)
+    rescue ActionDispatch::Http::Parameters::ParseError => error
+      if env['CONTENT_TYPE'] == 'application/vnd.api+json'
+        error_output = "JSON submitted is invalid"
+        return [
+          400, { "Content-Type" => "application/vnd.api+json" },
+          [ { status: 400, error: error_output }.to_json ]
+        ]
+      else
+        super(env)
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,4 +37,9 @@ Rails.application.configure do
   config.middleware.insert_before Rack::Runtime,
                                   ChunkedTransferDecoder,
                                   decoded_upstream: true
+
+  # Tweak middleware for handling JSON parse errors by providing a decent error response
+  # instead of a stacktrace
+  config.middleware.insert_before Rack::Head,
+                                  CatchInvalidJsonErrors
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,4 +50,9 @@ Rails.application.configure do
   config.middleware.insert_before Rack::Runtime,
                                   ChunkedTransferDecoder,
                                   decoded_upstream: true
+
+  # Tweak middleware for handling JSON parse errors by providing a decent error response
+  # instead of a stacktrace
+  config.middleware.insert_before Rack::Head,
+                                  CatchInvalidJsonErrors
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,4 +35,9 @@ Rails.application.configure do
   config.middleware.insert_before Rack::Runtime,
                                   ChunkedTransferDecoder,
                                   decoded_upstream: true
+
+  # Tweak middleware for handling JSON parse errors by providing a decent error response
+  # instead of a stacktrace
+  config.middleware.insert_before Rack::Head,
+                                  CatchInvalidJsonErrors
 end

--- a/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates-invalid.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates-invalid.yml
@@ -1,0 +1,266 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 312179us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44225us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 645768/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:58:23 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      X-Amzn-Requestid:
+      - 78a82580-9f22-11e8-ab43-6b0b123647dc
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lkv98HRaoAMFncA=
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 047d3a9e23f0016e74a43fb997cbd212.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7M7ycuNA69SJG4TeJJoq1bThuSYtYlB1LxQKnhHksHRCZaZYrsmadA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:58:23 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      X-Amzn-Requestid:
+      - 78c39cb4-9f22-11e8-8c7c-7d1d920b9b6b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lkv9-FFfIAMFZbw=
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2f58837c73ff25163966d00a02414d37.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - snN6VjCEopmZ4gHcRvJLaLiGJi5-cgKzpPBMKuGj1ItmIZ-gOnTm9w==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:58:23 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Mon, 13 Aug 2018 17:58:24 GMT
+      X-Amzn-Requestid:
+      - 78dbb866-9f22-11e8-9509-bd4a84b28c94
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lkv-AGRWoAMFs9Q=
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 17:58:23 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3f664d29b735d0f07574fc4382fb0221.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - RyK4TYqC0xSyPyfVpdxWHW27A-0E0Aul514CUc5eKzx3Nq_FVUy1vg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:58:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-combined-update-invalid-coverage-date-format.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-combined-update-invalid-coverage-date-format.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 13 Aug 2018 17:31:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 2019us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43598us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 963875/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:31:39 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Mon, 13 Aug 2018 17:31:39 GMT
+      X-Amzn-Requestid:
+      - bcb3b828-9f1e-11e8-a172-19cff6e82d9e
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LksDWHO4IAMFmFA=
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 17:31:39 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 51c76241371dfc20d25094a51b4759eb.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4_KJ0W5Az_p9WsOBlOMcbzU8m67B4s3W8qd4iMfStwxSz-V3AYHcIg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:31:39 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Mon, 13 Aug 2018 17:31:40 GMT
+      X-Amzn-Requestid:
+      - bcca4da3-9f1e-11e8-b35c-677302f7ba26
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - LksDYGjxIAMFxsA=
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 17:31:39 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 91e54ea7c5cc54f4a3500c72b19a2a23.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _sgfPPuwq6txZgyeR9KJQBnVYf28ppeu27ytKgUV_UefMG3HSXYfAA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 17:31:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-resources-invalid-customcoverage-update-managed-resource.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-invalid-customcoverage-update-managed-resource.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 13 Aug 2018 19:04:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 316039us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 46469us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 817153/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 19:04:50 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581/titles/581242
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1529'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 13 Aug 2018 19:04:51 GMT
+      X-Amzn-Requestid:
+      - c156c7b1-9f2b-11e8-86c2-2f4accb420be
+      X-Amzn-Remapped-Content-Length:
+      - '1529'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lk5s-EBLoAMF2hQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 19:04:49 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 316430958c7664ce84a9544466b4155f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zNYrEKaD6XnTJaRTJ3SVyxyRo-JEbO6KJgcOvYT1rE_YsOAx2qaCrQ==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":581242,"titleName":"Acta Scientiarum Polonorum. Biotechnologia","publisherName":"Wroclaw
+        University of Environmental & Life Sciences","identifiersList":[{"id":"1644-065X","source":"ResourceIdentifier","subtype":1,"type":0},{"id":"2083-8654","source":"ResourceIdentifier","subtype":2,"type":0},{"id":"581242","source":"AtoZ","subtype":0,"type":9},{"id":"97C7","source":"MFS","subtype":0,"type":8}],"subjectsList":[{"type":"TLI","subject":"Biological
+        Engineering"}],"isTitleCustom":false,"pubType":"Journal","customerResourcesList":[{"titleId":581242,"packageId":6581,"packageName":"EBSCO
+        Biotechnology Collection: India","packageType":"Complete","proxy":{"id":"TestingFolio","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":4829613,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by EP"},"managedCoverageList":[{"beginCoverage":"2008-12-01","endCoverage":""}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bti&jid=97C7&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"Peer-reviewed
+        coverage of topics in biochemistry, biophysics, epidemiology, toxicology,
+        virology, organic and polymer chemistry.","edition":null,"isPeerReviewed":true,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 19:04:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-resources-invalid-customcoverage-update.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-invalid-customcoverage-update.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 13 Aug 2018 18:27:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 320370us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45150us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.4.1
+      X-Forwarded-For:
+      - 10.36.4.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 669525/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 18:27:32 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/22/packages/1887786/titles/1440285
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.6.7
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1568'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 13 Aug 2018 18:27:33 GMT
+      X-Amzn-Requestid:
+      - 8b5c0f54-9f26-11e8-9fa3-2916c5c6b4da
+      X-Amzn-Remapped-Content-Length:
+      - '1568'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lk0PSH3qoAMFqyQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Mon, 13 Aug 2018 18:27:31 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5eeb97aa7733a60bc509534d9745abc7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - W9n2Bf4i_0OFbMjM4C3p_YYkz3v3Vt6S3uGsgzLcSCHzVK6dP7tPqw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":1440285,"titleName":"Havard''s Nursing Guide to Drugs (Nursing
+        Guide to Drugs)","publisherName":"Elsevier","identifiersList":[{"id":"1440285","source":"AtoZ","subtype":0,"type":9},{"id":"475765","source":"ResourceIdentifier","subtype":0,"type":7},{"id":"978-0-7295-3913-5","source":"ResourceIdentifier","subtype":1,"type":1},{"id":"978-0-7295-7913-1","source":"ResourceIdentifier","subtype":2,"type":1}],"subjectsList":[{"type":"BISAC","subject":"MEDICAL
+        / Nursing / Pharmacology"}],"isTitleCustom":false,"pubType":"Book","customerResourcesList":[{"titleId":1440285,"packageId":1887786,"packageName":"ProQuest
+        Ebook Central","packageType":"Variable","proxy":{"id":"TestingFolio","inherited":true},"isPackageCustom":false,"vendorId":22,"vendorName":"Proquest
+        Info & Learning Co","locationId":17545807,"isSelected":true,"isTokenNeeded":true,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2010-01-01","endCoverage":"2010-12-31"}],"customCoverageList":[],"coverageStatement":"Only
+        1990s issues available.","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"https://ebookcentral.proquest.com/lib/[[SiteID]]/detail.action?docID=1722033","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[{"type":"author","contributor":"Havard,
+        Margaret"},{"type":"author","contributor":"Tiziani, Adriana."}]}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 18:27:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -914,6 +914,48 @@ RSpec.describe 'Packages', type: :request do
         end
       end
 
+      describe 'combined update with invalid coverage date format' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'packages',
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": '01-01-2003',
+                  "endCoverage": '01-01-2004'
+                },
+                "isSelected": true,
+                "allowKbToAddTitles": true,
+                "visibilityData": {
+                  "isHidden": true,
+                  "reason": ''
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-packages-combined-update-invalid-coverage-date-format') do
+            put '/eholdings/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with expected status' do
+          expect(response).to have_http_status(422)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'gives the expected error message' do
+          expect(json.errors.first.title).to eql('Invalid beginCoverage')
+          expect(json.errors.first.detail).to eq 'Begincoverage has invalid format. Should be YYYY-MM-DD'
+          expect(json.errors.second.title).to eql('Invalid endCoverage')
+          expect(json.errors.second.detail).to eq 'Endcoverage has invalid format. Should be YYYY-MM-DD'
+        end
+      end
+
       describe 'deselecting a package' do
         let(:params) do
           {
@@ -1121,6 +1163,49 @@ RSpec.describe 'Packages', type: :request do
           .to eq('2003-01-01')
         expect(json.data.attributes.customCoverage.endCoverage)
           .to eq('2004-01-01')
+      end
+    end
+
+    describe 'changing the coverage dates to invalid' do
+      let(:params) do
+        {
+          "data": {
+            "type": 'packages',
+            "attributes": {
+              "customCoverage": {
+                "beginCoverage": '01-01-2003',
+                "endCoverage": '01-01-2004'
+              },
+              "isSelected": true,
+              "name": 'name of the ages forever and ever',
+              "contentType": 'Aggregated Full Text'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-package-coverage-dates-invalid') do
+          put '/eholdings/packages/123355-2845506',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'responds with expected error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'now has custom coverage' do
+        expect(json.errors.first.title)
+          .to eq('Invalid beginCoverage')
+        expect(json.errors.first.detail)
+          .to eq('Begincoverage has invalid format. Should be YYYY-MM-DD')
+        expect(json.errors.second.title)
+          .to eq('Invalid endCoverage')
+        expect(json.errors.second.detail)
+          .to eq('Endcoverage has invalid format. Should be YYYY-MM-DD')
       end
     end
 
@@ -1404,6 +1489,42 @@ RSpec.describe 'Packages', type: :request do
 
       it 'content type replaced with Unknown' do
         expect(json_response.data.attributes.contentType).to eql('Unknown')
+      end
+    end
+
+    describe 'giving begin coverage in an invalid format' do
+      let(:params) do
+        {
+          "data": {
+            "type": 'packages',
+            "attributes": {
+              "name": 'VCR Package 1.7',
+              "contentType": 'E-Book',
+              "customCoverage": {
+                "beginCoverage": '01-01-2003',
+                "endCoverage": '2004-01-01'
+              }
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('post-custom-package-invalid-begin-coverage') do
+          post '/eholdings/packages/',
+               params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'responds with expected error status' do
+        expect(response).to have_http_status(422)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'returns the expected error message' do
+        expect(json.errors.first.title).to eq 'Invalid beginCoverage'
+        expect(json.errors.first.detail).to eq 'Begincoverage has invalid format. Should be YYYY-MM-DD'
       end
     end
   end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -551,6 +551,98 @@ RSpec.describe 'Resources', type: :request do
         end
       end
 
+      describe 'setting invalid custom coverage on custom resource' do
+        let(:params) do
+          {
+            'data' => {
+              'type' => 'resources',
+              'attributes' => {
+                'isSelected' => true,
+                'customCoverages' => [
+                  {
+                    'beginCoverage' => '01-2003-01',
+                    'endCoverage' => '01-01-2004'
+                  }
+                ],
+                'proxy' => {
+                  'id' => 'EZProxy'
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-resources-invalid-customcoverage-update') do
+            put '/eholdings/resources/22-1887786-1440285',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with expected error status' do
+          expect(response).to have_http_status(422)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'returns the expected error message' do
+          expect(json.errors.first.title)
+            .to eq('Invalid beginCoverage')
+          expect(json.errors.first.detail)
+            .to eq('Begincoverage has invalid format. Should be YYYY-MM-DD')
+          expect(json.errors.second.title)
+            .to eq('Invalid endCoverage')
+          expect(json.errors.second.detail)
+            .to eq('Endcoverage has invalid format. Should be YYYY-MM-DD')
+        end
+      end
+
+      describe 'setting invalid custom coverage on managed resource' do
+        let(:params) do
+          {
+            'data' => {
+              'type' => 'resources',
+              'attributes' => {
+                'isSelected' => true,
+                'customCoverages' => [
+                  {
+                    'beginCoverage' => '01-2003-01',
+                    'endCoverage' => '01-01-2004'
+                  }
+                ],
+                'proxy' => {
+                  'id' => 'EZProxy'
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-resources-invalid-customcoverage-update-managed-resource') do
+            put '/eholdings/resources/19-6581-581242',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with expected error status' do
+          expect(response).to have_http_status(422)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'returns the expected error message' do
+          expect(json.errors.first.title)
+            .to eq('Invalid beginCoverage')
+          expect(json.errors.first.detail)
+            .to eq('Begincoverage has invalid format. Should be YYYY-MM-DD')
+          expect(json.errors.second.title)
+            .to eq('Invalid endCoverage')
+          expect(json.errors.second.detail)
+            .to eq('Endcoverage has invalid format. Should be YYYY-MM-DD')
+        end
+      end
+
       describe 'setting a custom embargo period' do
         let(:params) do
           {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-489, we are supposed to validate custom coverage in POST/PUT requests for (custom/managed) resources and packages where applicable so that the consumer gets an understandable error message instead of stack trace with bad request. 

## Approach
- Added necessary validation for the dates themselves both in resources and packages
- When json in the request body is invalid, we used to give a 400 with stack trace. Tweaked middleware for all json requests for better error message reporting when there are JSON parse errors, otherwise it behaves as before.
- Add associated unit tests

#### TODOS and Open Questions
- [ ] Unsure how to write a unit test for invalid json request since rubocop complains while linting the request body. Proof that it works is in the recorded gif and has been manually tested. We could probably also test this when we add more / modify our API tests to test the changes in this PR.

## Learning
https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/actionpack/lib/action_dispatch/middleware/show_exceptions.rb

## Screenshots
![custom_coverage_validate](https://user-images.githubusercontent.com/33662516/44053590-1c0dc632-9f0e-11e8-8202-326146b35d2e.gif)

