### PR TITLE
UIEH-525: Fix issue with updating resources

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -58,9 +58,8 @@ class ResourcesController < ApplicationController
   end
 
   def update
-    is_title_custom = title_custom?
     resource_validation =
-      Validation::ResourceUpdateParameters.new(is_title_custom, update_params)
+      Validation::ResourceUpdateParameters.new(update_params)
 
     if resource_validation.valid?
       @resource.update update_params
@@ -135,8 +134,7 @@ class ResourcesController < ApplicationController
         :edition,
         :description,
         :url,
-        :packageId,
-        :titleId,
+        proxy: [:id],
         visibilityData: %i[isHidden reason],
         customCoverageList: [
           %i[beginCoverage endCoverage]
@@ -157,33 +155,20 @@ class ResourcesController < ApplicationController
   def update_params
     # NOTE: deserialization happens before param parsing, so we
     # use the RMAPI property names here
-    params
-      .require(:resource)
-      .permit(
+    if title_custom?
+      resource_params
+    else
+      resource_params.except(
         :titleName,
-        :pubType,
-        :isSelected,
-        :coverageStatement,
         :isPeerReviewed,
+        :pubType,
         :publisherName,
         :edition,
         :description,
         :url,
-        proxy: [:id],
-        visibilityData: %i[isHidden reason],
-        customCoverageList: [
-          %i[beginCoverage endCoverage]
-        ],
-        contributorsList: [
-          %i[type contributor]
-        ],
-        identifiersList: [
-          %i[id subtype type]
-        ],
-        customEmbargoPeriod: %i[
-          embargoUnit
-          embargoValue
-        ]
+        :contributorsList,
+        :identifiersList
       )
+    end
   end
 end

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -6,9 +6,9 @@ module Validation
   class ResourceUpdateParameters
     include ActiveModel::Validations
 
-    attr_accessor :isTitleCustom, :isSelected, :isHidden, :customCoverageList, :contributorsList,
+    attr_accessor :isSelected, :isHidden, :customCoverageList, :contributorsList,
                   :identifiersList, :embargoUnit, :embargoValue, :coverageStatement,
-                  :edition, :titleName, :isPeerReviewed, :pubType, :publisherName, :description, :url
+                  :edition, :url
 
     # Deselected resources cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
@@ -22,18 +22,6 @@ module Validation
       validates :embargoUnit, absence: true, unless: :isSelected
       validates :embargoValue, absence: true, unless: :isSelected
       validates :coverageStatement, absence: true, unless: :isSelected
-    end
-
-    with_options unless: :isTitleCustom do
-      validates :titleName, absence: true, unless: :isTitleCustom
-      validates :isPeerReviewed, absence: true, unless: :isTitleCustom
-      validates :pubType, absence: true, unless: :isTitleCustom
-      validates :publisherName, absence: true, unless: :isTitleCustom
-      validates :edition, absence: true, unless: :isTitleCustom
-      validates :description, absence: true, unless: :isTitleCustom
-      validates :url, absence: true, unless: :isTitleCustom
-      validates :contributorsList, absence: true, unless: :isTitleCustom
-      validates :identifiersList, absence: true, unless: :isTitleCustom
     end
 
     validates :edition, length: { maximum: 250 }, allow_nil: true
@@ -86,8 +74,7 @@ module Validation
       end
     end
 
-    def initialize(is_title_custom, params = {})
-      @isTitleCustom = is_title_custom
+    def initialize(params = {})
       @isSelected = params[:isSelected]
       @isHidden = params.dig(:visibilityData, :isHidden)
       @customCoverageList = params[:customCoverageList]
@@ -97,11 +84,6 @@ module Validation
       @embargoValue = params.dig(:customEmbargoPeriod, :embargoValue)
       @coverageStatement = params[:coverageStatement]
       @edition = params[:edition]
-      @titleName = params[:titleName]
-      @isPeerReviewed = params[:isPeerReviewed]
-      @pubType = params[:pubType]
-      @publisherName = params[:publisherName]
-      @description = params[:description]
       @url = params[:url]
     end
   end

--- a/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-managed-update-custom-fields.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx/1.13.5
       Date:
-      - Tue, 31 Jul 2018 20:02:46 GMT
+      - Thu, 16 Aug 2018 18:32:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,15 +36,15 @@ http_interactions:
       - keep-alive
       X-Okapi-Trace:
       - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
-        : 202 306854us'
+        : 202 311668us'
       - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
-        : 200 44130us'
+        : 200 48554us'
       Host:
       - okapi.frontside.io
       X-Real-Ip:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-For:
-      - 10.128.0.3
+      - 10.36.2.1
       X-Forwarded-Host:
       - okapi.frontside.io
       X-Forwarded-Port:
@@ -66,7 +66,7 @@ http_interactions:
       User-Agent:
       - Ruby
       X-Okapi-Request-Id:
-      - 963202/configurations
+      - 572208/configurations
       X-Okapi-Url:
       - http://10.39.254.87:80
       X-Okapi-Permissions:
@@ -103,7 +103,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 31 Jul 2018 20:02:46 GMT
+  recorded_at: Thu, 16 Aug 2018 18:32:43 GMT
 - request:
     method: get
     uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
@@ -112,7 +112,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Flexirest/1.6.7
+      - Flexirest/1.7.0
       Connection:
       - Keep-Alive
       Accept:
@@ -135,15 +135,15 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Tue, 31 Jul 2018 20:02:46 GMT
+      - Thu, 16 Aug 2018 18:32:44 GMT
       X-Amzn-Requestid:
-      - b16a1902-94fc-11e8-bd7c-c7996ee1b7ed
+      - c3dde618-a182-11e8-8264-9bbf044c47b7
       X-Amzn-Remapped-Content-Length:
       - '1217'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Amz-Apigw-Id:
-      - K6L__EYCIAMF4eQ=
+      - Lutz2F0eIAMFQXg=
       X-Amzn-Remapped-Server:
       - Microsoft-IIS/8.5
       Cache-Control:
@@ -155,15 +155,15 @@ http_interactions:
       Pragma:
       - no-cache
       X-Amzn-Remapped-Date:
-      - Tue, 31 Jul 2018 20:02:46 GMT
+      - Thu, 16 Aug 2018 18:32:44 GMT
       X-Aspnet-Version:
       - 4.0.30319
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 93e404430d11dacb3232bae72aaaee90.cloudfront.net (CloudFront)
+      - 1.1 90d62e521ee2c5442b186a2cbca3fc9d.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - sK_cY1nFWoBx6rG2kg8lKEI704fqbSYCU90xBWPmx3315bbeWtBIrw==
+      - ojE9Y6Qj7gXX0s7GqNDH2bZdq4dgbYJmGeTwPXkmoxNl5EyPX_8MWw==
     body:
       encoding: UTF-8
       string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
@@ -171,5 +171,138 @@ http_interactions:
         Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
         Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
     http_version: 
-  recorded_at: Tue, 31 Jul 2018 20:02:46 GMT
+  recorded_at: Thu, 16 Aug 2018 18:32:44 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":false,"isHidden":false,"customCoverageList":[],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":null,"titleName":"ESI:
+        Electrical Supply Industries of the World","pubType":"BookSeries","isPeerReviewed":false,"publisherName":"ABS
+        Energy Research","edition":null,"description":null,"url":null,"proxy":{"id":"\u003cn\u003e","inherited":false}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.7.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 16 Aug 2018 18:32:44 GMT
+      X-Amzn-Requestid:
+      - c479d819-a182-11e8-a91a-510ab8dd74c8
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lut0AHzdIAMFWcA=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 18:32:44 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d56db0d65906a3edce526dc6600d65c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mJlFF7XZVTwY95AFil5JwNNLYR8pW1vI_dhsls606ZIOqyifpfZNBg==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 18:32:44 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/530/titles/417981
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.7.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1217'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 16 Aug 2018 18:32:45 GMT
+      X-Amzn-Requestid:
+      - c491ccb5-a182-11e8-8943-9d49e1fba4af
+      X-Amzn-Remapped-Content-Length:
+      - '1217'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lut0CFdboAMF59w=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 18:32:44 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 28b1b9930ccdd3e560b3f8d56677a679.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fBcHdEZ4Cx64HYP8PkDcFjl3Hg2uusnNNVYyzs_YGEihI5f5OrlWng==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":417981,"titleName":"ESI: Electrical Supply Industries of
+        the World","publisherName":"ABS Energy Research","identifiersList":[{"id":"15KM","source":"MFS","subtype":0,"type":8},{"id":"417981","source":"AtoZ","subtype":0,"type":9}],"subjectsList":[{"type":"TLI","subject":"Electrical
+        Engineering"}],"isTitleCustom":false,"pubType":"BookSeries","customerResourcesList":[{"titleId":417981,"packageId":530,"packageName":"Business
+        Source Corporate","packageType":"Complete","proxy":{"id":"<n>","inherited":true},"isPackageCustom":false,"vendorId":19,"vendorName":"EBSCO","locationId":1531344,"isSelected":false,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[{"beginCoverage":"2004-01-01","endCoverage":"2006-01-01"}],"customCoverageList":[],"coverageStatement":null,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":"http://search.ebscohost.com/direct.asp?db=bch&jid=15KM&scope=site","userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":null,"edition":null,"isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 18:32:45 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -787,8 +787,7 @@ RSpec.describe 'Resources', type: :request do
                 "publisherName": 'Frontside Newspapers',
                 "edition": '5',
                 "description": 'Something something something',
-                "url": 'https://frontside.io',
-                "packageId": '19-530'
+                "url": 'https://frontside.io'
               }
             }
           }
@@ -804,21 +803,10 @@ RSpec.describe 'Resources', type: :request do
         let!(:json) { Map JSON.parse response.body }
 
         it 'responds with OK status' do
-          expect(response).to have_http_status(422)
-          expect(json.errors[0].title).to eq 'Invalid titleName'
-          expect(json.errors[0].detail).to eq 'Titlename must be blank'
-          expect(json.errors[1].title).to eq 'Invalid isPeerReviewed'
-          expect(json.errors[1].detail).to eq 'Ispeerreviewed must be blank'
-          expect(json.errors[2].title).to eq 'Invalid pubType'
-          expect(json.errors[2].detail).to eq 'Pubtype must be blank'
-          expect(json.errors[3].title).to eq 'Invalid publisherName'
-          expect(json.errors[3].detail).to eq 'Publishername must be blank'
-          expect(json.errors[4].title).to eq 'Invalid edition'
-          expect(json.errors[4].detail).to eq 'Edition must be blank'
-          expect(json.errors[5].title).to eq 'Invalid description'
-          expect(json.errors[5].detail).to eq 'Description must be blank'
-          expect(json.errors[6].title).to eq 'Invalid url'
-          expect(json.errors[6].detail).to eq 'Url must be blank'
+          expect(response).to have_http_status(200)
+          expect(json.data.attributes.isPeerReviewed).to be false
+          expect(json.data.attributes.edition).to be_nil
+          expect(json.data.attributes.description).to be_nil
         end
       end
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-525, we are able to see multiple errors when we try to update a managed resource. Reason being that we added validation in mod-kb-ebsco to let user be notified when they update fields that they are not supposed to for managed resources as addressed in https://github.com/folio-org/mod-kb-ebsco/pull/182. However, since this shows up as multiple toasts in ui, and since UI always sends the complete payload it gets from making a GET request, ignore fields that cannot be updated for a managed resource such that multiple errors do not show up and at the same time, response of PUT is not misleading because fields that cannot be updated result in correct values or be null.

## Approach
- Remove the validation added earlier
- Instead, in the controller, pass only fields that can be updated for custom/managed resources
- Adjust the unit test accordingly.

#### TODOS and Open Questions
- [ ] Fix API tests in FSE Hosting to suit this change.

## Screenshots
![resources_fix](https://user-images.githubusercontent.com/33662516/44228644-ca242200-a163-11e8-95dd-0bb413cce177.gif)

