### PR TITLE
Update validation for custom coverage in packages to accept nil and empty strings

### DIFF
--- a/app/controllers/validation/custom_package_parameters.rb
+++ b/app/controllers/validation/custom_package_parameters.rb
@@ -10,8 +10,8 @@ module Validation
 
     validates :name, presence: true
     validates :contentType, presence: true
-    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.nil? }
-    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.nil? }
+    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.blank? }
+    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.blank? }
 
     def begin_coverage_valid_date_format?
       errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -20,8 +20,8 @@ module Validation
       validates :endCoverage, absence: true, unless: :isSelected
     end
 
-    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.nil? }
-    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.nil? }
+    validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.blank? }
+    validate :end_coverage_valid_date_format?, unless: -> { endCoverage.blank? }
 
     def begin_coverage_valid_date_format?
       errors.add(:beginCoverage, 'has invalid format. Should be YYYY-MM-DD') unless

--- a/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates-empty.yml
+++ b/spec/fixtures/vcr_cassettes/put-custom-package-coverage-dates-empty.yml
@@ -1,0 +1,476 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 311782us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45203us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 157159/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:27 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Amzn-Requestid:
+      - 3a344e8b-a18c-11e8-b246-433e9ce84f9e
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u2E4PIAMF_kw=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3fde21c07022d5a0a6d5c2e220c1ce8f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - OquZx3tdYa4wgjL4629FfXfYtTQ5VTGJU5iEQMfFzlU0uywQ2XHAFw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:27 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3a4bf618-a18c-11e8-9e60-f97861a9b319
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u4GvDoAMFbyw=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c06c27c7288c4be29d3b21ad2efad59f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Z5nbvAF6u5OKW6bmRfHNVSv_KedJMT78pVeMdb6f8DP5NICLVCoghA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3a665b1b-a18c-11e8-ae64-15a5f946a217
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u6GU3oAMF0Qg=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5f5ca5852c74982e7459707a6c9e215a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bVy8r6vGdMbqy1ESeBBZRd0UCT5hof7oiQMjarw2MgH4U1u25L5gXQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3a7db3aa-a18c-11e8-9849-6d7fc0b7ab76
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u7EwqoAMF-uw=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6b730041baa15e3191f61ffafbf4e633.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - EaeonimZoEOt-vEWNgY8KqJwLVgidrZTPgs5bxnwUhwfDFpZkmKVMA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '486'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3a909f5a-a18c-11e8-b7fb-3fde826584ed
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u8GRhoAMFvGA=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0ae737265831ce30da6ba6dcf15e3d61.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PmSK6venxBJJrkmQgcOVxFJEUhbxYsZNsswdkRyvq1XHub3h1dBmOQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: '{"contentType":1,"isSelected":true,"customCoverage":{"beginCoverage":"","endCoverage":""},"allowEbscoToAddTitles":null,"isHidden":null,"packageName":"name
+        of the ages forever and ever"}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3aa3d9a3-a18c-11e8-985d-813d5ade26ed
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u-EZ3IAMF7Kg=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c06c27c7288c4be29d3b21ad2efad59f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NNqpziNrBeF8fDg2hCQckuCf5NTTFbBE-PrOybyFgVZbVLO38xJ8Nw==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/2845506
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '469'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:40:28 GMT
+      X-Amzn-Requestid:
+      - 3abbf5e8-a18c-11e8-b64a-858057230bbb
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3u_H8iIAMF0rw=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:40:27 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 425f2389e5fb9a53718e2e31598cbbc7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4BPxtrgf1jeR6de1DlQlE2o9WNNoDt_sB5ETn8Cg20b9MmC1AzgQlw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":2845506,"packageName":"name of the ages forever and ever","isCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","titleCount":0,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":0,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":false,"packageToken":null,"packageType":"Custom"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:40:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-combined-update-empty-coverage-date-format.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-combined-update-empty-coverage-date-format.yml
@@ -1,0 +1,414 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 357805us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45365us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 607681/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:24 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Amzn-Requestid:
+      - a92c5187-a18b-11e8-b2c2-4f848e761014
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I1FAcIAMF8BQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f7d8a115683fdcb08e026f9afb821e4c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - tiQ6qbotvfIsdKOc0yK1DKlL1ONFV3puDkdgf7CFzcqkah3peiXxMQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:24 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Amzn-Requestid:
+      - a94027d7-a18b-11e8-ba74-af445071e526
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I2HH6IAMFivg=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3ca41706981cad42d8ecaabd29f88efa.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - x2xjTYRLhglOVQUKEo_4Q9lsJISVWjYmXhjltNU99SS6i7s-d5wATg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:24 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Amzn-Requestid:
+      - a955361e-a18b-11e8-bb2a-2be1ea8085f3
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I4FDtIAMFR2Q=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 28b1b9930ccdd3e560b3f8d56677a679.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sWMqJrGSa9aeTcVh0DbZnUfxZjryc8wnOGZ_LXvDWilgbyBUgbRCDg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:24 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '461'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:25 GMT
+      X-Amzn-Requestid:
+      - a9684965-a18b-11e8-985d-813d5ade26ed
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I5FnqoAMF7Kg=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0a65cba27376ea639b1f91e8b2ce1450.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gU5WIbQn3pNwJO1d7EZtDU9sxavhf5W2tcQv2JNmRXqgUGJiKiLDWA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":false},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:25 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"customCoverage":{"beginCoverage":"","endCoverage":""},"allowEbscoToAddTitles":true,"isHidden":true}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:25 GMT
+      X-Amzn-Requestid:
+      - a97ae65b-a18b-11e8-b133-536651a019c9
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I6G1poAMFT0Q=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c89cbbc4e4ec6f9b44fad110d349819a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wV7JIL6OVN5eSAFfP6NKSn3DKQqOQWmqNqDK2YZbmDiC8oaUpdeWDQ==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:25 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/19/packages/6581
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '468'
+      Connection:
+      - close
+      Date:
+      - Thu, 16 Aug 2018 19:36:25 GMT
+      X-Amzn-Requestid:
+      - a995e88b-a18b-11e8-97f8-790a93cb6c1f
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - Lu3I8FSgIAMFXVQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 16 Aug 2018 19:36:24 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3ca41706981cad42d8ecaabd29f88efa.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - QjflnnNgXzCoI_sjBtE9SsRsPoJTzv31JAZGRE_orI0TG1pqfTfXTg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":6581,"packageName":"EBSCO Biotechnology Collection: India","isCustom":false,"vendorId":19,"vendorName":"EBSCO","titleCount":156,"isSelected":true,"visibilityData":{"isHidden":true,"reason":"Hidden
+        by Customer"},"selectedCount":156,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"<n>","inherited":true},"allowEbscoToAddTitles":true,"packageToken":null,"packageType":"Complete"}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 19:36:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/packages_spec.rb
+++ b/spec/requests/packages_spec.rb
@@ -1008,6 +1008,46 @@ RSpec.describe 'Packages', type: :request do
         end
       end
 
+      describe 'combined update with empty coverage date format' do
+        let(:params) do
+          {
+            "data": {
+              "type": 'packages',
+              "attributes": {
+                "customCoverage": {
+                  "beginCoverage": '',
+                  "endCoverage": ''
+                },
+                "isSelected": true,
+                "allowKbToAddTitles": true,
+                "visibilityData": {
+                  "isHidden": true,
+                  "reason": ''
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-packages-combined-update-empty-coverage-date-format') do
+            put '/eholdings/packages/19-6581',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with expected status' do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'gives the expected coverage dates' do
+          expect(json.data.attributes.customCoverage.beginCoverage).to eql('')
+          expect(json.data.attributes.customCoverage.endCoverage).to eql('')
+        end
+      end
+
       describe 'deselecting a package' do
         let(:params) do
           {
@@ -1258,6 +1298,43 @@ RSpec.describe 'Packages', type: :request do
           .to eq('Invalid endCoverage')
         expect(json.errors.second.detail)
           .to eq('Endcoverage has invalid format. Should be YYYY-MM-DD')
+      end
+    end
+
+    describe 'changing the coverage dates to empty strings' do
+      let(:params) do
+        {
+          "data": {
+            "type": 'packages',
+            "attributes": {
+              "customCoverage": {
+                "beginCoverage": '',
+                "endCoverage": ''
+              },
+              "isSelected": true,
+              "name": 'name of the ages forever and ever',
+              "contentType": 'Aggregated Full Text'
+            }
+          }
+        }
+      end
+
+      before do
+        VCR.use_cassette('put-custom-package-coverage-dates-empty') do
+          put '/eholdings/packages/123355-2845506',
+              params: params, as: :json, headers: update_headers
+        end
+      end
+
+      it 'responds with expected status' do
+        expect(response).to have_http_status(200)
+      end
+
+      let!(:json) { Map JSON.parse response.body }
+
+      it 'gives the expected coverage dates' do
+        expect(json.data.attributes.customCoverage.beginCoverage).to eql('')
+        expect(json.data.attributes.customCoverage.endCoverage).to eql('')
       end
     end
 


### PR DESCRIPTION
## Purpose
Carole noticed a bug while updating both managed and custom packages with custom coverages. We recently added validations for format of custom coverage and we were allowing custom coverages to be nil where as UI passes custom coverage as empty strings in packages when not set.
All unit tests that were written were checking by passing `nil` as value for custom coverages and we could not detect this issue then. 

## Approach
- Modify check for nil? to blank? which checks for both nil and empty
- Add more unit tests that pass custom coverage as empty strings for both managed and custom packages.

## Screenshots
![packages_custom_coverage](https://user-images.githubusercontent.com/33662516/44231407-0c516180-a16c-11e8-9ccc-6902f53032cf.gif)

