### PR TITLE
UIEH-177: GET and PUT of package tokens at package level

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -103,6 +103,7 @@ class PackagesController < ApplicationController
         :isSelected,
         :allowKbToAddTitles,
         proxy: %i[id inherited],
+        packageToken: [:value],
         visibilityData: [:isHidden],
         customCoverage: %i[beginCoverage endCoverage]
       )
@@ -114,7 +115,7 @@ class PackagesController < ApplicationController
 
   def package_update_params
     if package.is_custom
-      package_params
+      package_params.except(:packageToken)
     else
       package_params.except(:name, :contentType)
     end

--- a/app/controllers/validation/package_parameters.rb
+++ b/app/controllers/validation/package_parameters.rb
@@ -7,7 +7,7 @@ module Validation
     include ActiveModel::Validations
 
     attr_accessor :isSelected, :isHidden, :allowEbscoToAddTitles,
-                  :beginCoverage, :endCoverage
+                  :beginCoverage, :endCoverage, :value
 
     # Deselected packages cannot be customized.  Though the UI is smart enough
     # to keep this from happening, a manual request to the API could lead
@@ -18,8 +18,10 @@ module Validation
       validates :isHidden, absence: true, unless: :isSelected
       validates :beginCoverage, absence: true, unless: :isSelected
       validates :endCoverage, absence: true, unless: :isSelected
+      validates :value, absence: true, unless: :isSelected
     end
 
+    validates :value, length: { maximum: 500 }
     validate :begin_coverage_valid_date_format?, unless: -> { beginCoverage.blank? }
     validate :end_coverage_valid_date_format?, unless: -> { endCoverage.blank? }
 
@@ -49,6 +51,7 @@ module Validation
       @isHidden = params.dig(:visibilityData, :isHidden)
       @beginCoverage = params.dig(:customCoverage, :beginCoverage)
       @endCoverage = params.dig(:customCoverage, :endCoverage)
+      @value = params.dig(:packageToken, :value)
     end
   end
 end

--- a/app/deserializable/deserializable_package.rb
+++ b/app/deserializable/deserializable_package.rb
@@ -4,6 +4,7 @@ class DeserializablePackage < JSONAPI::Deserializable::Resource
   attributes :allowKbToAddTitles,
              :contentType,
              :customCoverage,
+             :packageToken,
              :isSelected,
              :visibilityData,
              :proxy,

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -13,6 +13,7 @@ class Package
   attribute :is_selected
   attribute :name
   attribute :proxy, default: -> { Proxy.new }
+  attribute :package_token
   attribute :package_id
   attribute :package_type
   attribute :provider_id
@@ -42,6 +43,15 @@ class Package
 
     attribute :id
     attribute :inherited
+  end
+
+  class PackageToken
+    include ActiveAttr::Model
+
+    attribute :fact_name
+    attribute :help_text
+    attribute :value
+    attribute :prompt
   end
 
   def id

--- a/app/repositories/packages_repository.rb
+++ b/app/repositories/packages_repository.rb
@@ -42,6 +42,7 @@ class PackagesRepository < RmapiRepository
 
     payload = attrs.to_hash.deep_symbolize_keys
     payload[:allowEbscoToAddTitles] = payload.delete(:allowKbToAddTitles)
+    payload[:packageToken] = payload.delete(:packageToken)
     payload[:isHidden] = payload.dig(:visibilityData, :isHidden)
     payload.delete(:visibilityData)
     content_type_enum = {

--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 class SerializablePackage < SerializablePackageList
-  attributes :allow_kb_to_add_titles
+  attributes :allow_kb_to_add_titles,
+             :package_token
+
+  attribute :package_token do
+    @object.package_token&.transform_keys { |key| key.to_s.camelize(:lower).to_sym }
+  end
 end

--- a/spec/fixtures/vcr_cassettes/get-packages-success-with-package-token.yml
+++ b/spec/fixtures/vcr_cassettes/get-packages-success-with-package-token.yml
@@ -1,0 +1,166 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 23 Aug 2018 16:57:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 325542us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 45122us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 922430/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 16:57:33 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1115'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 16:57:33 GMT
+      X-Amzn-Requestid:
+      - a10cf764-a6f5-11e8-9bf0-3529a4e28725
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MFkblE4WoAMFilQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 16:57:33 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5d70fbb2ed26aa231fed552696cfa0a5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hjL3eZFEZsnFkUgHwixJ-5FF-_3ekyiSOCg5rJ9XvGYwDI7U1J0n3w==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token again with Mohan again test again","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 16:57:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-update-package-token-empty-string.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-update-package-token-empty-string.yml
@@ -1,0 +1,452 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 314339us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44338us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 719091/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Amzn-Requestid:
+      - ecba20d9-a70b-11e8-b89a-a78e63effa03
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z0Hx1oAMF2aQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9b6576d35a1a9eda48ee30caf8cac918.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mOG-mXgXXOKOcsaM-8lN_8SAEMZcnLDLyyB0OGgL-8HZAl67_C-BKw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token update","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Amzn-Requestid:
+      - eccda925-a70b-11e8-8af2-4b51930c3ee1
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z2FyLIAMF8rw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 4a93be6e6adaadeec2a72967f0720081.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - vWC_wKYfWPhmri1NvhbAvOuJc474JbsYYpfacSdcVTzStzC_adeyEA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token update","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Amzn-Requestid:
+      - ece3062b-a70b-11e8-a110-311fafdfc924
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z3HhioAMF0ug=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d3dab9ae8fe665c4fe0504e86b4de2fe.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Nam9QXnTTAFOI9981wKzaXfzWLsSisKCxXYKofvErRftHHYcfM3yKw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token update","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Amzn-Requestid:
+      - ecf81447-a70b-11e8-92f8-cdafd7e2c327
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z4FZToAMF7Rw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b7a66b6616123855c5af2d7cdf2b099f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - nVkPuWDEu4PY3XjtsfDrYiaQGbIsQTDxgS1Aw45mvsZl3Q56eJFAOQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token update","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"allowEbscoToAddTitles":null,"packageToken":{"value":""},"isHidden":null}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Amzn-Requestid:
+      - ed0d4a86-a70b-11e8-95c2-29a3a27e68dc
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z6HI6IAMFZ7A=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 9fbe771abcabdb4e14e7709f1f3c6e94.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 523IxBh-1fcBpwUX1RkwZC0FbJgyWMH5Ya_SDtqHSivBdO9SdHKvfA==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:37:10 GMT
+      X-Amzn-Requestid:
+      - ed247c0f-a70b-11e8-b196-557e6ae68bab
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7z7FDPIAMFbJw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:37:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c14d1dd7b538a9c80411fdf27e8cb2c8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Bqr8l04ju95QGmHZgpRkPpJ9L1nqwUlt8G1o0DP2wDE6Hn4N5DePsw==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:37:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-update-package-token.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-update-package-token.yml
@@ -1,0 +1,454 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 305210us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 43698us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 686478/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Amzn-Requestid:
+      - a52b7f0d-a70b-11e8-83e9-d5d4dcf402a4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hEEXcIAMF9pw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 e000b4829c397da077a65028075a32a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - S7HPqc-BVSgd7-hc3TNKaxGuRu3tHtTSRkwSxcubJxVjoTWhNnNA3A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"JSON
+        McTeamface","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Amzn-Requestid:
+      - a54129e1-a70b-11e8-aab3-0f403e406be0
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hFHxKoAMFesA=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f05c071c806220a4a58a278496a54430.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-b6YsnAN-ykMk_wK3x0LFfje6Qx_30Izkh-uB2Wg3AflMbvsCQtS5w=="
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"JSON
+        McTeamface","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Amzn-Requestid:
+      - a555ea2e-a70b-11e8-ac2c-ef951afd7345
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hHHEuIAMFhwQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a00eb4657c3b62cedb9b6571825eb82d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6D-dvAh2njf8yZE9sAgvXkywCrLllT9ZfDtHe6uUHpMrzGaH-Gy42Q==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"JSON
+        McTeamface","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:09 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Amzn-Requestid:
+      - a573ab47-a70b-11e8-ad50-db24ee0425a4
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hJFjjoAMFiSQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bdfe34c94134f86b07ebb7714d12d095.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - zpNPI_RTowrTcRElZKMbTzQel93H2n6HVJHJFTqg15upBeYNkVDToQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"JSON
+        McTeamface","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:09 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"allowEbscoToAddTitles":null,"packageToken":{"value":"test
+        package token update"},"isHidden":null}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:10 GMT
+      X-Amzn-Requestid:
+      - a58c8a7b-a70b-11e8-aead-3b6ea7e1d032
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hKG7koAMFvjw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 27f5831be5a9ad411fca9c84fe627bdc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gWgfcNLTmHzwtQMIYKhs9jvKqoynLHbP1Hm9tDjWTh_nJkbf4SRUZA==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:10 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1088'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:35:10 GMT
+      X-Amzn-Requestid:
+      - a5abaae2-a70b-11e8-bec1-b53feeebb8eb
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF7hMHXroAMFXdw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:35:09 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3b1807627d3f1dc0cdeb157fc313627b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 86whDU0kQPSI5h8FDcAj4cKgUHBAaX41iYtq8vopB7q96a6DL4HmcQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":false,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":"test
+        package token update","prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:35:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-update-with-lengthy-package-token.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-update-with-lengthy-package-token.yml
@@ -1,0 +1,223 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 23 Aug 2018 19:55:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 306680us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44141us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 946394/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:55:41 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:55:41 GMT
+      X-Amzn-Requestid:
+      - 839ac919-a70e-11e8-86c3-ab9a47c2dced
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF-hmGk0IAMFdug=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:55:41 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 69871091d5ae923909dc2904245b7354.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - RM0aWGGBH1zPr5SAlQxv8vs3YXt1GVtIb9S7qtY6qbKXz0RBJZfVLQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:55:41 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:55:41 GMT
+      X-Amzn-Requestid:
+      - 83b8fedf-a70e-11e8-8429-99c291304049
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF-hoHNkIAMFnJg=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:55:41 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 7c972d2210a2e2f3fddbb92b4c35f72e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 69ZZone59G3nBbRK-6G0cXKtnevr5CkG3ZXdQCpQKk3EZjr8ESuS3A==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:55:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-packages-isselected-update-without-package-token.yml
+++ b/spec/fixtures/vcr_cassettes/put-packages-isselected-update-without-package-token.yml
@@ -1,0 +1,448 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=KB_EBSCO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 23 Aug 2018 19:40:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.4.1-SNAPSHOT.21 http://10.39.255.17:8081/configurations/entries..
+        : 202 375606us'
+      - 'GET mod-configuration-4.0.4-SNAPSHOT.36 http://10.39.247.129:8081/configurations/entries..
+        : 200 44322us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.5
+      X-Forwarded-For:
+      - 10.128.0.5
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=KB_EBSCO"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 197784/configurations
+      X-Okapi-Url:
+      - http://10.39.254.87:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "28fd0ce0-108e-4471-8a7b-4645319fd707",
+            "module" : "KB_EBSCO",
+            "configName" : "api_credentials",
+            "code" : "kb.ebsco.credentials",
+            "description" : "EBSCO RM-API Credentials",
+            "enabled" : true,
+            "value" : "customer-id=TEST_CUSTOMER_ID&api-key=TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-06-26T13:23:48.592+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-06-26T13:23:48.592+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 1,
+          "resultInfo" : {
+            "totalRecords" : 1,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:03 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 5450879e-a70c-11e8-9872-a9c59ff52a2b
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8O-FjTIAMFlNA=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a86da8347e06cd1a49dfa25142e0bbf8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PrWLcUFlUree-rWJF8SNUR3ODN_ZBmLqeHIGsTRNdjUZOUNJdb_NzA==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 54e96d23-a70c-11e8-9333-bb7fadb1b779
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8PIGg-IAMFl_A=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a1b9c0f574e30dae7536945f59627868.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - "-F9yaxObWgOtoWRbsSnezbdQpA4qvZC7syqcqkvGR6Bn949AipazHQ=="
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 54fd1ba0-a70c-11e8-a114-6d3cb97b3593
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8PKGN-oAMFRHw=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bdfe34c94134f86b07ebb7714d12d095.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mGYN6UM7FczsMPO3738RY1BQ8huRx4lbC5B75JllUsXMiHhKsXy1NQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 55164912-a70c-11e8-b6fd-792b90208c0a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8PLFWQoAMFbjA=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d3dab9ae8fe665c4fe0504e86b4de2fe.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - spjRiXlK1RaCcNHj251hqU1cbNHpNVKY46MELcJpxNm-nQdRO2bYfg==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"allowEbscoToAddTitles":null,"packageToken":null,"isHidden":null}'
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 552ba64e-a70c-11e8-b8f8-cd51b6a2a0ca
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8PNH3poAMFqSQ=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a00eb4657c3b62cedb9b6571825eb82d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - r81q0IBAEQTOvOmOInjM-WwOxJVoFrqxpE0WlwptE3y1-OLFrGq1RA==
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/18/packages/343
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.ebsco.io
+      User-Agent:
+      - http.rb/3.3.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1064'
+      Connection:
+      - close
+      Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Amzn-Requestid:
+      - 554bff44-a70c-11e8-a474-21a4011e417c
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - MF8PPEy3IAMF8eA=
+      X-Amzn-Remapped-Date:
+      - Thu, 23 Aug 2018 19:40:04 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d3dab9ae8fe665c4fe0504e86b4de2fe.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 11ydk1PWc1ryj1gmJXczMqWKbKpfZhjW21ZdeklXnuhHEw1_VFL4cQ==
+    body:
+      encoding: UTF-8
+      string: '{"packageId":343,"packageName":"InfoTrac Custom","isCustom":false,"vendorId":18,"vendorName":"Gale
+        | Cengage","titleCount":15291,"isSelected":true,"visibilityData":{"isHidden":false,"reason":""},"selectedCount":15291,"isTokenNeeded":true,"contentType":"AggregatedFullText","customCoverage":{"beginCoverage":"","endCoverage":""},"proxy":{"id":"TestingFolio","inherited":true},"allowEbscoToAddTitles":false,"packageToken":{"factName":"[[gale.customcode.infocust]]","helpText":"<ul
+        style=\"list-style-type: disc;\">\r\n    <li style=\"line-height: normal;
+        margin: 0in 0in 12pt;\">Enter your Gale® custom package code in the space
+        provided below. The custom code may contain a combination of alpha/numeric
+        characters, varying in length.<br />\r\n    <br />\r\n    Example: The custom
+        package code immediately follows res_id=info:sid/gale: in a URL. The custom
+        package code in the following URL is SP00.<br />\r\n    <br />\r\n    http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&a","value":null,"prompt":"res_id=info:sid/gale:"},"packageType":"Variable"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 19:40:04 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-177, we are supposed to implement GET and PUT of package tokens at package level.

## Approach
- Add support for GET and PUT of package tokens at package level
- Uncover an RM API issue with updating package tokens for certain packages(More about this in TODO  section)
- Write associated unit tests

#### TODOS and Open Questions
- [ ] Uncovered an issue with RM API in updating tokens at package level for certain packages when we provide the full payload containing coverage dates; which the team is aware of and will fix eventually at some point
- [ ] Revise and add more unit tests with full payload after the RM API team fixes the issue on their end.

## Screenshots
![packagetokens](https://user-images.githubusercontent.com/33662516/44549749-0de0d380-a6f0-11e8-882c-fe72584bc5da.gif)

