### PR TITLE
Fix type of the `providerToken` field

### DIFF
--- a/ramls/providerListAttributes.json
+++ b/ramls/providerListAttributes.json
@@ -20,7 +20,7 @@
       "example": 49
     },
     "providerToken": {
-      "type": {"type": ["object", "null"]},
+      "type": "object",
       "description": "Provider token",
       "$ref": "providerToken.json"
     },


### PR DESCRIPTION
For some reason, the `type` of this field was an object containing an array: `{"type": ["object", "null"]}`. Unless there is some subtlety of JSON Schema that I don't know about, I think this must be a simple typo. At any rate, it prevented mod-graphql from properly ingesting the schema, so I have changed to to `"object"`, which seems from context to be correct.

(See https://issues.folio.org/browse/MODGQL-55 if interested in the history.)
