### PR TITLE
Fix proxy inheritance handling at package level to match provider and resource

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -102,7 +102,7 @@ class PackagesController < ApplicationController
         :contentType,
         :isSelected,
         :allowKbToAddTitles,
-        proxy: %i[id inherited],
+        proxy: [:id],
         packageToken: [:value],
         visibilityData: [:isHidden],
         customCoverage: %i[beginCoverage endCoverage]

--- a/app/repositories/packages_repository.rb
+++ b/app/repositories/packages_repository.rb
@@ -44,6 +44,10 @@ class PackagesRepository < RmapiRepository
     payload[:allowEbscoToAddTitles] = payload.delete(:allowKbToAddTitles)
     payload[:packageToken] = payload.delete(:packageToken)
     payload[:isHidden] = payload.dig(:visibilityData, :isHidden)
+    # RM API gives an error when we pass inherited as true along with updated proxy value
+    # Hard code it to false; it should not affect the state of inherited that RM API maintains
+    payload[:proxy] && payload[:proxy][:inherited] = false
+
     payload.delete(:visibilityData)
     content_type_enum = {
       aggregatedfulltext: 1,


### PR DESCRIPTION
## Purpose
Carole noticed a bug while testing out proxy implementation of packages in ui-eholdings and on further analysis, we figured that resources was passing the exact same payload but isn't failing. So, identified the discrepancy in implementation between providers, packages and resources and fixed the packages portion of it.

## Screenshots
![package_proxy](https://user-images.githubusercontent.com/33662516/45241879-19212b00-b2bc-11e8-99e2-9979e5f1aecf.gif)

