### PR TITLE
Correct Package List Serializer for Proxy

### DIFF
--- a/app/serializable/serializable_package.rb
+++ b/app/serializable/serializable_package.rb
@@ -2,7 +2,8 @@
 
 class SerializablePackage < SerializablePackageList
   attributes :allow_kb_to_add_titles,
-             :package_token
+             :package_token,
+             :proxy
 
   attribute :package_token do
     @object.package_token&.transform_keys { |key| key.to_s.camelize(:lower).to_sym }

--- a/app/serializable/serializable_package_list.rb
+++ b/app/serializable/serializable_package_list.rb
@@ -12,7 +12,6 @@ class SerializablePackageList < SerializableJSONAPIResource
              :is_custom,
              :is_selected,
              :name,
-             :proxy,
              :package_id,
              :package_type,
              :provider_id,


### PR DESCRIPTION
## Purpose
While investigating an issue reported - error `Proxy 'id' must be present when 'inherited' is false` when selecting or de-selecting some specific packages -- I observed an issue with the package list returned from mod-kb-ebsco. Specifically package list results were returning a proxy object with null id and inherited indicator.

     "proxy": {
                "id": null
                "inherited": null
            },

https://issues.folio.org/browse/UIEH-555 

Upon further investigation determined that proxy id is not returned as an element from rm api list response. It is only available when retrieving a detailed record.

## Approach
Update serializable_package_list to remove proxy.
Update serializable_package to include proxy

## Screenshots
Before
![2018-09-14 15 41 03](https://user-images.githubusercontent.com/19415226/45571649-ea173600-b834-11e8-922d-ea4b69c7eacf.gif)

After
![2018-09-14 15 33 30](https://user-images.githubusercontent.com/19415226/45571667-f8655200-b834-11e8-9803-cfdc7d077e1a.gif)

