### PR TITLE
Add default handling for rm api url when not part of configurations PUT request

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -11,7 +11,7 @@ class ConfigurationsController < ApplicationController
 
     config.customer_id = data_attributes['customerId']
     config.api_key = data_attributes['apiKey']
-    config.rmapi_base_url = data_attributes['rmapiBaseUrl']
+    config.rmapi_base_url = get_base_url(data_attributes)
 
     if config.save
       render jsonapi: config,
@@ -31,5 +31,14 @@ class ConfigurationsController < ApplicationController
 
     render jsonapi_errors: [error],
            status: :unprocessable_entity
+  end
+
+  def get_base_url(data_attributes)
+    if data_attributes['rmapiBaseUrl']
+      data_attributes['rmapiBaseUrl']
+    elsif config.rmapi_base_url
+      config.rmapi_base_url
+    else `https://sandbox.ebsco.io`
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/get-configuration-missinurl.yml
+++ b/spec/fixtures/vcr_cassettes/get-configuration-missinurl.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=EKB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries..
+        : 202 1435us'
+      - 'GET mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries..
+        : 200 42623us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.5.1
+      X-Forwarded-For:
+      - 10.36.5.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=EKB"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=EKB"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 737789/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "caaa62af-7c9b-4275-ae51-2cee3efc027b",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.url",
+            "description" : "EBSCO RM-API URL",
+            "enabled" : true,
+            "value" : "https://api.ebsco.io",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:38:30.601+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:38:30.601+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "71b214a7-05cc-4246-9f83-580f7842fd88",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.customerId",
+            "description" : "EBSCO RM-API Customer ID",
+            "enabled" : true,
+            "value" : "TEST_CUSTOMER_ID",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:38:30.812+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:38:30.812+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "89992a52-474c-4b62-a42f-b9cb2578eed1",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.apiKey",
+            "description" : "EBSCO RM-API API Key",
+            "enabled" : true,
+            "value" : "TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:38:31.008+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:38:31.008+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 3,
+          "resultInfo" : {
+            "totalRecords" : 3,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/put-configuration-missing-url.yml
+++ b/spec/fixtures/vcr_cassettes/put-configuration-missing-url.yml
@@ -1,0 +1,858 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=EKB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries..
+        : 202 510450us'
+      - 'GET mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries..
+        : 200 244605us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=EKB"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=EKB"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 586058/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "064dd0a4-7c7b-4c15-be40-1b815aa69d36",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.url",
+            "description" : "EBSCO RM-API URL",
+            "enabled" : true,
+            "value" : "https://api.ebsco.io",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:13.706+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:13.706+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "6b2cff88-7040-492f-a6eb-6ed331c8b985",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.customerId",
+            "description" : "EBSCO RM-API Customer ID",
+            "enabled" : true,
+            "value" : "TEST_CUSTOMER_ID",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:13.911+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:13.911+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "ba28eebb-edac-4aed-b27d-1440668d55ac",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.apiKey",
+            "description" : "EBSCO RM-API API Key",
+            "enabled" : true,
+            "value" : "TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:14.108+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:14.108+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 3,
+          "resultInfo" : {
+            "totalRecords" : 3,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:29 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors?count=1&offset=1&orderby=vendorname&search=zz12
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      Host:
+      - api.ebsco.io
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 17 Sep 2018 20:38:29 GMT
+      X-Amzn-Requestid:
+      - a27ee038-bab9-11e8-9f83-0fe4d0bbbec5
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - NYeO0FV8oAMFfGA=
+      X-Amzn-Remapped-Date:
+      - Mon, 17 Sep 2018 20:38:29 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 91ccbcd6bac9f333587d2a41caeeb0c5.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 20Cixrmo4EoW-McEK9wbiZ8m4ubPNyXWZ4P56r0XYxrLrVf5GR4rKw==
+    body:
+      encoding: UTF-8
+      string: '{"totalResults":0,"vendors":[]}'
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:29 GMT
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=EKB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries..
+        : 202 864us'
+      - 'GET mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries..
+        : 200 42670us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=EKB"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=EKB"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 653743/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "064dd0a4-7c7b-4c15-be40-1b815aa69d36",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.url",
+            "description" : "EBSCO RM-API URL",
+            "enabled" : true,
+            "value" : "https://api.ebsco.io",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:13.706+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:13.706+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "6b2cff88-7040-492f-a6eb-6ed331c8b985",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.customerId",
+            "description" : "EBSCO RM-API Customer ID",
+            "enabled" : true,
+            "value" : "TEST_CUSTOMER_ID",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:13.911+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:13.911+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "ba28eebb-edac-4aed-b27d-1440668d55ac",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.apiKey",
+            "description" : "EBSCO RM-API API Key",
+            "enabled" : true,
+            "value" : "TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-09-17T20:30:14.108+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-17T20:30:14.108+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 3,
+          "resultInfo" : {
+            "totalRecords" : 3,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:29 GMT
+- request:
+    method: delete
+    uri: https://okapi.frontside.io/configurations/entries/064dd0a4-7c7b-4c15-be40-1b815aa69d36
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:30 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'DELETE mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries/064dd0a4-7c7b-4c15-be40-1b815aa69d36
+        : 202 1658us'
+      - 'DELETE mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries/064dd0a4-7c7b-4c15-be40-1b815aa69d36
+        : 204 46871us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries/064dd0a4-7c7b-4c15-be40-1b815aa69d36"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries/064dd0a4-7c7b-4c15-be40-1b815aa69d36"
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 677972/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.delete"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:30 GMT
+- request:
+    method: delete
+    uri: https://okapi.frontside.io/configurations/entries/6b2cff88-7040-492f-a6eb-6ed331c8b985
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:30 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'DELETE mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries/6b2cff88-7040-492f-a6eb-6ed331c8b985
+        : 202 1564us'
+      - 'DELETE mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries/6b2cff88-7040-492f-a6eb-6ed331c8b985
+        : 204 41586us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries/6b2cff88-7040-492f-a6eb-6ed331c8b985"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries/6b2cff88-7040-492f-a6eb-6ed331c8b985"
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 720567/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.delete"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:30 GMT
+- request:
+    method: delete
+    uri: https://okapi.frontside.io/configurations/entries/ba28eebb-edac-4aed-b27d-1440668d55ac
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:30 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'DELETE mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries/ba28eebb-edac-4aed-b27d-1440668d55ac
+        : 202 2018us'
+      - 'DELETE mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries/ba28eebb-edac-4aed-b27d-1440668d55ac
+        : 204 41488us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries/ba28eebb-edac-4aed-b27d-1440668d55ac"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries/ba28eebb-edac-4aed-b27d-1440668d55ac"
+      Accept:
+      - text/plain
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 917619/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.delete"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:30 GMT
+- request:
+    method: post
+    uri: https://okapi.frontside.io/configurations/entries
+    body:
+      encoding: UTF-8
+      string: '{"module":"EKB","configName":"api_access","code":"kb.ebsco.url","description":"EBSCO
+        RM-API URL","enabled":true,"value":"https://api.ebsco.io"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'POST mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries
+        : 202 1158us'
+      - 'POST mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries
+        : 201 46363us'
+      Location:
+      - "/configurations/entries/caaa62af-7c9b-4275-ae51-2cee3efc027b"
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 968489/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.post","configuration.entries.item.post"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "caaa62af-7c9b-4275-ae51-2cee3efc027b",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.url",
+          "description" : "EBSCO RM-API URL",
+          "enabled" : true,
+          "value" : "https://api.ebsco.io",
+          "metadata" : {
+            "createdDate" : "2018-09-17T20:38:30.601+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2018-09-17T20:38:30.601+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:30 GMT
+- request:
+    method: post
+    uri: https://okapi.frontside.io/configurations/entries
+    body:
+      encoding: UTF-8
+      string: '{"module":"EKB","configName":"api_access","code":"kb.ebsco.customerId","description":"EBSCO
+        RM-API Customer ID","enabled":true,"value":"TEST_CUSTOMER_ID"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'POST mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries
+        : 202 1396us'
+      - 'POST mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries
+        : 201 43344us'
+      Location:
+      - "/configurations/entries/71b214a7-05cc-4246-9f83-580f7842fd88"
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.3
+      X-Forwarded-For:
+      - 10.128.0.3
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 770892/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.post","configuration.entries.item.post"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "71b214a7-05cc-4246-9f83-580f7842fd88",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.customerId",
+          "description" : "EBSCO RM-API Customer ID",
+          "enabled" : true,
+          "value" : "TEST_CUSTOMER_ID",
+          "metadata" : {
+            "createdDate" : "2018-09-17T20:38:30.812+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2018-09-17T20:38:30.812+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:30 GMT
+- request:
+    method: post
+    uri: https://okapi.frontside.io/configurations/entries
+    body:
+      encoding: UTF-8
+      string: '{"module":"EKB","configName":"api_access","code":"kb.ebsco.apiKey","description":"EBSCO
+        RM-API API Key","enabled":true,"value":"TEST_API_KEY"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Mon, 17 Sep 2018 20:38:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'POST mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries
+        : 202 1422us'
+      - 'POST mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries
+        : 201 43441us'
+      Location:
+      - "/configurations/entries/89992a52-474c-4b62-a42f-b9cb2578eed1"
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.128.0.4
+      X-Forwarded-For:
+      - 10.128.0.4
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - '081447/configurations'
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.item.post","configuration.entries.item.post"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id" : "89992a52-474c-4b62-a42f-b9cb2578eed1",
+          "module" : "EKB",
+          "configName" : "api_access",
+          "code" : "kb.ebsco.apiKey",
+          "description" : "EBSCO RM-API API Key",
+          "enabled" : true,
+          "value" : "TEST_API_KEY",
+          "metadata" : {
+            "createdDate" : "2018-09-17T20:38:31.008+0000",
+            "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+            "updatedDate" : "2018-09-17T20:38:31.008+0000",
+            "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 17 Sep 2018 20:38:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/configurations_spec.rb
+++ b/spec/requests/configurations_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe 'Configurations', type: :request do
     ]
   end
 
+  let(:resource_with_missing_url) do
+    [
+      '/eholdings/configuration',
+      params: {
+        data: {
+          type: 'configurations',
+          id: 'default',
+          attributes: {
+            customerId: customer_id,
+            apiKey: api_key
+          }
+        }
+      }.to_json,
+      headers: headers
+    ]
+  end
+
   let(:resource_with_invalid_content_type_header) do
     [
       '/eholdings/configuration',
@@ -104,6 +121,38 @@ RSpec.describe 'Configurations', type: :request do
       end
 
       it 'contains valid attributes' do
+        expect(json.data.attributes.customerId).to eql(customer_id)
+        expect(json.data.attributes.apiKey).to eql(masked_api_key)
+        expect(json.data.attributes.rmapiBaseUrl).to eql(rmapi_url)
+      end
+    end
+  end
+
+  describe 'setting the configuration with missing url' do
+    before do
+      VCR.use_cassette('put-configuration-missing-url') do
+        put(*resource_with_missing_url)
+      end
+    end
+
+    let!(:json) { Map JSON.parse response.body }
+
+    it 'expects the response to have 200' do
+      expect(response).to have_http_status(200)
+    end
+
+    describe 'reading the configuration' do
+      before do
+        VCR.use_cassette('get-configuration-missinurl') do
+          get(*resource)
+        end
+      end
+
+      it 'expect the response to be 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'updates configuration and defaults to currently configured url' do
         expect(json.data.attributes.customerId).to eql(customer_id)
         expect(json.data.attributes.apiKey).to eql(masked_api_key)
         expect(json.data.attributes.rmapiBaseUrl).to eql(rmapi_url)


### PR DESCRIPTION
## Purpose
After most recent update to mod-kb-ebsco https://github.com/folio-org/mod-kb-ebsco/pull/205, the configurations end  point PUT request now accepts rmapiBaseUrl as part of the request.


```{
    "data": {
        "id": "configuration",
        "type": "configurations",
        "attributes": {
            "customerId": "custid",
            "apiKey": "****************************************",
            "rmapiBaseUrl": "https://api.ebsco.io"
        }
    },
    "jsonapi": {
        "version": "1.0"
    }
}
```

UI eHoldings has not yet been updated to pass in the url parameter -- this will be covered in the following planned story.
https://issues.folio.org/browse/UIEH-548

In the interim, mod-kb-ebsco needs to support PUT Configurations requests from UI eHoldings that do not include a rmapiBaseUrl attribute yet

## Approach
Update configurations PUT request as follows:
(1) use rmapiBaseUrl attribute if it is passed as part of the PUT request
(2)use current configuration setting (if it is available)
(3)default to `https://sandbox.ebsco.io` if 1 and 2 are not available


