### PR TITLE
Update to version 1.0.2 after patch release for version 1.0.1

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -1,5 +1,5 @@
 {
-  "id": "mod-kb-ebsco-1.0.1",
+  "id": "mod-kb-ebsco-1.0.2",
   "name": "kb-ebsco",
   "provides": [
     {
@@ -47,7 +47,7 @@
   ],
   "permissionSets" : [],
   "launchDescriptor": {
-    "dockerImage": "mod-kb-ebsco:1.0.1",
+    "dockerImage": "mod-kb-ebsco:1.0.2",
     "dockerArgs": {
       "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
     },


### PR DESCRIPTION
## Purpose
Update code changes made to mod-kb-ebsco after tagged V1.0.1 patch release to reflect new 1.0.2 release number.
 
https://github.com/folio-org/mod-kb-ebsco/releases/tag/V1.0.1

## Approach
Update release version in ModuleDescriptor.json to 1.02
