### PR TITLE
UIEH-559: Response should contain only identifier types and subtypes that UIEH needs

### DIFF
--- a/app/serializable/serializable_title_list.rb
+++ b/app/serializable/serializable_title_list.rb
@@ -43,7 +43,8 @@ class SerializableTitleList < SerializableJSONAPIResource
     }
 
     if @object.identifiersList
-      sorted_identifiers_list = @object.identifiersList.sort_by { |identifier| [identifier.subtype, identifier.type] }
+      identifiers_list = @object.identifiersList.select { |identifier| ((identifier.type.zero? || identifier.type == 1) && (identifier.subtype == 1 || identifier.subtype == 2)) }
+      sorted_identifiers_list = identifiers_list.sort_by { |identifier| [identifier.subtype, identifier.type] }
       sorted_identifiers_list.map do |identifier|
         {
           id: identifier['id'],

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -373,9 +373,8 @@ RSpec.describe 'Titles', type: :request do
       expect(response).to have_http_status(200)
       expect(json_n.data.length).to equal(25)
       expect(json_n.data[6].id).to eq('3119726')
-      expect(json_n.data[6].attributes.identifiers.length).to eq(2)
-      expect(json_n.data[6].attributes.identifiers[0].subtype).to eq('Empty')
-      expect(json_n.data[6].attributes.identifiers[1].subtype).to eq('Online')
+      expect(json_n.data[6].attributes.identifiers.length).to eq(1)
+      expect(json_n.data[6].attributes.identifiers[0].subtype).to eq('Online')
     end
   end
 
@@ -409,9 +408,9 @@ RSpec.describe 'Titles', type: :request do
 
     it 'returns identifiers as human readable types and subtypes' do
       expect(json.data.attributes.identifiers).to include(
-        'id' => '316875',
-        'type' => 'BHM',
-        'subtype' => 'Empty'
+        'id' => '978-0-19-512574-0',
+        'type' => 'ISBN',
+        'subtype' => 'Print'
       )
     end
 
@@ -450,14 +449,13 @@ RSpec.describe 'Titles', type: :request do
 
     let!(:json) { Map JSON.parse response.body }
 
-    it 'contains identifiers that are sorted by subtype and type' do
+    it 'contains identifiers that are sorted by subtype and type and contain only types and subtypes that our UI needs' do
       expect(response).to have_http_status(200)
       expect(json.data.id).to eq('169441')
-      expect(json.data.attributes.identifiers.length).to eq(4)
-      expect(json.data.attributes.identifiers[0].subtype).to eq('Empty')
-      expect(json.data.attributes.identifiers[1].subtype).to eq('Print')
-      expect(json.data.attributes.identifiers[2].subtype).to eq('Online')
-      expect(json.data.attributes.identifiers[0].type).to eq('BHM')
+      expect(json.data.attributes.identifiers.length).to eq(3)
+      expect(json.data.attributes.identifiers[0].subtype).to eq('Print')
+      expect(json.data.attributes.identifiers[1].subtype).to eq('Online')
+      expect(json.data.attributes.identifiers[0].type).to eq('ISBN')
       expect(json.data.attributes.identifiers[1].type).to eq('ISBN')
     end
   end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-559, while running nightmare tests on UIEH, we were seeing flickering issue between list and detailed record. One of the reasons for that effect is that list records and detailed records contain differing lists of identifiers. Per our UI requirement, we need only those identifiers that have type = 0(ISSN) or 1(ISBN) and subtype = 1(Print) or 2(Online). This PR modifies the backend code to provide UI only with identifiers that are needed by UIEH.

## Approach
- In the place, where we are normalizing list to return sorted list of identifiers, filter the list that we get from RM API, sort the filtered list and return in response.
- Adjust unit tests accordingly because some of them look for other types or subtypes that mod-kb-ebsco no longer returns.

## Screenshots
![issn-isbn](https://user-images.githubusercontent.com/33662516/45842548-001c6f00-bceb-11e8-8e26-16455cb87a4d.gif)
