### PR TITLE
MODKBEBSCO-8 & MODKBEBSCO-10: Cleanup q param from titles endpoint as well as RAML

### DIFF
--- a/app/controllers/titles_controller.rb
+++ b/app/controllers/titles_controller.rb
@@ -14,7 +14,6 @@ class TitlesController < ApplicationController
 
     if title_query_params_validation.valid?
       @titles = titles.all(
-        q: params[:q],
         page: params[:page],
         filter: params[:filter],
         sort: params[:sort],

--- a/app/models/rm_api_resource.rb
+++ b/app/models/rm_api_resource.rb
@@ -20,13 +20,13 @@ class RmApiResource < Flexirest::Base
   # Having our Flexirest resources configured is great, but each one
   # needs use the correct credentials in order to make its
   # requests. However, all of the finders exist on the Class
-  # level. E.g. `Title.find(title_id)` and `Title.all(q:
-  # params[:q])`. In order to preserve the finders, we return a new,
+  # level. E.g. `Title.find(title_id)` and `Title.all(filter: `
+  # params[:filter])`. In order to preserve the finders, we return a new,
   # anonymous class that contains the per-request configuration so
   # they work the same, just scoped to this particular request:
   #
   #   Title.configure(config).find(title_id)
-  #   Title.configure(config).all(q: params[:q])
+  #   Title.configure(config).all(filter: params[:filter])
   def self.configure(config)
     Class.new(self).tap do |subclass|
       subclass.verbose!

--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -23,16 +23,8 @@ class Title < RmApiResource
       isxn = filters[:isxn]
       subject = filters[:subject]
       publisher = filters[:publisher]
-      query = request.get_params.delete(:q)
 
-      if query && querykeys.size == 1
-        fail ActionController::BadRequest, 'Conflicting query parameters'
-      end
-
-      if query
-        request.get_params[:search] = query
-        request.get_params[:searchfield] = 'titlename'
-      elsif titlename
+      if titlename
         request.get_params[:search] = titlename
         request.get_params[:searchfield] = 'titlename'
       elsif isxn

--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -804,12 +804,6 @@ types:
   get:
     description: Get a set of titles matching the given search criteria.
     queryParameters:
-      q:
-        displayName: Query by Title Name
-        type: string
-        description: String to search title name to get a collection of titles
-        example: War and Peace
-        required: false
       page:
         displayName: Page offset
         type: integer

--- a/spec/requests/titles_spec.rb
+++ b/spec/requests/titles_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Titles', type: :request do
   describe 'searching for titles' do
     before do
       VCR.use_cassette('search-titles') do
-        get '/eholdings/titles/?q=ebsco', headers: okapi_headers
+        get '/eholdings/titles/?filter[name]=ebsco', headers: okapi_headers
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with pagination' do
       before do
         VCR.use_cassette('search-titles-page2') do
-          get '/eholdings/titles/?q=ebsco&page=2', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=ebsco&page=2', headers: okapi_headers
         end
       end
 
@@ -44,7 +44,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with count within range' do
       before do
         VCR.use_cassette('search-titles-specify-count') do
-          get '/eholdings/titles/?q=ebsco&count=5', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=ebsco&count=5', headers: okapi_headers
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with count out of range' do
       before do
         VCR.use_cassette('search-titles-specify-count-out-of-range') do
-          get '/eholdings/titles/?q=e&count=150', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=e&count=150', headers: okapi_headers
         end
       end
 
@@ -76,7 +76,7 @@ RSpec.describe 'Titles', type: :request do
       before do
         VCR.use_cassette('search-titles-filter-book') do
           filter = { filter: { type: 'book' } }.to_query
-          get "/eholdings/titles/?q=news&#{filter}", headers: okapi_headers
+          get "/eholdings/titles/?filter[name]=news&#{filter}", headers: okapi_headers
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.describe 'Titles', type: :request do
         before do
           VCR.use_cassette('search-titles-filter-book-selection') do
             filter = { filter: { type: 'book', selected: true } }.to_query
-            get "/eholdings/titles/?q=news&#{filter}", headers: okapi_headers
+            get "/eholdings/titles/?filter[name]=news&#{filter}", headers: okapi_headers
           end
         end
 
@@ -111,7 +111,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with an invalid filter param' do
       before do
         VCR.use_cassette('search-titles-filter-invalid') do
-          get '/eholdings/titles/?q=news&filter=invalid', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=news&filter=invalid', headers: okapi_headers
         end
       end
 
@@ -126,7 +126,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with an invalid query param filter[selected]' do
       before do
         VCR.use_cassette('search-titles-invalid-query-param-selected') do
-          get '/eholdings/titles/?q=ebsco&filter[selected]=doNotEnter', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=ebsco&filter[selected]=doNotEnter', headers: okapi_headers
         end
       end
 
@@ -141,7 +141,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with an invalid query param filter[type]' do
       before do
         VCR.use_cassette('search-titles-invalid-query-param-type') do
-          get '/eholdings/titles/?q=ebsco&filter[type]=doNotEnter', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=ebsco&filter[type]=doNotEnter', headers: okapi_headers
         end
       end
 
@@ -156,7 +156,7 @@ RSpec.describe 'Titles', type: :request do
     describe 'with an invalid query param searchField' do
       before do
         VCR.use_cassette('search-titles-invalid-query-param-search-field') do
-          get '/eholdings/titles/?q=ebsco&searchfield=doNotEnter', headers: okapi_headers
+          get '/eholdings/titles/?filter[name]=ebsco&searchfield=doNotEnter', headers: okapi_headers
         end
       end
 
@@ -263,24 +263,6 @@ RSpec.describe 'Titles', type: :request do
         expect(response).to have_http_status(400)
         expect(json_c.errors.first.title).to eql(
           'Conflicting filter parameters'
-        )
-      end
-    end
-
-    describe 'with conflicting query parameters' do
-      before do
-        VCR.use_cassette('search-titles-query-conflict') do
-          get '/eholdings/titles/?q=ebsco&filter[name]=ebsco',
-              headers: okapi_headers
-        end
-      end
-
-      let!(:json_c) { Map JSON.parse response.body }
-
-      it 'returns a bad request' do
-        expect(response).to have_http_status(400)
-        expect(json_c.errors.first.title).to eql(
-          'Conflicting query parameters'
         )
       end
     end


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-8, after refactoring param `q=` to be `filter[name]=` instead, there is some left over code in mod-kb-ebsco to be cleaned up. This PR addresses that cleanup. Also, per https://issues.folio.org/browse/MODKBEBSCO-10, we have to update `/eholdings/titles` endpoint documentation to reflect the same.

## Approach
- Code cleanup in `titles_controller.rb` and `title.rb` to not use `q` anymore
- Modify unit tests and ensure that they still pass as expected.
- Double check a few requests to ensure that they work as expected.
- Cleanup RAML documentation for `/eholdings/titles` endpoint and run raml-lint to ensure that its valid.

## Screenshots
![code_cleanup](https://user-images.githubusercontent.com/33662516/45976103-dbd6d000-c013-11e8-90fb-7ccc37b5ebca.gif)
