### PR TITLE
MODKBEBSCO-5: Update resource PUT/POST to handle empty url

### DIFF
--- a/app/controllers/validation/resource_create_parameters.rb
+++ b/app/controllers/validation/resource_create_parameters.rb
@@ -19,7 +19,7 @@ module Validation
     validates :edition, length: { maximum: 250 }, allow_nil: true
     validates :description, length: { maximum: 1500 }, allow_nil: true
     validates :url, length: { maximum: 600 }, allow_nil: true
-    validate :url_has_valid_format?, unless: -> { url.nil? }
+    validate :url_has_valid_format?, unless: -> { url.blank? }
     validates :coverageStatement, length: { maximum: 250 }, allow_nil: true
     validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
     validate :custom_coverage_list_valid?, unless: -> { customCoverageList.blank? }

--- a/app/controllers/validation/resource_update_parameters.rb
+++ b/app/controllers/validation/resource_update_parameters.rb
@@ -26,7 +26,7 @@ module Validation
 
     validates :edition, length: { maximum: 250 }, allow_nil: true
     validate :identifiers_list_valid?, unless: -> { identifiersList.blank? }
-    validate :url_has_valid_format?, unless: -> { url.nil? }
+    validate :url_has_valid_format?, unless: -> { url.blank? }
     validate :custom_coverage_list_valid?, unless: -> { customCoverageList.blank? }
 
     def identifiers_list_valid?

--- a/spec/fixtures/vcr_cassettes/put-resources-update-empty-url.yml
+++ b/spec/fixtures/vcr_cassettes/put-resources-update-empty-url.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okapi.frontside.io/configurations/entries?query=module=EKB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.13.5
+      Date:
+      - Thu, 27 Sep 2018 18:56:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Okapi-Trace:
+      - 'GET mod-authtoken-1.5.2-SNAPSHOT.26 http://10.39.242.252:8081/configurations/entries..
+        : 202 301378us'
+      - 'GET mod-configuration-5.0.1-SNAPSHOT.45 http://10.39.249.105:8081/configurations/entries..
+        : 200 72796us'
+      Host:
+      - okapi.frontside.io
+      X-Real-Ip:
+      - 10.36.5.1
+      X-Forwarded-For:
+      - 10.36.5.1
+      X-Forwarded-Host:
+      - okapi.frontside.io
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/configurations/entries?query=module=EKB"
+      X-Scheme:
+      - https
+      X-Auth-Request-Redirect:
+      - "/configurations/entries?query=module=EKB"
+      Accept:
+      - application/json
+      X-Okapi-Tenant:
+      - fs
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+      X-Okapi-Request-Id:
+      - 409279/configurations
+      X-Okapi-Url:
+      - http://10.39.245.41:80
+      X-Okapi-Permissions:
+      - '["configuration.entries.collection.get","configuration.entries.collection.get"]'
+      X-Okapi-User-Id:
+      - 1ad737b0-d847-11e6-bf26-cec0c932ce01
+      X-Okapi-Token:
+      - TEST_OKAPI_TOKEN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains;
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "configs" : [ {
+            "id" : "d94c5e91-fe82-4eb7-a823-7a28376831a4",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.customerId",
+            "description" : "EBSCO RM-API Customer ID",
+            "enabled" : true,
+            "value" : "TEST_CUSTOMER_ID",
+            "metadata" : {
+              "createdDate" : "2018-09-24T18:25:04.316+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-24T18:25:04.316+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "2ce03532-7126-43e1-b532-d53d4bd837ff",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.url",
+            "description" : "EBSCO RM-API URL",
+            "enabled" : true,
+            "value" : "https://api.ebsco.io",
+            "metadata" : {
+              "createdDate" : "2018-09-24T18:25:04.267+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-24T18:25:04.267+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          }, {
+            "id" : "d414f3c4-85c1-47ac-b42c-d1e0a8294c3d",
+            "module" : "EKB",
+            "configName" : "api_access",
+            "code" : "kb.ebsco.apiKey",
+            "description" : "EBSCO RM-API API Key",
+            "enabled" : true,
+            "value" : "TEST_API_KEY",
+            "metadata" : {
+              "createdDate" : "2018-09-24T18:25:04.366+0000",
+              "createdByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+              "updatedDate" : "2018-09-24T18:25:04.366+0000",
+              "updatedByUserId" : "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+            }
+          } ],
+          "totalRecords" : 3,
+          "resultInfo" : {
+            "totalRecords" : 3,
+            "facets" : [ ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 18:56:19 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/3120611/titles/19017544
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.7.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '969'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 27 Sep 2018 18:56:19 GMT
+      X-Amzn-Requestid:
+      - 04f99960-c287-11e8-bf75-c9d3b9ffe620
+      X-Amzn-Remapped-Content-Length:
+      - '969'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - N5MpCELrIAMFQCw=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 27 Sep 2018 18:56:18 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5e247ae48d5501e7c1be84d6fd290885.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - EI0Q0h2St2_z1vZ52u-66UJTBRTeq1E3V8pAiZM7AakOnKalsY9mnw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":19017544,"titleName":"Nightmare Title","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Unspecified","customerResourcesList":[{"titleId":19017544,"packageId":3120611,"packageName":"123","packageType":"Custom","proxy":{"id":"<n>","inherited":false},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-01"}],"coverageStatement":"coverage
+        statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"","edition":"","isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 18:56:19 GMT
+- request:
+    method: put
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/3120611/titles/19017544
+    body:
+      encoding: UTF-8
+      string: '{"isSelected":true,"isHidden":false,"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-01"}],"contributorsList":null,"identifiersList":null,"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"coverageStatement":"coverage
+        statement","titleName":"Nightmare Title","pubType":"Unspecified","isPeerReviewed":false,"publisherName":null,"edition":"","description":"","url":"","proxy":{"id":"\u003cn\u003e","inherited":false}}'
+    headers:
+      User-Agent:
+      - Flexirest/1.7.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 27 Sep 2018 18:56:19 GMT
+      X-Amzn-Requestid:
+      - 051362c3-c287-11e8-851c-39d7855a1e8a
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - N5MpEFZ-oAMFXwg=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 27 Sep 2018 18:56:18 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d0aba1ed008065dfa80f3b92c85f7e52.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gqRIQNFqmLcr3HkrdO_SlhOGoy--fbjLLEkDqK7oUCPn1pXgm8gYbA==
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 18:56:19 GMT
+- request:
+    method: get
+    uri: https://api.ebsco.io/rm/rmaccounts/TEST_CUSTOMER_ID/vendors/123355/packages/3120611/titles/19017544
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Flexirest/1.7.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/json
+      X-Api-Key:
+      - TEST_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '969'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 27 Sep 2018 18:56:19 GMT
+      X-Amzn-Requestid:
+      - '0532835b-c287-11e8-9319-c53d0990a2de'
+      X-Amzn-Remapped-Content-Length:
+      - '969'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Amz-Apigw-Id:
+      - N5MpGG7LIAMFrdQ=
+      X-Amzn-Remapped-Server:
+      - Microsoft-IIS/8.5
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Powered-By:
+      - ASP.NET
+      Pragma:
+      - no-cache
+      X-Amzn-Remapped-Date:
+      - Thu, 27 Sep 2018 18:56:18 GMT
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5e247ae48d5501e7c1be84d6fd290885.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Wq7JkUaShQ9yEvfjMZaBR8jqi1encrU2d9U6jM882H75hXKGfpMCIw==
+    body:
+      encoding: UTF-8
+      string: '{"titleId":19017544,"titleName":"Nightmare Title","publisherName":null,"identifiersList":[],"subjectsList":[],"isTitleCustom":true,"pubType":"Unspecified","customerResourcesList":[{"titleId":19017544,"packageId":3120611,"packageName":"123","packageType":"Custom","proxy":{"id":"<n>","inherited":false},"isPackageCustom":true,"vendorId":123355,"vendorName":"API
+        DEV CORPORATE CUSTOMER","locationId":0,"isSelected":true,"isTokenNeeded":false,"visibilityData":{"isHidden":false,"reason":""},"managedCoverageList":[],"customCoverageList":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-01"}],"coverageStatement":"coverage
+        statement","managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"customEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"url":null,"userDefinedField1":null,"userDefinedField2":null,"userDefinedField3":null,"userDefinedField4":null,"userDefinedField5":null}],"description":"","edition":"","isPeerReviewed":false,"contributorsList":[]}'
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 18:56:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -858,6 +858,37 @@ RSpec.describe 'Resources', type: :request do
           expect(json.errors.first.detail).to eq 'Url has invalid format'
         end
       end
+
+      describe 'updating a resource with an empty url' do
+        let(:params) do
+          {
+            'data' => {
+              'type' => 'resources',
+              'attributes' => {
+                'isSelected' => true,
+                'url' => ''
+              }
+            }
+          }
+        end
+
+        before do
+          VCR.use_cassette('put-resources-update-empty-url') do
+            put '/eholdings/resources/123355-3120611-19017544',
+                params: params, as: :json, headers: update_headers
+          end
+        end
+
+        it 'responds with OK status' do
+          expect(response).to have_http_status(200)
+        end
+
+        let!(:json) { Map JSON.parse response.body }
+
+        it 'returns null url' do
+          expect(json.data.attributes.url).to eq(nil)
+        end
+      end
     end
 
     describe 'trying to update an invalid resource gives the expected errors' do


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-5, mod-kb-ebsco is returning an error 
`Invalid url` when handling a PUT request for a resource which has an empty url.

## Approach
- Update validation for create and update of resources. 
- Current validation checks that the url begins with `http://` or `https://`. 
- This validation is skipped if the url value is null.
- Validation should also be skipped if the url is empty.
- Added unit test which updates a resource with an empty url to confirm it doesn't fail

Sample PUT request with empty url:

`PUT eholdings/resources/123355-3120611-19017544`

`
{"data":{"id":"123355-3120611-19017544","type":"resources","attributes":{"description":"","edition":"","isPeerReviewed":false,"isTitleCustom":true,"publisherName":"","titleId":19017544,"contributors":[],"identifiers":[],"name":"Nightmare Title","publicationType":"Unspecified","subjects":[],"coverageStatement":"coverage statement","customEmbargoPeriod":{"embargoValue":0,"embargoUnit":null},"isSelected":true,"managedEmbargoPeriod":{"embargoUnit":null,"embargoValue":0},"packageId":"123355-3120611","packageName":"123","url":"","providerId":123355,"providerName":"API DEV CORPORATE CUSTOMER","visibilityData":{"isHidden":false,"reason":""},"managedCoverages":[],"customCoverages":[{"beginCoverage":"2003-01-01","endCoverage":"2003-12-01"}],"proxy":{"id":"<n>","inherited":false}}}}
`

## Screenshots
Before:
![2018-09-27 14 41 13](https://user-images.githubusercontent.com/19415226/46168710-429ff780-c267-11e8-9600-c372d761b456.gif)
After:
![2018-09-27 14 42 21](https://user-images.githubusercontent.com/19415226/46168729-4fbce680-c267-11e8-922b-ebf6bb39472d.gif)

