### PR TITLE
MODKBEBSCO-7: Update raml file and examples for missing token support

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -347,6 +347,21 @@ types:
                         Note that this attribute can be updated both for CUSTOM AND MANAGED PACKAGES.
                       type: visibilityData
                       required: false
+                    packageToken:
+                      displayName: Package token
+                      type: object
+                      description: |
+                        Tokens are variables in content URLs that identify the customer.
+                        The token is text within the URL that needs to be replaced with an institute-specific value.
+                      example: |
+                        {
+                          "value": "hellotoken"
+                        }
+                      required: false
+                    proxy:
+                      displayName: Proxy ID
+                      type: proxy
+                      required: false
           example: !include examples/packages/packages_put_request.json
       responses:
         200:

--- a/ramls/examples/packages/packages_packageId_get_200_response.json
+++ b/ramls/examples/packages/packages_packageId_get_200_response.json
@@ -22,7 +22,17 @@
         "isHidden": true,
         "reason": ""
       },
-      "allowKbToAddTitles": false
+      "allowKbToAddTitles": false,
+      "packageToken": {
+        "factName":"siteid",
+        "prompt":"/itweb/",
+        "helpText":"<ul><li>Enter your token</li></ul>",
+        "value": "123456"
+      },
+      "proxy": {
+        "id": "<n>",
+        "inherited": true
+      }
     },
     "relationships": {
       "resources": {

--- a/ramls/examples/packages/packages_put_request.json
+++ b/ramls/examples/packages/packages_put_request.json
@@ -11,6 +11,12 @@
       "isSelected": true,
       "visibilityData": {
         "isHidden": true
+      },
+      "packageToken": {
+        "value": "hellotoken"
+      },
+      "proxy": {
+        "id": "EZProxy"
       }
     }
   }

--- a/ramls/examples/providers/providers_providerId_get_200_response.json
+++ b/ramls/examples/providers/providers_providerId_get_200_response.json
@@ -6,8 +6,13 @@
       "name": "ecch",
       "packagesTotal": 2,
       "packagesSelected": 0,
-      "providerToken": null,
       "supportsCustomPackages": false,
+      "providerToken": {
+        "factName":"siteid",
+        "prompt":"/itweb/",
+        "helpText":"<ul><li>Enter your token</li></ul>",
+        "value": "123456"
+      },
       "proxy": {
         "id": "EZProxy",
         "inherited": true


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-7 -- RAML needs to be updated to include documentation for tokens.

## Approach

- update packages PUT and GET requests to include packageToken and Proxy
- update provider GET response example to include an example Proxy
- ran ./scripts/lint-raml-cop.sh to verify raml
- execute raml2html eholdings.raml > eholdings.html to create new api docs locally

## Screenshots
<img width="1669" alt="screen shot 2018-09-28 at 4 39 57 pm" src="https://user-images.githubusercontent.com/19415226/46232432-36866980-c33d-11e8-9308-18fa491f3c92.png">

