### PR TITLE
MODKBEBSCO-9, MODKBEBSCO-17 & MODKBEBSCO-18 : Update RAML to include proxies, configuration and status

### DIFF
--- a/ramls/eholdings.raml
+++ b/ramls/eholdings.raml
@@ -484,7 +484,7 @@ types:
               example: !include examples/providers/providers_providerId_404_response.json
     put:
       description: |
-        This operation allows you to update provider proxy and token values for a specifix provider ID.
+        This operation allows you to update provider proxy and token values for a specific provider ID.
       headers:
         Content-Type:
           example: application/vnd.api+json
@@ -955,3 +955,135 @@ types:
             example: !include examples/titles/titles_post_200_response.json
       400:
         description: Bad
+/eholdings/proxy-types:
+  displayName: Proxy Types
+  description: List of supported root proxy types.
+  get:
+    description: Get a list of supported root proxy types.
+    responses:
+      200:
+        body:
+          application/vnd.api+json:
+            description: An array containing supported root proxy types.
+            example: !include examples/proxies/root_proxies_get_200_response.json
+/eholdings/root-proxy:
+  displayName: Root Proxy
+  description: Root Proxy that is currently selected from proxy-type list.
+  get:
+    description: ID of root proxy that is currently selected from proxy-type list.
+    responses:
+      200:
+        body:
+          application/vnd.api+json:
+            description: ID of root proxy that is currently selected from proxy-type list.
+            example: !include examples/proxies/selected_root_proxy_get_200_response.json
+  put:
+      description: |
+        Update the current root proxy setting by selecting one from the supported list of proxy-types.
+      headers:
+        Content-Type:
+          example: application/vnd.api+json
+      body:
+        application/vnd.api+json:
+          properties:
+            data:
+              description: Needed because of JSON API
+              type: object
+              required: true
+              properties:
+                type: string
+                attributes:
+                  description: Needed because of JSON API
+                  type: object
+                  required: true
+                  properties:
+                    proxyTypeId:
+                      description: |
+                        ID of root-proxy that current selection should be updated to.
+                      type: string
+                      example: EZProxy
+                      required: true
+          example: !include examples/proxies/root_proxy_put_request.json
+      responses:
+        200:
+          description: OK
+          body:
+            application/vnd.api+json:
+              example: !include examples/proxies/root_proxy_put_200_response.json
+        422:
+          description: Unprocessable Entity
+          body:
+            application/vnd.api+json:
+              example: !include examples/proxies/root_proxy_put_422_response.json
+/eholdings/configuration:
+  displayName: Configuration
+  description: Setup KB Configuration.
+  get:
+    description: Details of KB configuration currently being used.
+    responses:
+      200:
+        body:
+          application/vnd.api+json:
+            description: Details of KB configuration currently being used.
+            example: !include examples/configuration/kb_configuration_get_200_response.json
+  put:
+      description: |
+        Update the currently set KB configuration.
+      headers:
+        Content-Type:
+          example: application/vnd.api+json
+      body:
+        application/vnd.api+json:
+          properties:
+            data:
+              description: Needed because of JSON API
+              type: object
+              required: true
+              properties:
+                type: string
+                attributes:
+                  description: Needed because of JSON API
+                  type: object
+                  required: true
+                  properties:
+                    customerId:
+                      description: |
+                        Customer ID using the KB.
+                      type: string
+                      example: apidvgvmt
+                      required: true
+                    apiKey:
+                      description: |
+                        API Key to use the KB.
+                      type: string
+                      example: xxxxxx
+                      required: true
+                    rmapiBaseUrl:
+                      description: |
+                        Base URL of the KB.
+                      type: string
+                      example: https://sandbox.ebsco.io
+                      required: true
+          example: !include examples/configuration/kb_configuration_put_request.json
+      responses:
+        200:
+          description: OK
+          body:
+            application/vnd.api+json:
+              example: !include examples/configuration/kb_configuration_put_200_response.json
+        422:
+          description: Unprocessable Entity
+          body:
+            application/vnd.api+json:
+              example: !include examples/configuration/kb_configuration_put_422_response.json
+/eholdings/status:
+  displayName: Status
+  description: Gives status of currently set KB configuration.
+  get:
+    description: Gives status of currently set KB configuration.
+    responses:
+      200:
+        body:
+          application/vnd.api+json:
+            description: Status of currently set KB configuration.
+            example: !include examples/status/status_get_200_response.json

--- a/ramls/examples/configuration/kb_configuration_get_200_response.json
+++ b/ramls/examples/configuration/kb_configuration_get_200_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "configuration",
+    "type": "configurations",
+    "attributes": {
+      "customerId": "apidvcorp",
+      "apiKey": "****************************************",
+      "rmapiBaseUrl": "https://api.ebsco.io"
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/configuration/kb_configuration_put_200_response.json
+++ b/ramls/examples/configuration/kb_configuration_put_200_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "configuration",
+    "type": "configurations",
+    "attributes": {
+      "customerId": "apidvcorp",
+      "apiKey": "****************************************",
+      "rmapiBaseUrl": "https://api.ebsco.io"
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/configuration/kb_configuration_put_422_response.json
+++ b/ramls/examples/configuration/kb_configuration_put_422_response.json
@@ -1,0 +1,12 @@
+{
+  "errors": [
+    {
+      "title": "Invalid KB API Credentials",
+      "detail": "Kb api credentials are invalid",
+      "source": {}
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/configuration/kb_configuration_put_request.json
+++ b/ramls/examples/configuration/kb_configuration_put_request.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "type": "configurations",
+    "attributes": {
+      "customerId": "apidvcorp",
+      "apiKey": "****************************************",
+      "rmapiBaseUrl": "https://api.ebsco.io"
+    }
+  }
+}

--- a/ramls/examples/proxies/root_proxies_get_200_response.json
+++ b/ramls/examples/proxies/root_proxies_get_200_response.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "id": "<n>",
+      "type": "proxyTypes",
+      "attributes": {
+        "id": "<n>",
+        "name": "None",
+        "urlMask": ""
+      }
+    },
+    {
+      "id": "EZProxy",
+      "type": "proxyTypes",
+      "attributes": {
+        "id": "EZProxy",
+        "name": "EZProxy",
+        "urlMask": "http://ezproxy.myinstitute.edu/login?url={targetURL}"
+      }
+    },
+    {
+      "id": "TestingFolio",
+      "type": "proxyTypes",
+      "attributes": {
+        "id": "TestingFolio",
+        "name": "TestingFolio",
+        "urlMask": "https://folio.frontside.io"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/proxies/root_proxy_put_200_response.json
+++ b/ramls/examples/proxies/root_proxy_put_200_response.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "id": "root-proxy",
+    "type": "rootProxies",
+    "attributes": {
+      "id": "root-proxy",
+      "proxyTypeId": "EZProxy"
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/proxies/root_proxy_put_422_response.json
+++ b/ramls/examples/proxies/root_proxy_put_422_response.json
@@ -1,0 +1,12 @@
+{
+  "errors": [
+    {
+      "title": "Invalid id",
+      "detail": "Id :Invalid proxy",
+      "source": {}
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/proxies/root_proxy_put_request.json
+++ b/ramls/examples/proxies/root_proxy_put_request.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "type": "rootProxies",
+    "attributes": {
+      "proxyTypeId": "EZProxy"
+    }
+  }
+}

--- a/ramls/examples/proxies/selected_root_proxy_get_200_response.json
+++ b/ramls/examples/proxies/selected_root_proxy_get_200_response.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "id": "root-proxy",
+    "type": "rootProxies",
+    "attributes": {
+      "id": "root-proxy",
+      "proxyTypeId": "EZProxy"
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/ramls/examples/status/status_get_200_response.json
+++ b/ramls/examples/status/status_get_200_response.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "status",
+    "type": "statuses",
+    "attributes": {
+      "isConfigurationValid": true
+    }
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-9, https://issues.folio.org/browse/MODKBEBSCO-17 and https://issues.folio.org/browse/MODKBEBSCO-18, we are supposed to update RAML to include the following endpoints - 
- /eholdings/proxy-types - GET
- /eholdings/root-proxy - GET and PUT
- /eholdings/configuration - GET and PUT
- /eholdings/status - GET

## Approach
- Hit those endpoints to understand what request/response looks like
- Generate examples based on above requests/responses
- Modify existing ramls/eholdings.raml to include these endpoints with examples
- Run scripts/lint-raml-cop.sh to verify that generated RAML is valid
- Run raml2html to preview generated HTML

## Learning
- Understand how the status endpoint is being used exactly in UIEH
