### PR TITLE
MODKBEBSCO-21: update-rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       slop (~> 3.0)
     public_suffix (3.0.2)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-21, there is a security vulnerability in rack >= 2.0.4 and <2.0.6. Our module uses 2.0.5. Update it to 2.0.6 to address the security vulnerability.

## Approach
- Update rack version using `bundle update rack`
- gemfile.lock is automatically regenerated to reflect the latest version of rack 2.0.6

## Screenshots
![screen shot 2018-11-29 at 9 23 49 am](https://user-images.githubusercontent.com/33662516/49228052-8a9ee000-f3b8-11e8-9467-75ac8f24da2b.png)
