### PR TITLE
MODKBEBSCO-22: Release V1.1.0 for Q4 Release

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -1,5 +1,5 @@
 {
-  "id": "mod-kb-ebsco-1.0.2",
+  "id": "mod-kb-ebsco-1.1.0",
   "name": "kb-ebsco",
   "provides": [
     {
@@ -47,7 +47,7 @@
   ],
   "permissionSets" : [],
   "launchDescriptor": {
-    "dockerImage": "mod-kb-ebsco:1.0.2",
+    "dockerImage": "mod-kb-ebsco:1.1.0",
     "dockerArgs": {
       "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
     },

--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -1,5 +1,5 @@
 {
-  "id": "mod-kb-ebsco-1.1.0",
+  "id": "mod-kb-ebsco-1.1.1",
   "name": "kb-ebsco",
   "provides": [
     {
@@ -47,7 +47,7 @@
   ],
   "permissionSets" : [],
   "launchDescriptor": {
-    "dockerImage": "mod-kb-ebsco:1.1.0",
+    "dockerImage": "mod-kb-ebsco-1.1.1",
     "dockerArgs": {
       "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
     },

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,13 @@
+## 1.1.0 2018-12-05
+ * [MODKBEBSCO-21] - Security vulnerability reported in rack >= 2.0.4, < 2.0.6
+ * [MODKBEBSCO-20] - Security vulnerability reported in loofah @ 2.2.2
+ * [MODKBEBSCO-18] - Create RAML documentation for status endpoint
+ * [MODKBEBSCO-17] - Create RAML documentation for configuration
+ * [MODKBEBSCO-15] - Update Titles Search to support searchType param/Remove advancedSearch param
+ * [MODKBEBSCO-10] - Update RAML docs: Remove q from the title endpoint docs
+ * [MODKBEBSCO-9] - Create RAML documentation for root-proxies
+ * [MODKBEBSCO-8] - Refactor titles endpoint and remove `q` as a optional in mod-kb-ebsco
+ * [MODKBEBSCO-7] - Update RAML documentation to include tokens
+ * [MODKBEBSCO-6] - mod-kb-ebsco and mod-codex-ekb should store rm api credentials in same location (backend)"
+ * [MODKBEBSCO-5] - invalid url error' when editing a title with empty url
+


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODKBEBSCO-22 - release mod-kb-ebsco for Q4 release

## Approach
- Created tag V1.1.0 in Jira and assigned applicable Jira issues
- Followed release procedures (https://dev.folio.org/guidelines/release-procedures/)
- Added news.md with reference to relevant Jira issues
- To do release in single PR
```
1. git checkout -b release-1.1.0
2. Updated code - module descriptor version and added news.md
3.  git commit --m "Update to release version and news"
4.  git push
5.  git tag v1.1.0
6.  git push --tags
7. Update code module descriptor
8  git commit --m "Update to the next (post release) version 1.1.1"
9. git push
```

Note -- ModuleDescriptor references newer snapshot version as mod-kb-ebsco-1.1.1 (without snapshot extension). This is consistent with how prior snapshot release was handled

## Learning
https://dev.folio.org/guidelines/release-procedures/

## Screenshots
<img width="1671" alt="screen shot 2018-12-05 at 1 36 13 pm" src="https://user-images.githubusercontent.com/19415226/49535805-086c5b00-f893-11e8-8b6e-70fb6dc5f00b.png">

<img width="1636" alt="screen shot 2018-12-05 at 1 54 16 pm" src="https://user-images.githubusercontent.com/19415226/49536942-b547d780-f895-11e8-9928-327a25e05e53.png">

